### PR TITLE
Fix/several fixes

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -9,7 +9,7 @@ export type CallConfig<
   PropName extends string = string,
 > = {
   call: Call<Params, Result>;
-  resultProp?: PropName;
+  resultProp: PropName;
   mapPipe?: 'switchMap' | 'concatMap' | 'exhaustMap';
   storeResult?: boolean;
   onSuccess?: (result: Result, ...params: Params) => void;
@@ -22,4 +22,4 @@ export type ExtractCallResultType<T extends Call | CallConfig> =
       ? R
       : never;
 export type ExtractCallParams<T extends Call | CallConfig> =
-  T extends Call<infer P> ? P : T extends CallConfig<infer P> ? P : never;
+  T extends Call<infer P> ? P : T extends CallConfig<infer P> ? P : [];

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
@@ -46,6 +46,25 @@ describe('withCalls', () => {
     });
   });
 
+  it('Successful call of a no parameters method, should set status to loading and loaded ', async () => {
+    const Store = signalStore(
+      withState({ foo: 'bar' }),
+      withCalls(() => ({
+        testCall: () => {
+          return apiResponse;
+        },
+      })),
+    );
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      expect(store.isTestCallLoading()).toBeFalsy();
+      store.testCall();
+      expect(store.isTestCallLoading()).toBeTruthy();
+      apiResponse.next('test');
+      expect(store.isTestCallLoaded()).toBeTruthy();
+      expect(store.testCallResult()).toBe('test');
+    });
+  });
   it('passing a signal should call when signal value changes ', async () => {
     TestBed.runInInjectionContext(() => {
       const store = new Store();
@@ -108,6 +127,55 @@ describe('withCalls', () => {
         expect(store.testCall2Error()).toEqual(new Error('fail'));
         expect(store.result()).toBe(undefined);
         expect(onError).toHaveBeenCalledWith(new Error('fail'), { ok: false });
+      });
+    });
+    it('Successful call of a no parameters method and resultProp, should set status to loading and loaded ', async () => {
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          withState({ foo: 'bar' }),
+          withCalls(() => ({
+            testCall2: typedCallConfig({
+              call: () => {
+                return apiResponse;
+              },
+              resultProp: 'result',
+              onSuccess,
+              onError,
+            }),
+          })),
+        );
+        const store = new Store();
+        expect(store.isTestCall2Loading()).toBeFalsy();
+        store.testCall2();
+        expect(store.isTestCall2Loading()).toBeTruthy();
+        apiResponse.next('test');
+        expect(store.isTestCall2Loaded()).toBeTruthy();
+        expect(store.result()).toBe('test');
+        expect(onSuccess).toHaveBeenCalledWith('test', { ok: true });
+      });
+    });
+    it('Successful call of a no parameters method and no resultProp, should set status to loading and loaded ', async () => {
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          withState({ foo: 'bar' }),
+          withCalls(() => ({
+            testCall2: typedCallConfig({
+              call: () => {
+                return apiResponse;
+              },
+              onSuccess,
+              onError,
+            }),
+          })),
+        );
+        const store = new Store();
+        expect(store.isTestCall2Loading()).toBeFalsy();
+        store.testCall2();
+        expect(store.isTestCall2Loading()).toBeTruthy();
+        apiResponse.next('test');
+        expect(store.isTestCall2Loaded()).toBeTruthy();
+        expect(store.testCall2Result()).toBe('test');
+        expect(onSuccess).toHaveBeenCalledWith('test', { ok: true });
       });
     });
     it('Successful call should set status to loading and loaded ', async () => {

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -201,7 +201,6 @@ export function withCalls<
                     ? call.resultProp
                     : `${callName}Result`,
               });
-              console.log({ callNameKey, callStatusKey, resultPropKey });
               // TODO: fix as any
               const mapPipe =
                 isCallConfig(call) && call.mapPipe

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.model.ts
@@ -52,4 +52,6 @@ export type NamedEntitiesMultiSelectionMethods<Collection extends string> = {
   [K in Collection as `toggleSelectAll${Capitalize<
     string & K
   >}Entities`]: () => void;
+} & {
+  [K in Collection as `clear${Capitalize<string & K>}Selection`]: () => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
@@ -67,6 +67,21 @@ describe('withEntitiesMultiSelection', () => {
       store.toggleSelectEntities({ id: mockProducts[4].id });
       expect(store.isAllEntitiesSelected()).toEqual('some');
     });
+
+    it('cleanEntitiesSelected should clear selection', () => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.toggleSelectAllEntities();
+      expect(store.isAllEntitiesSelected()).toEqual('all');
+      store.clearEntitiesSelection();
+      expect(store.isAllEntitiesSelected()).toEqual('none');
+      store.toggleSelectEntities({ ids: mockProducts.map((p) => p.id) });
+      expect(store.isAllEntitiesSelected()).toEqual('all');
+      store.toggleSelectEntities({ id: mockProducts[4].id });
+      expect(store.isAllEntitiesSelected()).toEqual('some');
+      store.clearEntitiesSelection();
+      expect(store.isAllEntitiesSelected()).toEqual('none');
+    });
   });
 
   describe('with collection', () => {
@@ -125,6 +140,23 @@ describe('withEntitiesMultiSelection', () => {
       expect(store.isAllProductsSelected()).toEqual('all');
       store.toggleSelectProductsEntities({ id: mockProducts[4].id });
       expect(store.isAllProductsSelected()).toEqual('some');
+    });
+
+    it('clean[Collection]Selected should clear selection', () => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts, { collection }));
+      store.toggleSelectAllProductsEntities();
+      expect(store.isAllProductsSelected()).toEqual('all');
+      store.clearProductsSelection();
+      expect(store.isAllProductsSelected()).toEqual('none');
+      store.toggleSelectProductsEntities({
+        ids: mockProducts.map((p) => p.id),
+      });
+      expect(store.isAllProductsSelected()).toEqual('all');
+      store.toggleSelectProductsEntities({ id: mockProducts[4].id });
+      expect(store.isAllProductsSelected()).toEqual('some');
+      store.clearProductsSelection();
+      expect(store.isAllProductsSelected()).toEqual('none');
     });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
@@ -276,7 +276,9 @@ export function withEntitiesMultiSelection<
             [selectedIdsMapKey]: { ...oldIdsMap, ...idsMap },
           });
         },
-        [clearEntitiesSelectionKey]: clearEntitiesSelection,
+        [clearEntitiesSelectionKey]: () => {
+          clearEntitiesSelection(state, selectedIdsMapKey);
+        },
         [toggleSelectAllEntitiesKey]: () => {
           const allSelected = isAllEntitiesSelected();
           if (allSelected === 'all') {


### PR DESCRIPTION
Fix for #74 , generate correct type when using withCalls with typedCallConfig with no resultProp and a call with no params
Fix for #75 clearEntitiesSelection not working and missing equivalent method in NamedEntitiesMultiSelectionMethods