### PR TITLE
fix(local-traits): rollback allow writing effects inside TraitsLocal

### DIFF
--- a/apps/example-app/src/app/examples/product-picker-page/components/product-select-dialog/product-select-dialog.component.ts
+++ b/apps/example-app/src/app/examples/product-picker-page/components/product-select-dialog/product-select-dialog.component.ts
@@ -47,9 +47,9 @@ import { ProductsLocalTraits } from './products.traits';
 })
 export class ProductSelectDialogComponent implements OnInit {
   data$ = combineLatest([
-    this.store.select(this.localTraits.localSelectors.selectProductsList),
-    this.store.select(this.localTraits.localSelectors.isProductsLoading),
-    this.store.select(this.localTraits.localSelectors.selectProductSelected),
+    this.store.select(this.localTraits.selectors.selectProductsList),
+    this.store.select(this.localTraits.selectors.isProductsLoading),
+    this.store.select(this.localTraits.selectors.selectProductSelected),
   ]).pipe(
     map(([products, isLoading, selectedProduct]) => ({
       products,
@@ -61,19 +61,17 @@ export class ProductSelectDialogComponent implements OnInit {
   constructor(private store: Store, private localTraits: ProductsLocalTraits) {}
 
   ngOnInit() {
-    this.store.dispatch(this.localTraits.localActions.loadProducts());
+    this.store.dispatch(this.localTraits.actions.loadProducts());
   }
 
   select({ id }: Product) {
-    this.store.dispatch(this.localTraits.localActions.selectProduct({ id }));
+    this.store.dispatch(this.localTraits.actions.selectProduct({ id }));
   }
 
   filter(filters: ProductFilter) {
-    this.store.dispatch(
-      this.localTraits.localActions.filterProducts({ filters })
-    );
+    this.store.dispatch(this.localTraits.actions.filterProducts({ filters }));
   }
   sort(sort: Sort<Product>) {
-    this.store.dispatch(this.localTraits.localActions.sortProducts(sort));
+    this.store.dispatch(this.localTraits.actions.sortProducts(sort));
   }
 }

--- a/libs/ngrx-traits/src/lib/create-entity-feature.spec.ts
+++ b/libs/ngrx-traits/src/lib/create-entity-feature.spec.ts
@@ -78,19 +78,6 @@ const productMixedFactory = mixEntityFeatures({
 
 @Injectable()
 class ProductTraitLocal extends TraitsLocalStore<typeof productFeatureFactory> {
-  loadEntities$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(this.localActions.loadProducts),
-      mapTo(
-        this.localActions.loadProductsSuccess({
-          entities: [
-            { id: 1, name: 'name', description: 'description', price: 123 },
-          ],
-        })
-      )
-    );
-  });
-
   setup(): LocalTraitsConfig<typeof productFeatureFactory> {
     return {
       componentName: 'ProductTestComponent',
@@ -103,19 +90,6 @@ class ProductTraitLocal extends TraitsLocalStore<typeof productFeatureFactory> {
 class ProductCombinedTraitLocal extends TraitsLocalStore<
   typeof productCombinedFactory
 > {
-  loadEntities$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(this.localActions.products.loadProducts),
-      mapTo(
-        this.localActions.products.loadProductsSuccess({
-          entities: [
-            { id: 1, name: 'name', description: 'description', price: 123 },
-          ],
-        })
-      )
-    );
-  });
-
   setup(): LocalTraitsConfig<typeof productCombinedFactory> {
     return {
       componentName: 'ProductCombinedTestComponent',
@@ -128,19 +102,6 @@ class ProductCombinedTraitLocal extends TraitsLocalStore<
 class ProductMixedTraitLocal extends TraitsLocalStore<
   typeof productMixedFactory
 > {
-  loadEntities$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(this.localActions.loadProducts),
-      mapTo(
-        this.localActions.loadProductsSuccess({
-          entities: [
-            { id: 1, name: 'name', description: 'description', price: 123 },
-          ],
-        })
-      )
-    );
-  });
-
   setup(): LocalTraitsConfig<typeof productMixedFactory> {
     return {
       componentName: 'ProductMixedTestComponent',
@@ -153,19 +114,6 @@ class ProductMixedTraitLocal extends TraitsLocalStore<
 class ProductAddEntityPropertiesTraitLocal extends TraitsLocalStore<
   typeof productAddEntityPropertiesFactory
 > {
-  loadEntities$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(this.localActions.loadProducts),
-      mapTo(
-        this.localActions.loadProductsSuccess({
-          entities: [
-            { id: 1, name: 'name', description: 'description', price: 123 },
-          ],
-        })
-      )
-    );
-  });
-
   setup(): LocalTraitsConfig<typeof productAddEntityPropertiesFactory> {
     return {
       componentName: 'ProductAddEntityPropertiesTestComponent',
@@ -447,19 +395,15 @@ describe('Ngrx-Traits Integration Test', () => {
     describe('single feature trait local', () => {
       it('test some action and selectors in products ', async () => {
         const { localTrait, store } = initTraitLocal();
-        await basicProductTest(
-          localTrait.localActions,
-          localTrait.localSelectors,
-          store
-        );
+        await basicProductTest(localTrait.actions, localTrait.selectors, store);
       });
 
       describe('test combined trait local', () => {
         it('test some action and selectors in products ', async () => {
           const { localTrait, store } = initCombinedTraitLocal();
           await basicProductTest(
-            localTrait.localActions.products,
-            localTrait.localSelectors.products,
+            localTrait.actions.products,
+            localTrait.selectors.products,
             store
           );
         });
@@ -467,8 +411,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in productOrders ', async () => {
           const { localTrait, store } = initCombinedTraitLocal();
           await basicProductOrdersTest(
-            localTrait.localActions.productOrders,
-            localTrait.localSelectors.productOrders,
+            localTrait.actions.productOrders,
+            localTrait.selectors.productOrders,
             store
           );
         });
@@ -476,8 +420,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in clients ', async () => {
           const { localTrait, store } = initCombinedTraitLocal();
           await basicClientsTest(
-            localTrait.localActions.clients,
-            localTrait.localSelectors.clients,
+            localTrait.actions.clients,
+            localTrait.selectors.clients,
             store
           );
         });
@@ -487,8 +431,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in products ', async () => {
           const { localTrait, store } = initMixedTraitLocal();
           await basicProductTest(
-            localTrait.localActions,
-            localTrait.localSelectors,
+            localTrait.actions,
+            localTrait.selectors,
             store
           );
         });
@@ -496,8 +440,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in productOrders ', async () => {
           const { localTrait, store } = initMixedTraitLocal();
           await basicProductOrdersTest(
-            localTrait.localActions,
-            localTrait.localSelectors,
+            localTrait.actions,
+            localTrait.selectors,
             store
           );
         });
@@ -505,8 +449,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in clients ', async () => {
           const { localTrait, store } = initMixedTraitLocal();
           await basicClientsTest(
-            localTrait.localActions,
-            localTrait.localSelectors,
+            localTrait.actions,
+            localTrait.selectors,
             store
           );
         });
@@ -516,8 +460,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in products ', async () => {
           const { localTrait, store } = initAddEntityProperties();
           await basicProductTest(
-            localTrait.localActions,
-            localTrait.localSelectors,
+            localTrait.actions,
+            localTrait.selectors,
             store
           );
         });
@@ -525,8 +469,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in productOrders ', async () => {
           const { localTrait, store } = initAddEntityProperties();
           await basicProductOrdersTest(
-            localTrait.localActions.productOrders,
-            localTrait.localSelectors.productOrders,
+            localTrait.actions.productOrders,
+            localTrait.selectors.productOrders,
             store
           );
         });
@@ -534,8 +478,8 @@ describe('Ngrx-Traits Integration Test', () => {
         it('test some action and selectors in clients ', async () => {
           const { localTrait, store } = initAddEntityProperties();
           await basicClientsTest(
-            localTrait.localActions.clients,
-            localTrait.localSelectors.clients,
+            localTrait.actions.clients,
+            localTrait.selectors.clients,
             store
           );
         });

--- a/libs/ngrx-traits/src/lib/local-store/README.md
+++ b/libs/ngrx-traits/src/lib/local-store/README.md
@@ -22,69 +22,64 @@ const productFeatureFactory = createEntityFeatureFactory(
 );
 ```
 
-The next step is to create a service that will be use in your component, it needs to extend `TraitsLocalStore< typeof traitsFactory>` notice the use of **typeof** to get the types of the traits factory you created.
+The next step is optional, if the state of your component needs to be instantiated from a backend call or needs any sort of side effects you can add an extra effect a follows:
+
+```typescript
+const productsEffect: TraitLocalEffectsFactory<typeof productFeature> = (
+  allActions
+) => {
+  @Injectable()
+  class ProductsEffects extends TraitEffect {
+    loadProducts$ = createEffect(() =>
+      this.actions$.pipe(
+        ofType(allActions.loadEntities),
+        switchMap(() =>
+          //call your service to get the products data
+          this.productService.getProducts().pipe(
+            map((products) => allActions.loadEntitiesSuccess({ entities: products })),
+            catchError(() => of(allActions.loadEntitiesFail()))
+          )
+        )
+      )
+    );
+
+    constructor(
+      actions$: Actions,
+      store: Store,
+      private productService: ProductService
+    ) {
+      super(actions$, store);
+    }
+  }
+  return ProductsEffects;
+};
+```
+
+Notice this is a normal effect wrap in a function, an important bit is `practiceEffect: TraitLocalEffectsFactory<typeof traitsFactory>`
+the _typeof traitsFactory_ gives the types for the allActions and allSelectors params from the traitsFactory, you could also simply add your own types to the allActions and allSelectors params by using the traits actions in and selectors interfaces like `allActions:LoadEntitiesActions<MyEntity> & FilterActions<MyEntities>`.
+
+In the future you will be able to add custom actions, selectors, reducers, and effects but for now is just an extra effect which should help with most of the cases, but this means the logic inside the effect is currently is limited to only use traits actions or global action no custom actions, if you need custom logic you can mix it with ngrx component store
+
+The next step is to create a service that will be use in your component, it needs to extend `TraitsLocalStore< typeof traitsFactory>` again notice the use of **typeof** to get the types of the traits factory you created.
 
 ```typescript
 @Injectable()
 export class ProductsLocalTraits extends TraitsLocalStore<
-  typeof productFeatureFactory
+  typeof productFeature
   > {
   setup(): LocalTraitsConfig<typeof productFeature> {
     return {
       componentName: 'ProductsPickerComponent',
       traitsFactory: productFeature,
+      effectFactory: productsEffect,
     };
   }
 }
 ```
 
-By extending **TraitsLocalStore** you get an _localActions_ and _localSelectors_ properties in the service with all the actions and selectors you set up in your trait factory.
+The **effectFactory** param in the setup method is optional. By extending **TraitsLocalStore** you get an _actions_ and _selectors_ properties in the service with all the actions and selectors you set up in your trait factory.
 
-The next step is optional, if the state of your component needs to be instantiated from a backend call or needs any sort of side effects you can add an extra effect a follows:
-
-```typescript
-import { ProductService } from './product.service';
-
-@Injectable()
-export class ProductsLocalTraits extends TraitsLocalStore<typeof productFeatureFactory> {
-  // TraitsLocalStore adds a reference to the injector so to get a service reference you can
-  productService = this.injector.get(ProductService);
-  //Alternativally you could override the constructor to get a reference to your service 
-  // constructor(
-  //   injector: Injector,
-  //   private productService: ProductService
-  // ) {
-  //   super(injector);
-  // }
-  loadProducts$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(this.localActions.loadProducts),
-      switchMap(() =>
-        //call your service to get the products data
-        this.productService.getProducts().pipe(
-          map((products) => this.localActions.loadProductsSuccess({ entities: products })),
-          catchError(() => of(this.localActions.loadProductsFail()))
-        )
-      )
-    )
-  );
-
-  setup(): LocalTraitsConfig<typeof productFeature> {
-    return {
-      componentName: 'ProductsPickerComponent',
-      traitsFactory: productFeature,
-    };
-  }
-}
-```
-
-An important bit is `extends TraitLocalEffectsFactory<typeof traitsFactory>`
-the _typeof traitsFactory_ gives the types for the localActions and localSelectors properties in the class.
-
-You can also add custom actions, selectors, reducers, and effects to your LocalTrait by creating a [Custom Traits](../../../traits/src/custom-traits.md), for this is just an extra effect we need and this should help with most of the cases.
-
-
-We are ready to use the service in our component, basically we just need to add the service we just created in the providers property of the _@Component_ like `providers: [ProductsLocalTraits],` and declare the service in the constructor of your component, after that you use like you will use normal actions and selectors for example:
+Now we are ready to use the service in our component, basically just need to add the service we just created in the providers property of the _@Component_ like `providers: [ProductsLocalTraits],` and declare the service in the constructor of your component, after that you use like you will use normal actions and selectors for example:
 
 ```typescript
 @Component({
@@ -93,13 +88,12 @@ We are ready to use the service in our component, basically we just need to add 
   providers: [ProductsLocalTraits], //<- Our local store service
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-
 export class ProductSelectDialogComponent implements OnInit {
   data$ = combineLatest([
     //using local traits selectors
-    this.store.select(this.localTraits.localSelectors.selectProductsList),
-    this.store.select(this.localTraits.localSelectors.isProductsLoading),
-    this.store.select(this.localTraits.localSelectors.selectProductSelected),    
+    this.store.selectEntity(this.localTraits.selectors.selectAll),
+    this.store.selectEntity(this.localTraits.selectors.isLoading),
+    this.store.selectEntity(this.localTraits.selectors.selectEntitySelected),
     // you could mix it with normal selectors
     // this.store.selectEntity(UserSelectors.selectCurrentUser),
   ]).pipe(
@@ -111,90 +105,59 @@ export class ProductSelectDialogComponent implements OnInit {
   );
 
   constructor(private store: Store,
-              private traits: ProductsLocalTraits //<-- inject our service
+              private localTraits: ProductsLocalTraits // inject our service
   ) {}
 
   ngOnInit() {
     // firing a local trait action like a normal action
-    this.store.dispatch(this.localTraits.localActions.loadProducts());
+    this.store.dispatch(this.localTraits.actions.loadEntities());
   }
 
-  select({ id }: Product) {
-    this.store.dispatch(this.localTraits.localActions.selectProduct({ id }));
+  selectEntity(id: string) {
+    this.store.dispatch(this.localTraits.actions.selectEntity({ id }));
   }
 
   filter(filters: ProductFilter) {
-    this.store.dispatch(
-      this.localTraits.localActions.filterProducts({ filters })
-    );
+    this.store.dispatch(this.localTraits.actions.filter({ filters }));
   }
   sort(sort: Sort<Product>) {
-    this.store.dispatch(this.localTraits.localActions.sortProducts(sort));
+    this.store.dispatch(this.localTraits.actions.sort(sort));
   }
 }
 ```
-And that's it :)
 
-[//]: # (Extending **TraitsLocalStore** allows you to only get one set of traits this normally should be enough, but it could happen that you need more than one traitFactory, if so you need to create a service like the following:)
+Extending **TraitsLocalStore** allows you to only get one set of traits this normally should be enough, but it could happen that you need more than one traitFactory, if so you need to create a service like the following:
 
-[//]: # ()
-[//]: # (```typescript)
+```typescript
+@Injectable()
+export class ProductsLocalTraits implements OnDestroy {
+  traits1 = buildLocalTraits(
+    this.injector,
+    'ProductsDropdownComponent',
+    traitsFactory1,
+    practiceEffect1
+  );
+  traits2 = buildLocalTraits(
+    this.injector,
+    'ProductsDropdownComponent',
+    traitsFactory2,
+    practiceEffect2
+  );
 
-[//]: # (@Injectable&#40;&#41;)
+  actions1 = this.traits1.actions;
+  selectors1 = this.traits1.selectors;
 
-[//]: # (export class ProductsLocalTraits implements OnDestroy {)
+  actions2 = this.traits2.actions;
+  selectors2 = this.traits2.selectors;
 
-[//]: # (  traits1 = buildLocalTraits&#40;)
+  constructor(private injector: Injector) {}
 
-[//]: # (    this.injector,)
+  ngOnDestroy() {
+    // Very important be sure to call the traits destroy here
+    this.traits1.destroy();
+    this.traits2.destroy();
+  }
+}
+```
 
-[//]: # (    'ProductsDropdownComponent',)
-
-[//]: # (    traitsFactory1,)
-
-[//]: # (    practiceEffect1)
-
-[//]: # (  &#41;;)
-
-[//]: # (  traits2 = buildLocalTraits&#40;)
-
-[//]: # (    this.injector,)
-
-[//]: # (    'ProductsDropdownComponent',)
-
-[//]: # (    traitsFactory2,)
-
-[//]: # (    practiceEffect2)
-
-[//]: # (  &#41;;)
-
-[//]: # ()
-[//]: # (  actions1 = this.traits1.actions;)
-
-[//]: # (  selectors1 = this.traits1.selectors;)
-
-[//]: # ()
-[//]: # (  actions2 = this.traits2.actions;)
-
-[//]: # (  selectors2 = this.traits2.selectors;)
-
-[//]: # ()
-[//]: # (  constructor&#40;private injector: Injector&#41; {})
-
-[//]: # ()
-[//]: # (  ngOnDestroy&#40;&#41; {)
-
-[//]: # (    // Very important be sure to call the traits destroy here)
-
-[//]: # (    this.traits1.destroy&#40;&#41;;)
-
-[//]: # (    this.traits2.destroy&#40;&#41;;)
-
-[//]: # (  })
-
-[//]: # (})
-
-[//]: # (```)
-
-[//]: # ()
-[//]: # (Essentially you just need to use **buildLocalTraits** to create the traits and then use your preferred way to store the actions and selectors, but be sure to implement a **ngOnDestroy** and call the destroy method in the resulting traits, which ensures the effects and reducers are clean when the component is destroyed)
+Essentially you just need to use **buildLocalTraits** to create the traits and then use your preferred way to store the actions and selectors, but be sure to implement a **ngOnDestroy** and call the destroy method in the resulting traits, which ensures the effects and reducers are clean when the component is destroyed


### PR DESCRIPTION
The previous feature to enable writing effects inside the LocalTraits brough a race condition that
makes the effects of the LocalTraits not be initialized when the component ngOnit was call this was
do to using the queueMicroTask to register services