### PR TITLE
fix(example-app): Remove dependencies to deprecated @angular/flex-layout

### DIFF
--- a/apps/example-app/src/app/examples/components/search-options/search-options.component.ts
+++ b/apps/example-app/src/app/examples/components/search-options/search-options.component.ts
@@ -39,7 +39,7 @@ import { takeUntil, delay } from 'rxjs/operators';
         mat-icon-button
         matSuffix
         (click)="clear()"
-        [fxShow]="!!input.value"
+
       >
         <mat-icon>close</mat-icon>
       </button>

--- a/apps/example-app/src/app/examples/components/search-options/search-options.module.ts
+++ b/apps/example-app/src/app/examples/components/search-options/search-options.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SearchOptionsComponent } from './search-options.component';
-import { FlexLayoutModule } from '@angular/flex-layout';
+
 import { MatInputModule } from '@angular/material/input';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
@@ -12,7 +12,7 @@ import { MatButtonModule } from '@angular/material/button';
   exports: [SearchOptionsComponent],
   imports: [
     CommonModule,
-    FlexLayoutModule,
+
     MatInputModule,
     ReactiveFormsModule,
     MatIconModule,

--- a/apps/example-app/src/app/examples/product-shop-page/components/product-basket-tab/product-basket-tab.module.ts
+++ b/apps/example-app/src/app/examples/product-shop-page/components/product-basket-tab/product-basket-tab.module.ts
@@ -5,7 +5,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { ProductBasketModule } from '../../../components/product-basket/product-basket.module';
 import { ProductDetailModule } from '../../../components/product-detail/product-detail.module';
-import { GridModule } from '@angular/flex-layout';
+
 import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
@@ -17,7 +17,7 @@ import { MatButtonModule } from '@angular/material/button';
     MatProgressSpinnerModule,
     ProductBasketModule,
     ProductDetailModule,
-    GridModule,
+
     MatButtonModule,
   ],
 })

--- a/apps/example-app/src/app/examples/product-shop-page/components/product-shop-tab/product-shop-tab.module.ts
+++ b/apps/example-app/src/app/examples/product-shop-page/components/product-shop-tab/product-shop-tab.module.ts
@@ -7,7 +7,7 @@ import { ProductSearchFormModule } from '../../../components/product-search-form
 import { ProductListModule } from '../../../components/product-list/product-list.module';
 import { ProductDetailModule } from '../../../components/product-detail/product-detail.module';
 import { ProductBasketModule } from '../../../components/product-basket/product-basket.module';
-import { GridModule } from '@angular/flex-layout';
+
 import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
@@ -21,7 +21,7 @@ import { MatButtonModule } from '@angular/material/button';
     ProductListModule,
     ProductDetailModule,
     ProductBasketModule,
-    GridModule,
+
     MatButtonModule,
   ],
 })

--- a/apps/example-app/src/app/examples/product-shop-page/product-shop-page.module.ts
+++ b/apps/example-app/src/app/examples/product-shop-page/product-shop-page.module.ts
@@ -10,7 +10,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { ProductsBasketStateModule } from './state/products-basket/products-basket-state.module';
 import { ProductBasketModule } from '../components/product-basket/product-basket.module';
-import { GridModule } from '@angular/flex-layout';
+
 import { ProductDetailModule } from '../components/product-detail/product-detail.module';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatIconModule } from '@angular/material/icon';
@@ -29,7 +29,7 @@ import { MatBadgeModule } from '@angular/material/badge';
     MatCardModule,
     MatButtonModule,
     ProductBasketModule,
-    GridModule,
+
     ProductDetailModule,
     MatTabsModule,
     MatIconModule,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,10 @@
         "@angular/animations": "14.0.5",
         "@angular/cdk": "14.0.4",
         "@angular/common": "14.0.5",
-        "@angular/compiler": "14.0.5",
         "@angular/core": "14.0.5",
-        "@angular/flex-layout": "12.0.0-beta.34",
         "@angular/forms": "14.0.5",
         "@angular/material": "14.0.4",
         "@angular/platform-browser": "14.0.5",
-        "@angular/platform-browser-dynamic": "14.0.5",
-        "@angular/router": "14.0.5",
         "@ngrx/effects": "14.0.1",
         "@ngrx/entity": "14.0.1",
         "@ngrx/store": "14.0.1",
@@ -37,8 +33,11 @@
         "@angular-eslint/eslint-plugin-template": "14.0.2",
         "@angular-eslint/template-parser": "14.0.2",
         "@angular/cli": "13.3.8",
+        "@angular/compiler": "14.0.5",
         "@angular/compiler-cli": "14.0.5",
         "@angular/language-service": "14.0.5",
+        "@angular/platform-browser-dynamic": "14.0.5",
+        "@angular/router": "14.0.5",
         "@babel/cli": "^7.17.10",
         "@babel/core": "^7.18.0",
         "@babel/plugin-proposal-class-properties": "^7.17.12",
@@ -503,6 +502,21 @@
         }
       }
     },
+    "node_modules/@angular-devkit/core/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@angular-devkit/schematics": {
       "version": "14.0.5",
       "license": "MIT",
@@ -904,6 +918,7 @@
     },
     "node_modules/@angular/compiler": {
       "version": "14.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -974,20 +989,6 @@
         "zone.js": "~0.11.4"
       }
     },
-    "node_modules/@angular/flex-layout": {
-      "version": "12.0.0-beta.34",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@angular/cdk": "^12.0.0",
-        "@angular/common": ">=12.0.0",
-        "@angular/core": ">=12.0.0",
-        "@angular/platform-browser": ">=12.0.0",
-        "rxjs": "^6.0.0"
-      }
-    },
     "node_modules/@angular/forms": {
       "version": "14.0.5",
       "license": "MIT",
@@ -1050,6 +1051,7 @@
     },
     "node_modules/@angular/platform-browser-dynamic": {
       "version": "14.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1066,6 +1068,7 @@
     },
     "node_modules/@angular/router": {
       "version": "14.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -2819,6 +2822,23 @@
         "node": ">=v14"
       }
     },
+    "node_modules/@commitlint/config-validator/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@commitlint/execute-rule": {
       "version": "17.0.0",
       "dev": true,
@@ -3400,21 +3420,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "devOptional": true,
@@ -3444,11 +3449,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -5225,10 +5225,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@nrwl/web/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
     "node_modules/@nrwl/web/node_modules/json5": {
       "version": "1.0.1",
       "license": "MIT",
@@ -5302,6 +5298,21 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/@nrwl/web/node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@nrwl/web/node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "license": "MIT",
@@ -5351,20 +5362,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@nrwl/web/node_modules/schema-utils/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@nrwl/web/node_modules/semver": {
@@ -5779,20 +5776,6 @@
         }
       }
     },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/find-up": {
       "version": "5.0.0",
       "license": "MIT",
@@ -5806,10 +5789,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/locate-path": {
       "version": "6.0.0",
@@ -7313,8 +7292,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "license": "MIT",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7328,6 +7308,17 @@
       "dependencies": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/acorn-globals/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/acorn-import-assertions": {
@@ -7401,12 +7392,13 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.11.0",
-      "license": "MIT",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       },
       "funding": {
@@ -7429,12 +7421,32 @@
         }
       }
     },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
+    },
+    "node_modules/ajv/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -9357,6 +9369,22 @@
         "webpack": "^5.1.0"
       }
     },
+    "node_modules/copy-webpack-plugin/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/copy-webpack-plugin/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "dev": true,
@@ -9717,6 +9745,21 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/css-minimizer-webpack-plugin/node_modules/ajv-keywords": {
@@ -11055,21 +11098,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
       "devOptional": true,
@@ -11195,11 +11223,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "devOptional": true,
@@ -11255,17 +11278,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/espree/node_modules/acorn": {
-      "version": "8.7.1",
-      "devOptional": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/esprima": {
@@ -11773,24 +11785,6 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/file-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/file-loader/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
     "node_modules/file-loader/node_modules/schema-utils": {
       "version": "3.1.1",
       "license": "MIT",
@@ -12068,20 +12062,6 @@
         "yarn": ">=1.0.0"
       }
     },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/ansi-styles": {
       "version": "4.3.0",
       "license": "MIT",
@@ -12129,10 +12109,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
       "version": "2.7.0",
@@ -16079,16 +16055,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/acorn": {
-      "version": "8.7.1",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/jsdom/node_modules/form-data": {
       "version": "3.0.1",
       "license": "MIT",
@@ -17112,6 +17078,22 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "dev": true,
@@ -17522,6 +17504,22 @@
         "@angular/compiler-cli": "^14.0.0 || ^14.0.0-next || ^14.1.0-next",
         "tslib": "^2.3.0",
         "typescript": ">=4.6.2 <4.8"
+      }
+    },
+    "node_modules/ng-packagr/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ng-packagr/node_modules/brace-expansion": {
@@ -23399,24 +23397,6 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/raw-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/raw-loader/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
     "node_modules/raw-loader/node_modules/schema-utils": {
       "version": "3.1.1",
       "license": "MIT",
@@ -24424,24 +24404,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",
@@ -25757,24 +25719,6 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "3.1.1",
       "license": "MIT",
@@ -25789,16 +25733,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/terser/node_modules/acorn": {
-      "version": "8.7.1",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -26152,16 +26086,6 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.7.1",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/ts-node/node_modules/acorn-walk": {
@@ -26752,6 +26676,21 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/webpack-dev-middleware/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "license": "MIT",
@@ -26825,6 +26764,21 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/webpack-dev-server/node_modules/ajv-keywords": {
@@ -26919,34 +26873,6 @@
     },
     "node_modules/webpack/node_modules/@types/estree": {
       "version": "0.0.51",
-      "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/acorn": {
-      "version": "8.7.1",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
@@ -27546,6 +27472,19 @@
         "jsonc-parser": "3.0.0",
         "rxjs": "6.6.7",
         "source-map": "0.7.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "@angular-devkit/schematics": {
@@ -27820,6 +27759,7 @@
     },
     "@angular/compiler": {
       "version": "14.0.5",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -27855,12 +27795,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "@angular/flex-layout": {
-      "version": "12.0.0-beta.34",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "@angular/forms": {
       "version": "14.0.5",
       "requires": {
@@ -27885,12 +27819,14 @@
     },
     "@angular/platform-browser-dynamic": {
       "version": "14.0.5",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/router": {
       "version": "14.0.5",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -28930,6 +28866,21 @@
       "requires": {
         "@commitlint/types": "^17.0.0",
         "ajv": "^8.11.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "@commitlint/execute-rule": {
@@ -29270,16 +29221,6 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "devOptional": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "argparse": {
           "version": "2.0.1",
           "devOptional": true
@@ -29297,10 +29238,6 @@
           "requires": {
             "argparse": "^2.0.1"
           }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "devOptional": true
         },
         "minimatch": {
           "version": "3.1.2",
@@ -30458,9 +30395,6 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
-        "json-schema-traverse": {
-          "version": "0.4.1"
-        },
         "json5": {
           "version": "1.0.1",
           "requires": {
@@ -30503,6 +30437,17 @@
             "schema-utils": "^4.0.0"
           },
           "dependencies": {
+            "ajv": {
+              "version": "8.12.0",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+              "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            },
             "ajv-keywords": {
               "version": "5.1.0",
               "requires": {
@@ -30532,17 +30477,6 @@
             "@types/json-schema": "^7.0.8",
             "ajv": "^6.12.5",
             "ajv-keywords": "^3.5.2"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "6.12.6",
-              "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-              }
-            }
           }
         },
         "semver": {
@@ -30810,24 +30744,12 @@
         "source-map": "^0.7.3"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "find-up": {
           "version": "5.0.0",
           "requires": {
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
           }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
         },
         "locate-path": {
           "version": "6.0.0",
@@ -31822,13 +31744,22 @@
       }
     },
     "acorn": {
-      "version": "7.4.1"
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
     },
     "acorn-globals": {
       "version": "6.0.0",
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        }
       }
     },
     "acorn-import-assertions": {
@@ -31877,18 +31808,40 @@
       }
     },
     "ajv": {
-      "version": "8.11.0",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "ajv-formats": {
       "version": "2.1.1",
       "requires": {
         "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "ajv-keywords": {
@@ -33099,6 +33052,18 @@
         "serialize-javascript": "^6.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ajv-keywords": {
           "version": "5.1.0",
           "dev": true,
@@ -33304,6 +33269,17 @@
         "source-map": "^0.6.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ajv-keywords": {
           "version": "5.1.0",
           "requires": {
@@ -34105,16 +34081,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "devOptional": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "devOptional": true,
@@ -34186,10 +34152,6 @@
             "argparse": "^2.0.1"
           }
         },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "devOptional": true
-        },
         "minimatch": {
           "version": "3.1.2",
           "devOptional": true,
@@ -34257,12 +34219,6 @@
         "acorn": "^8.7.1",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.7.1",
-          "devOptional": true
-        }
       }
     },
     "esprima": {
@@ -34578,18 +34534,6 @@
         "schema-utils": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
-        },
         "schema-utils": {
           "version": "3.1.1",
           "requires": {
@@ -34771,15 +34715,6 @@
         "tapable": "^1.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "requires": {
@@ -34804,9 +34739,6 @@
         },
         "has-flag": {
           "version": "4.0.0"
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
         },
         "schema-utils": {
           "version": "2.7.0",
@@ -37276,9 +37208,6 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.7.1"
-        },
         "form-data": {
           "version": "3.0.1",
           "requires": {
@@ -37931,6 +37860,18 @@
         "schema-utils": "^4.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ajv-keywords": {
           "version": "5.1.0",
           "dev": true,
@@ -38194,6 +38135,18 @@
         "stylus": "^0.58.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "brace-expansion": {
           "version": "2.0.1",
           "dev": true,
@@ -42037,18 +41990,6 @@
         "schema-utils": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
-        },
         "schema-utils": {
           "version": "3.1.1",
           "requires": {
@@ -42679,20 +42620,6 @@
         "@types/json-schema": "^7.0.5",
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
-        }
       }
     },
     "secure-compare": {
@@ -43543,9 +43470,6 @@
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.7.1"
-        },
         "commander": {
           "version": "2.20.3"
         },
@@ -43584,18 +43508,6 @@
         "terser": "^5.7.2"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
-        },
         "schema-utils": {
           "version": "3.1.1",
           "requires": {
@@ -43786,9 +43698,6 @@
         "yn": "3.1.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.7.1"
-        },
         "acorn-walk": {
           "version": "8.2.0"
         }
@@ -44155,21 +44064,6 @@
         "@types/estree": {
           "version": "0.0.51"
         },
-        "acorn": {
-          "version": "8.7.1"
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
-        },
         "schema-utils": {
           "version": "3.1.1",
           "requires": {
@@ -44190,6 +44084,17 @@
         "schema-utils": "^4.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ajv-keywords": {
           "version": "5.1.0",
           "requires": {
@@ -44240,6 +44145,17 @@
         "ws": "^8.4.2"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ajv-keywords": {
           "version": "5.1.0",
           "requires": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@angular/cdk": "14.0.4",
     "@angular/common": "14.0.5",
     "@angular/core": "14.0.5",
-    "@angular/flex-layout": "12.0.0-beta.34",
     "@angular/forms": "14.0.5",
     "@angular/material": "14.0.4",
     "@angular/platform-browser": "14.0.5",


### PR DESCRIPTION
Usage of @angular/flex-layout was creating Conflicting peer dependency when running `npm install`
Removing this dependency fix that.

When removing it's usage from example-app to be able to build, no other change have been made to the html.
It's possible it may not represent the intended output, but the librairy look to be working appropriatly. 

Since I'm not the creator, it's hard to access, but would be ready to make the necessary change.