### PR TITLE
Fix/several fixes

### DIFF
--- a/apps/example-app/project.json
+++ b/apps/example-app/project.json
@@ -6,7 +6,7 @@
   "prefix": "ngrx-traits",
   "targets": {
     "build": {
-      "executor": "@angular-devkit/build-angular:browser",
+      "executor": "@angular-devkit/build-angular:browser-esbuild",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/apps/example-app",

--- a/apps/example-app/src/app/examples/signals/infinete-scroll-page/components/products-branch-dropdown/products-branch.store.ts
+++ b/apps/example-app/src/app/examples/signals/infinete-scroll-page/components/products-branch-dropdown/products-branch.store.ts
@@ -42,37 +42,3 @@ export const ProductsBranchStore = signalStore(
   }),
   withLogger('branchStore'),
 );
-// const collection = 'products';
-// export const ProductsBranchStore2 = signalStore(
-//   withEntities({
-//     entity,
-//     collection,
-//   }),
-//   withCallStatus({ initialValue: 'loading', collection }),
-//   withEntitiesRemoteFilter({
-//     entity,
-//     defaultFilter: { search: '' },
-//     collection,
-//   }),
-//   withEntitiesRemoteScrollPagination({
-//     bufferSize: 30,
-//     entity,
-//     collection,
-//   }),
-//   withEntitiesLoadingCall({
-//     collection,
-//     fetchEntities: async ({ productsRequest, productsFilter }) => {
-//       const res = await lastValueFrom(
-//         inject(BranchService).getBranches({
-//           search: productsFilter().search,
-//           skip: productsRequest().startIndex,
-//           take: productsRequest().size,
-//         }),
-//       );
-//       return { entities: res.resultList, total: res.total };
-//     },
-//   }),
-//   withLogger('branchStore'),
-// );
-// const store = new ProductsBranchStore2();
-// getInfiniteScrollDataSource({ store, collection, entity });

--- a/apps/example-app/src/app/examples/signals/infinete-scroll-page/components/products-branch-dropdown/products-branch.store.ts
+++ b/apps/example-app/src/app/examples/signals/infinete-scroll-page/components/products-branch-dropdown/products-branch.store.ts
@@ -1,5 +1,6 @@
 import { inject } from '@angular/core';
 import {
+  getInfiniteScrollDataSource,
   withCallStatus,
   withEntitiesLoadingCall,
   withEntitiesRemoteFilter,
@@ -41,3 +42,37 @@ export const ProductsBranchStore = signalStore(
   }),
   withLogger('branchStore'),
 );
+// const collection = 'products';
+// export const ProductsBranchStore2 = signalStore(
+//   withEntities({
+//     entity,
+//     collection,
+//   }),
+//   withCallStatus({ initialValue: 'loading', collection }),
+//   withEntitiesRemoteFilter({
+//     entity,
+//     defaultFilter: { search: '' },
+//     collection,
+//   }),
+//   withEntitiesRemoteScrollPagination({
+//     bufferSize: 30,
+//     entity,
+//     collection,
+//   }),
+//   withEntitiesLoadingCall({
+//     collection,
+//     fetchEntities: async ({ productsRequest, productsFilter }) => {
+//       const res = await lastValueFrom(
+//         inject(BranchService).getBranches({
+//           search: productsFilter().search,
+//           skip: productsRequest().startIndex,
+//           take: productsRequest().size,
+//         }),
+//       );
+//       return { entities: res.resultList, total: res.total };
+//     },
+//   }),
+//   withLogger('branchStore'),
+// );
+// const store = new ProductsBranchStore2();
+// getInfiniteScrollDataSource({ store, collection, entity });

--- a/apps/example-app/src/app/examples/signals/product-list-paginated-page/product.store.ts
+++ b/apps/example-app/src/app/examples/signals/product-list-paginated-page/product.store.ts
@@ -37,11 +37,6 @@ export const ProductsRemoteStore = signalStore(
     pageSize: 5,
     pagesToCache: 2,
   }),
-  // withEntitiesRemoteScrollPagination({
-  //   bufferSize: 5,
-  //   collection,
-  //   entity
-  // }),
   withEntitiesRemoteSort({
     entity,
     collection,

--- a/apps/example-app/src/app/examples/signals/product-list-paginated-page/product.store.ts
+++ b/apps/example-app/src/app/examples/signals/product-list-paginated-page/product.store.ts
@@ -11,7 +11,6 @@ import {
   withEntitiesRemotePagination,
   withEntitiesRemoteSort,
   withEntitiesSingleSelection,
-  withSyncToWebStorage,
 } from '@ngrx-traits/signals';
 import { signalStore, type } from '@ngrx/signals';
 import { withEntities } from '@ngrx/signals/entities';
@@ -38,6 +37,11 @@ export const ProductsRemoteStore = signalStore(
     pageSize: 5,
     pagesToCache: 2,
   }),
+  // withEntitiesRemoteScrollPagination({
+  //   bufferSize: 5,
+  //   collection,
+  //   entity
+  // }),
   withEntitiesRemoteSort({
     entity,
     collection,

--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -17,29 +17,31 @@ and store the result of the call</p></dd>
 <dt><a href="#withEntitiesLocalFilter">withEntitiesLocalFilter(config)</a></dt>
 <dd><p>Generates necessary state, computed and methods for locally filtering entities in the store,
 the generated filter[collenction]Entities method will filter the entities based on the filter function
-and is debounced by default. Requires withEntities to be used.</p></dd>
+and is debounced by default.</p>
+<p>Requires withEntities to be used.</p></dd>
 <dt><a href="#withEntitiesRemoteFilter">withEntitiesRemoteFilter(config)</a></dt>
 <dd><p>Generates necessary state, computed and methods for remotely filtering entities in the store,
 the generated filter[collection]Entities method will filter the entities by calling set[collection]Loading()
 and you should either create an effect that listens toe [collection]Loading can call the api with the [collection]Filter params
 or use withEntitiesLoadingCall to call the api with the [collection]Filter params
-and is debounced by default. Requires withEntities and withCallStatus to be present before this function.</p></dd>
+and is debounced by default.</p>
+<p>Requires withEntities and withCallStatus to be present before this function.</p></dd>
 <dt><a href="#withEntitiesLoadingCall">withEntitiesLoadingCall(config)</a></dt>
 <dd><p>Generates a onInit hook that fetches entities from a remote source
 when the [collection]Loading is true, by calling the fetchEntities function
 and if successful, it will call set[Collection]Loaded and also set the entities
 to the store using the setAllEntities method or the setEntitiesResult method
 if it exists (comes from withEntitiesRemotePagination),
-if an error occurs it will set the error to the store using set[Collection]Error with the error.
-Requires withEntities and withCallStatus to be present in the store.</p></dd>
+if an error occurs it will set the error to the store using set[Collection]Error with the error.</p>
+<p>Requires withEntities and withCallStatus to be present in the store.</p></dd>
 <dt><a href="#withEntitiesLocalPagination">withEntitiesLocalPagination(config)</a></dt>
-<dd><p>Generates necessary state, computed and methods for local pagination of entities in the store.
-Requires withEntities to be present in the store.</p></dd>
+<dd><p>Generates necessary state, computed and methods for local pagination of entities in the store.</p>
+<p>Requires withEntities to be present in the store.</p></dd>
 <dt><a href="#withEntitiesRemotePagination">withEntitiesRemotePagination(config)</a></dt>
 <dd><p>Generates necessary state, computed and methods for remote pagination of entities in the store.
 When the page changes, it will try to load the current page from cache if it's not present,
 it will call set[collection]Loading(), and you should either create an effect that listens to [collection]Loading
-and call the api with the [collection]PagedRequest params and use set[Collection]LoadResult to set the result
+and call the api with the [collection]PagedRequest params and use set[Collection]Result to set the result
 and changing the status errors manually
 or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
 the result and errors automatically. Requires withEntities and withCallStatus to be used.
@@ -50,26 +52,34 @@ different between this and withEntitiesRemotePagination this will can only got t
 of entities keeps growing, ideally for implementing infinite scroll style ui.
 When the page changes, it will try to load the current page from cache if it's not present,
 it will call set[collection]Loading(), and you should either create an effect that listens to is[Collection]Loading
-and call the api with the [collection]PagedRequest params and use set[Collection]LoadResult to set the result
+and call the api with the [collection]PagedRequest params and use set[Collection]Result to set the result
 and changing the status errors manually
 or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
-the result and errors automatically. Requires withEntities and withCallStatus to be used.
-Requires withEntities and withCallStatus to be present in the store.</p></dd>
+the result and errors automatically. Requires withEntities and withCallStatus to be used.</p>
+<p>The generated set[Collection]Result method will append the entities to the cache of entities,
+it requires either just set of requested entities set[Collection]Result({ entities }) in which case it will assume there is no more result if you set less entities
+than the requested buffer size, or you can provide an extra param to the entities, total set[Collection]Result({ entities, total }) so it calculates if there is more
+or a hasMore param set[Collection]Result({entities, hasMore}) that you can set to false to indicate the end of the entities.</p>
+<p>Requires withEntities and withCallStatus to be present in the store.</p></dd>
 <dt><a href="#withEntitiesMultiSelection">withEntitiesMultiSelection(config)</a></dt>
 <dd><p>Generates state, signals and methods for multi selection of entities.
 Warning: isAll[Collection]Selected and toggleSelectAll[Collection] wont work
-correctly in using remote pagination, because they cant select all the data</p></dd>
+correctly in using remote pagination, because they cant select all the data.</p>
+<p>Requires withEntities to be used before this feature.</p></dd>
 <dt><a href="#withEntitiesSingleSelection">withEntitiesSingleSelection(config)</a></dt>
-<dd><p>Generates state, computed and methods for single selection of entities. Requires withEntities to be present before this function.</p></dd>
+<dd><p>Generates state, computed and methods for single selection of entities.</p>
+<p>Requires withEntities to be present before this function.</p></dd>
 <dt><a href="#withEntitiesLocalSort">withEntitiesLocalSort(config)</a></dt>
-<dd><p>Generates necessary state, computed and methods for sorting locally entities in the store. Requires withEntities to be present before this function</p></dd>
+<dd><p>Generates necessary state, computed and methods for sorting locally entities in the store.</p>
+<p>Requires withEntities to be present before this function</p></dd>
 <dt><a href="#withEntitiesRemoteSort">withEntitiesRemoteSort(config)</a></dt>
 <dd><p>Generates state, signals, and methods to sort entities remotely. When the sort method is called it will store the sort
 and call set[Collection]Loading, and you should either create an effect that listens to [collection]Loading
-and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]LoadResult if is paginated
+and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]Result if is paginated
 with the sorted result that come from the backend, plus changing the status  and set errors is needed.
 or use withEntitiesLoadingCall to call the api with the [collection]Sort params which handles setting
-the result and errors automatically. Requires withEntities and withCallStatus to be present before this function.</p></dd>
+the result and errors automatically.</p>
+<p>Requires withEntities and withCallStatus to be present before this function.</p></dd>
 <dt><a href="#withEventHandler">withEventHandler(eventHandlerFactory)</a></dt>
 <dd><p>Adds an event handler to the store, allowing the store to listen to events and react to them.
 This helps with the communications between different store feature functions, normally a store feature can only
@@ -176,7 +186,8 @@ withCalls(({ productsSelectedEntity }) => ({
 ## withEntitiesLocalFilter(config)
 <p>Generates necessary state, computed and methods for locally filtering entities in the store,
 the generated filter[collenction]Entities method will filter the entities based on the filter function
-and is debounced by default. Requires withEntities to be used.</p>
+and is debounced by default.</p>
+<p>Requires withEntities to be used.</p>
 
 **Kind**: global function  
 
@@ -222,7 +233,8 @@ const store = signalStore(
 the generated filter[collection]Entities method will filter the entities by calling set[collection]Loading()
 and you should either create an effect that listens toe [collection]Loading can call the api with the [collection]Filter params
 or use withEntitiesLoadingCall to call the api with the [collection]Filter params
-and is debounced by default. Requires withEntities and withCallStatus to be present before this function.</p>
+and is debounced by default.</p>
+<p>Requires withEntities and withCallStatus to be present before this function.</p>
 
 **Kind**: global function  
 
@@ -302,8 +314,8 @@ when the [collection]Loading is true, by calling the fetchEntities function
 and if successful, it will call set[Collection]Loaded and also set the entities
 to the store using the setAllEntities method or the setEntitiesResult method
 if it exists (comes from withEntitiesRemotePagination),
-if an error occurs it will set the error to the store using set[Collection]Error with the error.
-Requires withEntities and withCallStatus to be present in the store.</p>
+if an error occurs it will set the error to the store using set[Collection]Error with the error.</p>
+<p>Requires withEntities and withCallStatus to be present in the store.</p>
 
 **Kind**: global function  
 
@@ -364,8 +376,8 @@ export const ProductsRemoteStore = signalStore(
 <a name="withEntitiesLocalPagination"></a>
 
 ## withEntitiesLocalPagination(config)
-<p>Generates necessary state, computed and methods for local pagination of entities in the store.
-Requires withEntities to be present in the store.</p>
+<p>Generates necessary state, computed and methods for local pagination of entities in the store.</p>
+<p>Requires withEntities to be present in the store.</p>
 
 **Kind**: global function  
 
@@ -404,7 +416,7 @@ export const ProductsLocalStore = signalStore(
 <p>Generates necessary state, computed and methods for remote pagination of entities in the store.
 When the page changes, it will try to load the current page from cache if it's not present,
 it will call set[collection]Loading(), and you should either create an effect that listens to [collection]Loading
-and call the api with the [collection]PagedRequest params and use set[Collection]LoadResult to set the result
+and call the api with the [collection]PagedRequest params and use set[Collection]Result to set the result
 and changing the status errors manually
 or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
 the result and errors automatically. Requires withEntities and withCallStatus to be used.
@@ -455,7 +467,7 @@ export const store = signalStore(
     },
   }),
 // withEntitiesLoadingCall is the same as doing the following:
-// withHooks(({ productsLoading, setProductsError, setProductsLoadResult, ...state }) => ({
+// withHooks(({ productsLoading, setProductsError, setProductsResult, ...state }) => ({
 //   onInit: async () => {
 //     effect(() => {
 //       if (isProductsLoading()) {
@@ -469,7 +481,7 @@ export const store = signalStore(
 //             tap((res) =>
 //               patchState(
 //                 state,
-//                 setProductsLoadResult(res.resultList, res.total),
+//                 setProductsResult({ entities: res.resultList, total: res.total } ),
 //               ),
 //             ),
 //             catchError((error) => {
@@ -489,7 +501,7 @@ export const store = signalStore(
  store.productsPagedRequest // { startIndex: number, size: number, page: number }
  // generates the following methods
  store.loadProductsPage({ pageIndex: number, forceLoad?: boolean }) // loads the page and sets the requestPage to the pageIndex
- store.setProductsLoadResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
+ store.setProductsResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
 ```
 <a name="withEntitiesRemoteScrollPagination"></a>
 
@@ -499,11 +511,15 @@ different between this and withEntitiesRemotePagination this will can only got t
 of entities keeps growing, ideally for implementing infinite scroll style ui.
 When the page changes, it will try to load the current page from cache if it's not present,
 it will call set[collection]Loading(), and you should either create an effect that listens to is[Collection]Loading
-and call the api with the [collection]PagedRequest params and use set[Collection]LoadResult to set the result
+and call the api with the [collection]PagedRequest params and use set[Collection]Result to set the result
 and changing the status errors manually
 or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
-the result and errors automatically. Requires withEntities and withCallStatus to be used.
-Requires withEntities and withCallStatus to be present in the store.</p>
+the result and errors automatically. Requires withEntities and withCallStatus to be used.</p>
+<p>The generated set[Collection]Result method will append the entities to the cache of entities,
+it requires either just set of requested entities set[Collection]Result({ entities }) in which case it will assume there is no more result if you set less entities
+than the requested buffer size, or you can provide an extra param to the entities, total set[Collection]Result({ entities, total }) so it calculates if there is more
+or a hasMore param set[Collection]Result({entities, hasMore}) that you can set to false to indicate the end of the entities.</p>
+<p>Requires withEntities and withCallStatus to be present in the store.</p>
 
 **Kind**: global function  
 
@@ -548,7 +564,7 @@ export const store = signalStore(
     },
   }),
 // withEntitiesLoadingCall is the same as doing the following:
-// withHooks(({ productsLoading, setProductsError, setProductsLoadResult, ...state }) => ({
+// withHooks(({ productsLoading, setProductsError, setProductsResult, ...state }) => ({
 //   onInit: async () => {
 //     effect(() => {
 //       if (isProductsLoading()) {
@@ -562,7 +578,8 @@ export const store = signalStore(
 //             tap((res) =>
 //               patchState(
 //                 state,
-//                 setProductsLoadResult(res.resultList, res.total),
+//                 // total is not required, you can use hasMore or none see docs
+//                 setProductsResult({ entities: res.resultList, total: res.total } ),
 //               ),
 //             ),
 //             catchError((error) => {
@@ -578,7 +595,7 @@ export const store = signalStore(
 
  // in your component add
  store = inject(ProductsRemoteStore);
- dataSource = getInfiniteScrollDataSource(store, { collecrion: 'products' }) // pass this to your cdkVirtualFor see examples section
+ dataSource = getInfiniteScrollDataSource(store, { collection: 'products' }) // pass this to your cdkVirtualFor see examples section
   // generates the following signals
   store.productsPagination // { currentPage: number, requestPage: number, bufferSize: 5, total: number, pagesToCache: number, cache: { start: number, end: number } } used internally
  // generates the following computed signals
@@ -588,14 +605,15 @@ export const store = signalStore(
  store.loadProductsNextPage() // loads next page
  store.loadProductsPreviousPage() // loads previous page
  store.loadProductsFirstPage() // loads first page
- store.setProductsLoadResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
+ store.setProductsResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
 ```
 <a name="withEntitiesMultiSelection"></a>
 
 ## withEntitiesMultiSelection(config)
 <p>Generates state, signals and methods for multi selection of entities.
 Warning: isAll[Collection]Selected and toggleSelectAll[Collection] wont work
-correctly in using remote pagination, because they cant select all the data</p>
+correctly in using remote pagination, because they cant select all the data.</p>
+<p>Requires withEntities to be used before this feature.</p>
 
 **Kind**: global function  
 
@@ -629,7 +647,8 @@ store.toggleSelectAllProducts // () => void;
 <a name="withEntitiesSingleSelection"></a>
 
 ## withEntitiesSingleSelection(config)
-<p>Generates state, computed and methods for single selection of entities. Requires withEntities to be present before this function.</p>
+<p>Generates state, computed and methods for single selection of entities.</p>
+<p>Requires withEntities to be present before this function.</p>
 
 **Kind**: global function  
 
@@ -667,7 +686,8 @@ export const store = signalStore(
 <a name="withEntitiesLocalSort"></a>
 
 ## withEntitiesLocalSort(config)
-<p>Generates necessary state, computed and methods for sorting locally entities in the store. Requires withEntities to be present before this function</p>
+<p>Generates necessary state, computed and methods for sorting locally entities in the store.</p>
+<p>Requires withEntities to be present before this function</p>
 
 **Kind**: global function  
 
@@ -701,10 +721,11 @@ store.sortProductsEntities({ sort: { field: 'name', direction: 'asc' } }) - sort
 ## withEntitiesRemoteSort(config)
 <p>Generates state, signals, and methods to sort entities remotely. When the sort method is called it will store the sort
 and call set[Collection]Loading, and you should either create an effect that listens to [collection]Loading
-and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]LoadResult if is paginated
+and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]Result if is paginated
 with the sorted result that come from the backend, plus changing the status  and set errors is needed.
 or use withEntitiesLoadingCall to call the api with the [collection]Sort params which handles setting
-the result and errors automatically. Requires withEntities and withCallStatus to be present before this function.</p>
+the result and errors automatically.</p>
+<p>Requires withEntities and withCallStatus to be present before this function.</p>
 
 **Kind**: global function  
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -76,7 +76,7 @@ import {
 export function withEntitiesLocalFilter<
   Entity extends { id: string | number },
   Filter extends Record<string, unknown>,
->(options: {
+>(config: {
   filterFn: (entity: Entity, filter?: Filter) => boolean;
   defaultFilter: Filter;
   entity?: Entity;
@@ -133,7 +133,7 @@ export function withEntitiesLocalFilter<
   Entity extends { id: string | number },
   Collection extends string,
   Filter extends Record<string, unknown>,
->(options: {
+>(config: {
   filterFn: (entity: Entity, filter?: Filter) => boolean;
   defaultFilter: Filter;
   entity?: Entity;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -39,7 +39,9 @@ import {
 /**
  * Generates necessary state, computed and methods for locally filtering entities in the store,
  * the generated filter[collenction]Entities method will filter the entities based on the filter function
- * and is debounced by default. Requires withEntities to be used.
+ * and is debounced by default.
+ *
+ * Requires withEntities to be used.
  *
  * @param config
  * @param config.filterFn - The function that will be used to filter the entities
@@ -65,7 +67,7 @@ import {
  *   }),
  *  );
  *
- *  // generates the following signals
+ * // generates the following signals
  *  store.productsFilter // { search: string }
  *  // generates the following computed signals
  *  store.isProductsFilterChanged // boolean
@@ -95,7 +97,9 @@ export function withEntitiesLocalFilter<
 /**
  * Generates necessary state, computed and methods for locally filtering entities in the store,
  * the generated filter[collenction]Entities method will filter the entities based on the filter function
- * and is debounced by default. Requires withEntities to be used.
+ * and is debounced by default.
+ *
+ * Requires withEntities to be used.
  *
  * @param config
  * @param config.filterFn - The function that will be used to filter the entities
@@ -155,6 +159,7 @@ export function withEntitiesLocalFilter<
     methods: NamedEntitiesFilterMethods<Collection, Filter>;
   }
 >;
+
 export function withEntitiesLocalFilter<
   Entity extends { id: string | number },
   Collection extends string,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -139,10 +139,13 @@ export function withEntitiesLocalFilter<
   entity?: Entity;
   collection?: Collection;
 }): SignalStoreFeature<
-  // TODO: the problem seems be with the state pro, when set to any
-  //  it works but is it has a namedstate it doesnt
+  // TODO: we have a problem  with the state property, when set to string
+  // it works but is it has a Collection, some methods are not generated, it seems
+  // to only be accessible using store['filterEntities']
+  // the workaround doesn't cause any issues, because the signals prop does work and still
+  // gives the right error requiring withEntities to be used
   {
-    state: NamedEntityState<Entity, any>;
+    state: NamedEntityState<Entity, string>;
     signals: NamedEntitySignals<Entity, Collection>;
     methods: {};
   },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
@@ -199,7 +199,7 @@ describe('withEntitiesRemoteFilter', () => {
                   : false,
               );
             }
-            return of(result);
+            return of({ entities: result, total: result.length });
           },
         }),
       );

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -42,7 +42,9 @@ import {
  * the generated filter[collection]Entities method will filter the entities by calling set[collection]Loading()
  * and you should either create an effect that listens toe [collection]Loading can call the api with the [collection]Filter params
  * or use withEntitiesLoadingCall to call the api with the [collection]Filter params
- * and is debounced by default. Requires withEntities and withCallStatus to be present before this function.
+ * and is debounced by default.
+ *
+ * Requires withEntities and withCallStatus to be present before this function.
  * @param config
  * @param config.defaultFilter - The default filter to be used
  * @param config.entity - The entity type to be used
@@ -79,9 +81,9 @@ import {
  * //     effect(() => {
  * //       if (isProductsLoading()) {
  * //         inject(ProductService)
- * //            .getProducts({
+ * //              .getProducts({
  * //                 search: productsFilter().name,
- * //             })
+ * //               })
  * //           .pipe(
  * //             takeUntilDestroyed(),
  * //             tap((res) =>
@@ -131,7 +133,9 @@ export function withEntitiesRemoteFilter<
  * the generated filter[collection]Entities method will filter the entities by calling set[collection]Loading()
  * and you should either create an effect that listens toe [collection]Loading can call the api with the [collection]Filter params
  * or use withEntitiesLoadingCall to call the api with the [collection]Filter params
- * and is debounced by default. Requires withEntities and withCallStatus to be present before this function.
+ * and is debounced by default.
+ *
+ * Requires withEntities and withCallStatus to be present before this function.
  * @param config
  * @param config.defaultFilter - The default filter to be used
  * @param config.entity - The entity type to be used

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -208,7 +208,7 @@ export function withEntitiesRemoteFilter<
   collection?: Collection;
 }): SignalStoreFeature<
   {
-    state: NamedEntityState<Entity, any>;
+    state: NamedEntityState<Entity, string>;
     signals: NamedEntitySignals<Entity, Collection>;
     methods: NamedCallStatusMethods<Collection>;
   },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.spec.ts
@@ -151,7 +151,7 @@ describe('withEntitiesLoadingCall', () => {
       });
     }));
 
-    it('should set[Collection]LoadResult if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
+    it('should set[Collection]Result if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
       TestBed.runInInjectionContext(() => {
         const Store = signalStore(
           withEntities({

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
@@ -62,7 +62,9 @@ import { getWithEntitiesRemotePaginationKeys } from '../with-entities-pagination
  * to the store using the setAllEntities method or the setEntitiesResult method
  * if it exists (comes from withEntitiesRemotePagination),
  * if an error occurs it will set the error to the store using set[Collection]Error with the error.
+ *
  * Requires withEntities and withCallStatus to be present in the store.
+ *
  * @param config - Configuration object
  * @param config.fetchEntities - A function that fetches the entities from a remote source the return type
  * @param config.collection - The collection name
@@ -156,7 +158,9 @@ export function withEntitiesLoadingCall<
  * to the store using the setAllEntities method or the setEntitiesResult method
  * if it exists (comes from withEntitiesRemotePagination),
  * if an error occurs it will set the error to the store using set[Collection]Error with the error.
+ *
  * Requires withEntities and withCallStatus to be present in the store.
+ *
  * @param config - Configuration object
  * @param config.fetchEntities - A function that fetches the entities from a remote source the return type
  * @param config.collection - The collection name

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/signal-infinite-datasource.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/signal-infinite-datasource.ts
@@ -23,6 +23,7 @@ export function getInfiniteScrollDataSource<Entity, Collection extends string>(
       }
     | {
         collection: Collection;
+        entity: Entity;
         store: NamedEntitySignals<Entity, Collection> &
           NamedEntitiesScrollPaginationMethods<Entity, Collection>;
       },
@@ -47,13 +48,11 @@ export function getInfiniteScrollDataSource<Entity, Collection extends string>(
       this.subscription = collectionViewer.viewChange
         .pipe(
           filter(({ end, start }) => {
-            const { bufferSize, total } = entitiesScrollCache();
+            const { bufferSize, hasMore } = entitiesScrollCache();
             // filter first request that is done by the cdkscroll,
             // filter last request
             // only do requests when you pass a specific threshold
-            return (
-              start != 0 && end <= total! && end + bufferSize >= entities.length
-            );
+            return start != 0 && hasMore && end + bufferSize >= entities.length;
           }),
         )
         .subscribe(() => {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.model.ts
@@ -45,3 +45,12 @@ export type NamedEntitiesPaginationLocalMethods<Collection extends string> = {
     pageIndex: number;
   }) => void;
 };
+
+export type SetEntitiesResult<ResultParam> = {
+  setEntitiesResult: (result: ResultParam) => void;
+};
+export type NamedSetEntitiesResult<Collection extends string, ResultParam> = {
+  [K in Collection as `set${Capitalize<string & K>}Result`]: (
+    result: ResultParam,
+  ) => void;
+};

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.ts
@@ -120,7 +120,7 @@ export function withEntitiesLocalPagination<
   collection?: Collection;
 }): SignalStoreFeature<
   {
-    state: NamedEntityState<Entity, any>; // if put Collection the some props get lost and can only be access ['prop'] weird bug
+    state: NamedEntityState<Entity, string>; // if put Collection the some props get lost and can only be access ['prop'] weird bug
     signals: NamedEntitySignals<Entity, Collection>;
     methods: {};
   },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.ts
@@ -36,6 +36,7 @@ import {
 
 /**
  * Generates necessary state, computed and methods for local pagination of entities in the store.
+ *
  * Requires withEntities to be present in the store.
  * @param config
  * @param config.pageSize - The number of entities to show per page
@@ -54,7 +55,7 @@ import {
  *     entity,
  *     collection,
  *     pageSize: 5,
- *   }));
+ *   }),
  *
  *   // generates the following signals
  *   store.productsPagination // { currentPage: 0, pageSize: 5 }
@@ -83,6 +84,7 @@ export function withEntitiesLocalPagination<
 >;
 /**
  * Generates necessary state, computed and methods for local pagination of entities in the store.
+ *
  * Requires withEntities to be present in the store.
  * @param config
  * @param config.pageSize - The number of entities to show per page

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.model.ts
@@ -3,6 +3,8 @@ import { Signal } from '@angular/core';
 import {
   EntitiesPaginationLocalMethods,
   NamedEntitiesPaginationLocalMethods,
+  NamedSetEntitiesResult,
+  SetEntitiesResult,
 } from './with-entities-local-pagination.model';
 
 export type PaginationState = {
@@ -60,17 +62,13 @@ export type NamedEntitiesPaginationRemoteComputed<
     isLoading: boolean;
   }>;
 };
+
 export type EntitiesPaginationRemoteMethods<Entity> =
-  EntitiesPaginationLocalMethods & {
-    setEntitiesResult: (result: { entities: Entity[]; total: number }) => void;
-  };
+  EntitiesPaginationLocalMethods &
+    SetEntitiesResult<{ entities: Entity[]; total: number }>;
 
 export type NamedEntitiesPaginationRemoteMethods<
   Entity,
   Collection extends string,
-> = NamedEntitiesPaginationLocalMethods<Collection> & {
-  [K in Collection as `set${Capitalize<string & K>}Result`]: (result: {
-    entities: Entity[];
-    total: number;
-  }) => void;
-};
+> = NamedEntitiesPaginationLocalMethods<Collection> &
+  NamedSetEntitiesResult<Collection, { entities: Entity[]; total: number }>;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.ts
@@ -54,111 +54,12 @@ import {
  * Generates necessary state, computed and methods for remote pagination of entities in the store.
  * When the page changes, it will try to load the current page from cache if it's not present,
  * it will call set[collection]Loading(), and you should either create an effect that listens to [collection]Loading
- * and call the api with the [collection]PagedRequest params and use set[Collection]LoadResult to set the result
+ * and call the api with the [collection]PagedRequest params and use set[Collection]Result to set the result
  * and changing the status errors manually
  * or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
- * the result and errors automatically. Requires withEntities and withCallStatus to be present before this function.
- * @param config
- * @param config.pageSize - The number of entities to show per page
- * @param config.currentPage - The current page to show
- * @param config.pagesToCache - The number of pages to cache
- * @param config.entity - The entity type
- * @param config.collection - The name of the collection
+ * the result and errors automatically.
  *
- * @example
- * export const ProductsRemoteStore = signalStore(
- *   { providedIn: 'root' },
- *   // required withEntities and withCallStatus
- *   withEntities({ entity, collection }),
- *   withCallStatus({ prop: collection, initialValue: 'loading' }),
- *
- *   withEntitiesRemotePagination({
- *     entity,
- *     collection,
- *     pageSize: 5,
- *     pagesToCache: 2,
- *   })
- *   // after you can use withEntitiesLoadingCall to connect the filter to
- *   // the api call, or do it manually as shown after
- *    withEntitiesLoadingCall({
- *     collection,
- *     fetchEntities: ({ productsPagedRequest }) => {
- *       return inject(ProductService)
- *         .getProducts({
- *           take: productsPagedRequest().size,
- *           skip: productsPagedRequest().startIndex,
- *         }).pipe(
- *           map((d) => ({
- *             entities: d.resultList,
- *             total: d.total,
- *           })),
- *         )
- *     },
- *   }),
- * // withEntitiesLoadingCall is the same as doing the following:
- * // withHooks(({ productsLoading, setProductsError, setProductsLoadResult, ...state }) => ({
- * //   onInit: async () => {
- * //     effect(() => {
- * //       if (isProductsLoading()) {
- * //         inject(ProductService)
- * //             .getProducts({
- * //                take: productsPagedRequest().size,
- * //                skip: productsPagedRequest().startIndex,
- * //              })
- * //           .pipe(
- * //             takeUntilDestroyed(),
- * //             tap((res) =>
- * //               patchState(
- * //                 state,
- * //                 setProductsLoadResult(res.resultList, res.total),
- * //               ),
- * //             ),
- * //             catchError((error) => {
- * //               setProductsError(error);
- * //               return EMPTY;
- * //             }),
- * //           )
- * //           .subscribe();
- * //       }
- * //     });
- * //   },
- *  })),
- *   // generates the following signals
- *   store.productsPagination // { currentPage: number, requestPage: number, pageSize: 5, total: number, pagesToCache: number, cache: { start: number, end: number } } used internally
- *  // generates the following computed signals
- *  store.productsCurrentPage // { entities: Product[], pageIndex: number, total: number, pageSize: 5, pagesCount: number, hasPrevious: boolean, hasNext: boolean, isLoading: boolean }
- *  store.productsPagedRequest // { startIndex: number, size: number, page: number }
- *  // generates the following methods
- *  store.loadProductsPage({ pageIndex: number, forceLoad?: boolean }) // loads the page and sets the requestPage to the pageIndex
- *  store.setProductsLoadResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
- */
-export function withEntitiesRemotePagination<
-  Entity extends { id: string | number },
->(config: {
-  pageSize?: number;
-  currentPage?: number;
-  pagesToCache?: number;
-  entity?: Entity;
-}): SignalStoreFeature<
-  {
-    state: EntityState<Entity>;
-    signals: EntitySignals<Entity> & CallStatusComputed;
-    methods: CallStatusMethods;
-  },
-  {
-    state: EntitiesPaginationRemoteState;
-    signals: EntitiesPaginationRemoteComputed<Entity>;
-    methods: EntitiesPaginationRemoteMethods<Entity>;
-  }
->;
-/**
- * Generates necessary state, computed and methods for remote pagination of entities in the store.
- * When the page changes, it will try to load the current page from cache if it's not present,
- * it will call set[collection]Loading(), and you should either create an effect that listens to [collection]Loading
- * and call the api with the [collection]PagedRequest params and use set[Collection]LoadResult to set the result
- * and changing the status errors manually
- * or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
- * the result and errors automatically. Requires withEntities and withCallStatus to be present before this function.
+ * Requires withEntities and withCallStatus to be present before this function.
  * @param config
  * @param config.pageSize - The number of entities to show per page
  * @param config.currentPage - The current page to show
@@ -199,7 +100,7 @@ export function withEntitiesRemotePagination<
  *     },
  *   }),
  * // withEntitiesLoadingCall is the same as doing the following:
- * // withHooks(({ productsLoading, setProductsError, setProductsLoadResult, ...state }) => ({
+ * // withHooks(({ productsLoading, setProductsError, setProductsResult, ...state }) => ({
  * //   onInit: async () => {
  * //     effect(() => {
  * //       if (isProductsLoading()) {
@@ -213,7 +114,7 @@ export function withEntitiesRemotePagination<
  * //             tap((res) =>
  * //               patchState(
  * //                 state,
- * //                 setProductsLoadResult(res.resultList, res.total),
+ * //                 setProductsResult({ entities: res.resultList, total: res.total } ),
  * //               ),
  * //             ),
  * //             catchError((error) => {
@@ -233,7 +134,112 @@ export function withEntitiesRemotePagination<
  *  store.productsPagedRequest // { startIndex: number, size: number, page: number }
  *  // generates the following methods
  *  store.loadProductsPage({ pageIndex: number, forceLoad?: boolean }) // loads the page and sets the requestPage to the pageIndex
- *  store.setProductsLoadResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
+ *  store.setProductsResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
+ */
+export function withEntitiesRemotePagination<
+  Entity extends { id: string | number },
+>(config: {
+  pageSize?: number;
+  currentPage?: number;
+  pagesToCache?: number;
+  entity?: Entity;
+}): SignalStoreFeature<
+  {
+    state: EntityState<Entity>;
+    signals: EntitySignals<Entity> & CallStatusComputed;
+    methods: CallStatusMethods;
+  },
+  {
+    state: EntitiesPaginationRemoteState;
+    signals: EntitiesPaginationRemoteComputed<Entity>;
+    methods: EntitiesPaginationRemoteMethods<Entity>;
+  }
+>;
+/**
+ * Generates necessary state, computed and methods for remote pagination of entities in the store.
+ * When the page changes, it will try to load the current page from cache if it's not present,
+ * it will call set[collection]Loading(), and you should either create an effect that listens to [collection]Loading
+ * and call the api with the [collection]PagedRequest params and use set[Collection]Result to set the result
+ * and changing the status errors manually
+ * or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
+ * the result and errors automatically.
+ *
+ * Requires withEntities and withCallStatus to be present before this function.
+ * @param config
+ * @param config.pageSize - The number of entities to show per page
+ * @param config.currentPage - The current page to show
+ * @param config.pagesToCache - The number of pages to cache
+ * @param config.entity - The entity type
+ * @param config.collection - The name of the collection
+ *
+ * @example
+ * const entity = type<Product>();
+ * const collection = 'products';
+ * export const store = signalStore(
+ *   { providedIn: 'root' },
+ *   // required withEntities and withCallStatus
+ *   withEntities({ entity, collection }),
+ *   withCallStatus({ prop: collection, initialValue: 'loading' }),
+ *
+ *   withEntitiesRemotePagination({
+ *     entity,
+ *     collection,
+ *     pageSize: 5,
+ *     pagesToCache: 2,
+ *   })
+ *   // after you can use withEntitiesLoadingCall to connect the filter to
+ *   // the api call, or do it manually as shown after
+ *    withEntitiesLoadingCall({
+ *     collection,
+ *     fetchEntities: ({ productsPagedRequest }) => {
+ *       return inject(ProductService)
+ *         .getProducts({
+ *           take: productsPagedRequest().size,
+ *           skip: productsPagedRequest().startIndex,
+ *         }).pipe(
+ *           map((d) => ({
+ *             entities: d.resultList,
+ *             total: d.total,
+ *           })),
+ *         )
+ *     },
+ *   }),
+ * // withEntitiesLoadingCall is the same as doing the following:
+ * // withHooks(({ productsLoading, setProductsError, setProductsResult, ...state }) => ({
+ * //   onInit: async () => {
+ * //     effect(() => {
+ * //       if (isProductsLoading()) {
+ * //         inject(ProductService)
+ * //             .getProducts({
+ * //                take: productsPagedRequest().size,
+ * //                skip: productsPagedRequest().startIndex,
+ * //              })
+ * //           .pipe(
+ * //             takeUntilDestroyed(),
+ * //             tap((res) =>
+ * //               patchState(
+ * //                 state,
+ * //                 setProductsResult({ entities: res.resultList, total: res.total } ),
+ * //               ),
+ * //             ),
+ * //             catchError((error) => {
+ * //               setProductsError(error);
+ * //               return EMPTY;
+ * //             }),
+ * //           )
+ * //           .subscribe();
+ * //       }
+ * //     });
+ * //   },
+ *  })),
+ *   // generates the following signals
+ *   store.productsPagination // { currentPage: number, requestPage: number, pageSize: 5, total: number, pagesToCache: number, cache: { start: number, end: number } } used internally
+ *  // generates the following computed signals
+ *  store.productsCurrentPage // { entities: Product[], pageIndex: number, total: number, pageSize: 5, pagesCount: number, hasPrevious: boolean, hasNext: boolean, isLoading: boolean }
+ *  store.productsPagedRequest // { startIndex: number, size: number, page: number }
+ *  // generates the following methods
+ *  store.loadProductsPage({ pageIndex: number, forceLoad?: boolean }) // loads the page and sets the requestPage to the pageIndex
+ *  store.setProductsResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
  */
 
 export function withEntitiesRemotePagination<
@@ -262,7 +268,7 @@ export function withEntitiesRemotePagination<
  * Generates necessary state, computed and methods for remote pagination of entities in the store.
  * When the page changes, it will try to load the current page from cache if it's not present,
  * it will call set[collection]Loading(), and you should either create an effect that listens to [collection]Loading
- * and call the api with the [collection]PagedRequest params and use set[Collection]LoadResult to set the result
+ * and call the api with the [collection]PagedRequest params and use set[Collection]Result to set the result
  * and changing the status errors manually
  * or use withEntitiesLoadingCall to call the api with the [collection]PagedRequest params which handles setting
  * the result and errors automatically. Requires withEntities and withCallStatus to be used.
@@ -307,7 +313,7 @@ export function withEntitiesRemotePagination<
  *     },
  *   }),
  * // withEntitiesLoadingCall is the same as doing the following:
- * // withHooks(({ productsLoading, setProductsError, setProductsLoadResult, ...state }) => ({
+ * // withHooks(({ productsLoading, setProductsError, setProductsResult, ...state }) => ({
  * //   onInit: async () => {
  * //     effect(() => {
  * //       if (isProductsLoading()) {
@@ -321,7 +327,7 @@ export function withEntitiesRemotePagination<
  * //             tap((res) =>
  * //               patchState(
  * //                 state,
- * //                 setProductsLoadResult(res.resultList, res.total),
+ * //                 setProductsResult({ entities: res.resultList, total: res.total } ),
  * //               ),
  * //             ),
  * //             catchError((error) => {
@@ -341,7 +347,7 @@ export function withEntitiesRemotePagination<
  *  store.productsPagedRequest // { startIndex: number, size: number, page: number }
  *  // generates the following methods
  *  store.loadProductsPage({ pageIndex: number, forceLoad?: boolean }) // loads the page and sets the requestPage to the pageIndex
- *  store.setProductsLoadResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
+ *  store.setProductsResult(entities: Product[], total: number) // appends the entities to the cache of entities and total
  */
 export function withEntitiesRemotePagination<
   Entity extends { id: string | number },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.ts
@@ -247,7 +247,7 @@ export function withEntitiesRemotePagination<
   collection?: Collection;
 }): SignalStoreFeature<
   {
-    state: NamedEntityState<Entity, any>; // if put Collection the some props get lost and can only be access ['prop'] weird bug
+    state: NamedEntityState<Entity, string>; // if put Collection the some props get lost and can only be access ['prop'] weird bug
     signals: NamedEntitySignals<Entity, Collection> &
       NamedCallStatusComputed<Collection>;
     methods: NamedCallStatusMethods<Collection>;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.model.ts
@@ -1,8 +1,12 @@
 import { Signal } from '@angular/core';
 
+import {
+  NamedSetEntitiesResult,
+  SetEntitiesResult,
+} from './with-entities-local-pagination.model';
+
 export type ScrollPaginationState = {
   bufferSize: number;
-  total: number | undefined;
   hasMore: boolean;
 };
 export type EntitiesScrollPaginationState = {
@@ -26,18 +30,37 @@ export type NamedEntitiesScrollPaginationComputed<
     size: number;
   }>;
 };
-export type EntitiesScrollPaginationMethods<Entity> = {
-  setEntitiesResult: (result: { entities: Entity[]; total: number }) => void;
+export type EntitiesScrollPaginationMethods<Entity> = SetEntitiesResult<
+  | {
+      entities: Entity[];
+      total: number;
+    }
+  | {
+      entities: Entity[];
+      hasMore: boolean;
+    }
+  | {
+      entities: Entity[];
+    }
+> & {
   loadMoreEntities: () => void;
 };
 export type NamedEntitiesScrollPaginationMethods<
   Entity,
   Collection extends string,
-> = {
-  [K in Collection as `set${Capitalize<string & K>}Result`]: (result: {
-    entities: Entity[];
-    total: number;
-  }) => void;
-} & {
+> = NamedSetEntitiesResult<
+  Collection,
+  | {
+      entities: Entity[];
+      total: number;
+    }
+  | {
+      entities: Entity[];
+      hasMore: boolean;
+    }
+  | {
+      entities: Entity[];
+    }
+> & {
   [K in Collection as `loadMore${Capitalize<string & K>}`]: () => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.ts
@@ -260,7 +260,7 @@ export function withEntitiesRemoteScrollPagination<
   collection?: Collection;
 }): SignalStoreFeature<
   {
-    state: NamedEntityState<Entity, any>; // if put Collection the some props get lost and can only be access ['prop'] weird bug
+    state: NamedEntityState<Entity, string>; // if put Collection the some props get lost and can only be access ['prop'] weird bug
     signals: NamedEntitySignals<Entity, Collection> &
       NamedCallStatusComputed<Collection>;
     methods: NamedCallStatusMethods<Collection>;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.ts
@@ -305,7 +305,6 @@ export function withEntitiesRemoteScrollPagination<
   return signalStoreFeature(
     withState({
       [entitiesScrollCacheKey]: {
-        total: undefined,
         bufferSize,
         hasMore: true,
       },
@@ -339,13 +338,21 @@ export function withEntitiesRemoteScrollPagination<
       const setLoading = state[setLoadingKey] as () => void;
 
       return {
-        [setEntitiesResultKey]: ({
-          entities,
-          total,
-        }: {
-          entities: Entity[];
-          total: number;
-        }) => {
+        [setEntitiesResultKey]: (
+          options:
+            | {
+                entities: Entity[];
+                total: number;
+              }
+            | {
+                entities: Entity[];
+                hasMore: boolean;
+              }
+            | {
+                entities: Entity[];
+              },
+        ) => {
+          const entities = options.entities;
           const entitiesOld = state[entitiesKey] as Signal<Entity[]>;
           patchState(
             state as StateSignal<object>,
@@ -357,8 +364,12 @@ export function withEntitiesRemoteScrollPagination<
             {
               [entitiesScrollCacheKey]: {
                 ...entitiesScrollCache(),
-                total,
-                hasMore: entitiesOld().length + entities.length < total,
+                hasMore:
+                  'hasMore' in options
+                    ? options.hasMore
+                    : 'total' in options
+                      ? entitiesOld().length + entities.length < options.total
+                      : entities.length == entitiesScrollCache().bufferSize,
               },
             },
           );

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
@@ -36,7 +36,9 @@ import { getEntitiesMultiSelectionKeys } from './with-entities-multi-selection.u
 /**
  * Generates state, signals and methods for multi selection of entities.
  * Warning: isAll[Collection]Selected and toggleSelectAll[Collection] wont work
- * correctly in using remote pagination, because they cant select all the data
+ * correctly in using remote pagination, because they cant select all the data.
+ *
+ * Requires withEntities to be used before this feature.
  * @param config
  * @param config.entity - the entity type
  * @param config.collection - the collection name
@@ -81,7 +83,9 @@ export function withEntitiesMultiSelection<
 /**
  * Generates state, signals and methods for multi selection of entities.
  * Warning: isAll[Collection]Selected and toggleSelectAll[Collection] wont work
- * correctly in using remote pagination, because they cant select all the data
+ * correctly in using remote pagination, because they cant select all the data.
+ *
+ * Requires withEntities to be used before this feature.
  * @param config
  * @param config.entity - the entity type
  * @param config.collection - the collection name

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.ts
@@ -33,7 +33,9 @@ import {
 import { getEntitiesSingleSelectionKeys } from './with-entities-single-selection.util';
 
 /**
- * Generates state, computed and methods for single selection of entities. Requires withEntities to be present before this function.
+ * Generates state, computed and methods for single selection of entities.
+ *
+ * Requires withEntities to be present before this function.
  * @param config
  * @param config.collection - The collection name
  * @param config.entity - The entity type
@@ -80,7 +82,9 @@ export function withEntitiesSingleSelection<
   }
 >;
 /**
- * Generates state, computed and methods for single selection of entities. Requires withEntities to be present before this function.
+ * Generates state, computed and methods for single selection of entities.
+ *
+ * Requires withEntities to be present before this function.
  * @param config
  * @param config.collection - The collection name
  * @param config.entity - The entity type

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
@@ -108,10 +108,13 @@ export function withEntitiesLocalSort<
   entity?: Entity;
   collection?: Collection;
 }): SignalStoreFeature<
-  // TODO: the problem seems be with the state pro, when set to empty
-  //  it works but is it has a namedstate it doesnt
+  // TODO: we have a problem  with the state property, when set to string
+  // it works but is it has a Collection, some methods are not generated, it seems
+  // to only be accessible using store['filterEntities']
+  // the workaround doesn't cause any issues, because the signals prop does work and still
+  // gives the right error requiring withEntities to be used
   {
-    state: NamedEntityState<Entity, any>;
+    state: NamedEntityState<Entity, string>;
     signals: NamedEntitySignals<Entity, Collection>;
     methods: {};
   },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
@@ -36,7 +36,9 @@ import {
 import { getWithEntitiesSortKeys } from './with-entities-sort.util';
 
 /**
- * Generates necessary state, computed and methods for sorting locally entities in the store. Requires withEntities to be present before this function
+ * Generates necessary state, computed and methods for sorting locally entities in the store.
+ *
+ * Requires withEntities to be present before this function
  * @param config
  * @param config.defaultSort - The default sort to be applied to the entities
  * @param config.entity - The type entity to be used
@@ -77,7 +79,9 @@ export function withEntitiesLocalSort<
   }
 >;
 /**
- * Generates necessary state, computed and methods for sorting locally entities in the store. Requires withEntities to be present before this function
+ * Generates necessary state, computed and methods for sorting locally entities in the store.
+ *
+ * Requires withEntities to be present before this function
  * @param config
  * @param config.defaultSort - The default sort to be applied to the entities
  * @param config.entity - The type entity to be used

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
@@ -35,10 +35,12 @@ import { getWithEntitiesSortKeys } from './with-entities-sort.util';
 /**
  * Generates state, signals, and methods to sort entities remotely. When the sort method is called it will store the sort
  * and call set[Collection]Loading, and you should either create an effect that listens to [collection]Loading
- * and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]LoadResult if is paginated
+ * and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]Result if is paginated
  * with the sorted result that come from the backend, plus changing the status  and set errors is needed.
  * or use withEntitiesLoadingCall to call the api with the [collection]Sort params which handles setting
- * the result and errors automatically. Requires withEntities and withCallStatus to be present before this function.
+ * the result and errors automatically.
+ *
+ * Requires withEntities and withCallStatus to be present before this function.
  *
  * @param config
  * @param config.defaultSort - The default sort to use when the store is initialized
@@ -125,10 +127,12 @@ export function withEntitiesRemoteSort<
 /**
  * Generates state, signals, and methods to sort entities remotely. When the sort method is called it will store the sort
  * and call set[Collection]Loading, and you should either create an effect that listens to [collection]Loading
- * and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]LoadResult if is paginated
+ * and call the api with the [collection]Sort params and use wither setAllEntities if is not paginated or set[Collection]Result if is paginated
  * with the sorted result that come from the backend, plus changing the status  and set errors is needed.
  * or use withEntitiesLoadingCall to call the api with the [collection]Sort params which handles setting
- * the result and errors automatically. Requires withEntities and withCallStatus to be present before this function.
+ * the result and errors automatically.
+ *
+ * Requires withEntities and withCallStatus to be present before this function.
  *
  * @param config
  * @param config.defaultSort - The default sort to use when the store is initialized

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
@@ -204,7 +204,7 @@ export function withEntitiesRemoteSort<
   collection?: Collection;
 }): SignalStoreFeature<
   {
-    state: NamedEntityState<Entity, any>;
+    state: NamedEntityState<Entity, string>;
     signals: NamedEntitySignals<Entity, Collection>;
     methods: NamedCallStatusMethods<Collection>;
   },


### PR DESCRIPTION
withEntitiesRemoteScrollPagination setEntitiesResult now accepts besides { entities , total} also {entities, hasMore}, or just {entities}, in the last case it will know there are no more entities if the returned entities are less than the requested size