### PR TITLE
 feat(signals): allow withEntitiesLoadingCall to receive a factory function for config

### DIFF
--- a/apps/example-app/src/app/examples/signals/infinete-scroll-page/products-branch.store.ts
+++ b/apps/example-app/src/app/examples/signals/infinete-scroll-page/products-branch.store.ts
@@ -30,8 +30,8 @@ export const ProductsBranchStore = signalStore(
       pageSize: 10,
       entity,
     }),
-    withEntitiesLoadingCall({
-      fetchEntities: async ({ entitiesPagedRequest, entitiesFilter }) => {
+    withEntitiesLoadingCall(({ entitiesPagedRequest, entitiesFilter }) => ({
+      fetchEntities: async () => {
         const res = await lastValueFrom(
           inject(BranchService).getBranches({
             search: entitiesFilter().search,
@@ -41,7 +41,7 @@ export const ProductsBranchStore = signalStore(
         );
         return { entities: res.resultList };
       },
-    }),
+    })),
   ),
   signalStoreFeature(
     withEntities({

--- a/apps/example-app/src/app/examples/signals/product-shop-page/products-shop.store.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/products-shop.store.ts
@@ -118,26 +118,24 @@ export const ProductsShopStore = signalStore(
   { providedIn: 'root' },
   productsStoreFeature,
   orderItemsStoreFeature,
-  withEntitiesLoadingCall({
-    collection: productsCollection,
-    fetchEntities: async ({
-      productsPagedRequest,
-      productsFilter,
-      productsSort,
-    }) => {
-      const res = await lastValueFrom(
-        inject(ProductService).getProducts({
-          search: productsFilter().search,
-          skip: productsPagedRequest().startIndex,
-          take: productsPagedRequest().size,
-          sortAscending: productsSort().direction === 'asc',
-          sortColumn: productsSort().field,
-        }),
-      );
-      return { entities: res.resultList, total: res.total };
-    },
-    mapError: (error) => (error as Error).message,
-  }),
+  withEntitiesLoadingCall(
+    ({ productsPagedRequest, productsFilter, productsSort }) => ({
+      collection: productsCollection,
+      fetchEntities: async () => {
+        const res = await lastValueFrom(
+          inject(ProductService).getProducts({
+            search: productsFilter().search,
+            skip: productsPagedRequest().startIndex,
+            take: productsPagedRequest().size,
+            sortAscending: productsSort().direction === 'asc',
+            sortColumn: productsSort().field,
+          }),
+        );
+        return { entities: res.resultList, total: res.total };
+      },
+      mapError: (error) => (error as Error).message,
+    }),
+  ),
   withCalls(({ orderItemsEntities }, snackBar = inject(MatSnackBar)) => ({
     loadProductDetail: ({ id }: { id: string }) =>
       inject(ProductService).getProductDetail(id),

--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -339,7 +339,7 @@ if an error occurs it will set the error to the store using set[Collection]Error
 
 | Param | Description |
 | --- | --- |
-| config | <p>Configuration object</p> |
+| config | <p>Configuration object or factory function that returns the configuration object</p> |
 | config.fetchEntities | <p>A function that fetches the entities from a remote source the return type</p> |
 | config.collection | <p>The collection name</p> |
 | config.onSuccess | <p>A function that is called when the fetchEntities is successful</p> |

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.spec.ts
@@ -14,270 +14,539 @@ import { Product } from '../test.model';
 describe('withEntitiesLoadingCall', () => {
   const entity = type<Product>();
   const collection = 'products';
+  describe('using config as object', () => {
+    describe('without collection setLoading should call fetch entities', () => {
+      it('should setAllEntities if fetchEntities returns an Entity[] ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall({
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of(result);
+              },
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts);
+        });
+      }));
 
-  describe('without collection setLoading should call fetch entities', () => {
-    it('should setAllEntities if fetchEntities returns an Entity[] ', fakeAsync(() => {
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-          }),
-          withCallStatus(),
-          withEntitiesLoadingCall({
-            fetchEntities: () => {
-              let result = [...mockProducts];
-              return of(result);
-            },
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.entities()).toEqual([]);
-        store.setLoading();
-        tick();
-        expect(store.entities()).toEqual(mockProducts);
-      });
-    }));
+      it('should setAllEntities if fetchEntities returns an a {entities: Entity[]} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall({
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of({ entities: result });
+              },
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts);
+        });
+      }));
 
-    it('should setAllEntities if fetchEntities returns an a {entities: Entity[]} ', fakeAsync(() => {
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-          }),
-          withCallStatus(),
-          withEntitiesLoadingCall({
-            fetchEntities: () => {
-              let result = [...mockProducts];
-              return of({ entities: result });
-            },
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.entities()).toEqual([]);
-        store.setLoading();
-        tick();
-        expect(store.entities()).toEqual(mockProducts);
-      });
-    }));
+      it('should setEntitiesPagedResult if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesRemotePagination({
+              entity,
+              pageSize: 10,
+            }),
+            withEntitiesLoadingCall({
+              fetchEntities: ({ entitiesPagedRequest }) => {
+                let result = [...mockProducts];
+                const total = result.length;
+                const options = {
+                  skip: entitiesPagedRequest()?.startIndex,
+                  take: entitiesPagedRequest()?.size,
+                };
+                if (options?.skip || options?.take) {
+                  const skip = +(options?.skip ?? 0);
+                  const take = +(options?.take ?? 0);
+                  result = result.slice(skip, skip + take);
+                }
+                return of({ entities: result, total });
+              },
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts.slice(0, 30));
+        });
+      }));
 
-    it('should setEntitiesPagedResult if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-          }),
-          withCallStatus(),
-          withEntitiesRemotePagination({
-            entity,
-            pageSize: 10,
-          }),
-          withEntitiesLoadingCall({
-            fetchEntities: ({ entitiesPagedRequest }) => {
-              let result = [...mockProducts];
-              const total = result.length;
-              const options = {
-                skip: entitiesPagedRequest()?.startIndex,
-                take: entitiesPagedRequest()?.size,
-              };
-              if (options?.skip || options?.take) {
-                const skip = +(options?.skip ?? 0);
-                const take = +(options?.take ?? 0);
-                result = result.slice(skip, skip + take);
-              }
-              return of({ entities: result, total });
-            },
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.entities()).toEqual([]);
-        store.setLoading();
-        tick();
-        expect(store.entities()).toEqual(mockProducts.slice(0, 30));
-      });
-    }));
+      it('should call setLoaded and onSuccess if fetchEntities call is successful', fakeAsync(() => {
+        const onSuccess = jest.fn();
+        const onError = jest.fn();
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall({
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of(result);
+              },
+              onSuccess,
+              onError,
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts);
+          expect(store.isLoaded()).toBeTruthy();
+          expect(onSuccess).toHaveBeenCalledWith(mockProducts);
+          expect(onError).not.toHaveBeenCalled();
+        });
+      }));
 
-    it('should call setLoaded and onSuccess if fetchEntities call is successful', fakeAsync(() => {
-      const onSuccess = jest.fn();
-      const onError = jest.fn();
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-          }),
-          withCallStatus(),
-          withEntitiesLoadingCall({
-            fetchEntities: () => {
-              let result = [...mockProducts];
-              return of(result);
-            },
-            onSuccess,
-            onError,
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.entities()).toEqual([]);
-        store.setLoading();
-        tick();
-        expect(store.entities()).toEqual(mockProducts);
-        expect(store.isLoaded()).toBeTruthy();
-        expect(onSuccess).toHaveBeenCalledWith(mockProducts);
-        expect(onError).not.toHaveBeenCalled();
-      });
-    }));
+      it('should call setError and onError if fetchEntities call fails ', fakeAsync(() => {
+        const onSuccess = jest.fn();
+        const onError = jest.fn();
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall({
+              fetchEntities: () => {
+                return throwError(() => new Error('fail'));
+              },
+              onSuccess,
+              onError,
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual([]);
+          expect(store.error()).toEqual(new Error('fail'));
+          expect(onError).toHaveBeenCalledWith(new Error('fail'));
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+      }));
 
-    it('should call setError and onError if fetchEntities call fails ', fakeAsync(() => {
-      const onSuccess = jest.fn();
-      const onError = jest.fn();
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-          }),
-          withCallStatus(),
-          withEntitiesLoadingCall({
-            fetchEntities: () => {
-              return throwError(() => new Error('fail'));
-            },
-            onSuccess,
-            onError,
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.entities()).toEqual([]);
-        store.setLoading();
-        tick();
-        expect(store.entities()).toEqual([]);
-        expect(store.error()).toEqual(new Error('fail'));
-        expect(onError).toHaveBeenCalledWith(new Error('fail'));
-        expect(onSuccess).not.toHaveBeenCalled();
-      });
-    }));
+      it('should call setError and onError if fetchEntities call fails with correct type if mapError is used', fakeAsync(() => {
+        const onSuccess = jest.fn();
+        const onError = jest.fn();
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus({ errorType: type<string>() }),
+            withEntitiesLoadingCall({
+              fetchEntities: () => {
+                return throwError(() => new Error('fail'));
+              },
+              onSuccess,
+              mapError: (error) => (error as Error).message,
+              onError,
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual([]);
+          expect(store.error()).toEqual('fail');
+          expect(onError).toHaveBeenCalledWith('fail');
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+      }));
+    });
 
-    it('should call setError and onError if fetchEntities call fails with correct type if mapError is used', fakeAsync(() => {
-      const onSuccess = jest.fn();
-      const onError = jest.fn();
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-          }),
-          withCallStatus({ errorType: type<string>() }),
-          withEntitiesLoadingCall({
-            fetchEntities: () => {
-              return throwError(() => new Error('fail'));
-            },
-            onSuccess,
-            mapError: (error) => (error as Error).message,
-            onError,
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.entities()).toEqual([]);
-        store.setLoading();
-        tick();
-        expect(store.entities()).toEqual([]);
-        expect(store.error()).toEqual('fail');
-        expect(onError).toHaveBeenCalledWith('fail');
-        expect(onSuccess).not.toHaveBeenCalled();
-      });
-    }));
+    describe('with collection set[Collection]Loading should call fetch entities', () => {
+      it('should setAllEntities if fetchEntities returns an Entity[] ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+              collection,
+            }),
+            withCallStatus({ collection }),
+            withEntitiesLoadingCall({
+              collection,
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of(result);
+              },
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.productsEntities()).toEqual([]);
+          store.setProductsLoading();
+          tick();
+          expect(store.productsEntities()).toEqual(mockProducts);
+        });
+      }));
+
+      it('should setAllEntities if fetchEntities returns an a {entities: Entity[]} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+              collection,
+            }),
+            withCallStatus({ collection }),
+            withEntitiesLoadingCall({
+              collection,
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of({ entities: result });
+              },
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.productsEntities()).toEqual([]);
+          store.setProductsLoading();
+          tick();
+          expect(store.productsEntities()).toEqual(mockProducts);
+        });
+      }));
+
+      it('should set[Collection]Result if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+              collection,
+            }),
+            withCallStatus({ collection }),
+            withEntitiesRemotePagination({
+              entity,
+              collection,
+              pageSize: 10,
+            }),
+            withEntitiesLoadingCall({
+              collection,
+              fetchEntities: ({ productsPagedRequest }) => {
+                let result = [...mockProducts];
+                const total = result.length;
+                const options = {
+                  skip: productsPagedRequest()?.startIndex,
+                  take: productsPagedRequest()?.size,
+                };
+                if (options?.skip || options?.take) {
+                  const skip = +(options?.skip ?? 0);
+                  const take = +(options?.take ?? 0);
+                  result = result.slice(skip, skip + take);
+                }
+                return of({ entities: result, total });
+              },
+            }),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.productsEntities()).toEqual([]);
+          store.setProductsLoading();
+          tick();
+          expect(store.productsEntities()).toEqual(mockProducts.slice(0, 30));
+        });
+      }));
+    });
   });
 
-  describe('with collection set[Collection]Loading should call fetch entities', () => {
-    it('should setAllEntities if fetchEntities returns an Entity[] ', fakeAsync(() => {
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-            collection,
-          }),
-          withCallStatus({ collection }),
-          withEntitiesLoadingCall({
-            collection,
-            fetchEntities: () => {
-              let result = [...mockProducts];
-              return of(result);
-            },
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.productsEntities()).toEqual([]);
-        store.setProductsLoading();
-        tick();
-        expect(store.productsEntities()).toEqual(mockProducts);
-      });
-    }));
+  describe('using config as factory', () => {
+    describe('without collection setLoading should call fetch entities', () => {
+      it('should setAllEntities if fetchEntities returns an Entity[] ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall(() => ({
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of(result);
+              },
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts);
+        });
+      }));
 
-    it('should setAllEntities if fetchEntities returns an a {entities: Entity[]} ', fakeAsync(() => {
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-            collection,
-          }),
-          withCallStatus({ collection }),
-          withEntitiesLoadingCall({
-            collection,
-            fetchEntities: () => {
-              let result = [...mockProducts];
-              return of({ entities: result });
-            },
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.productsEntities()).toEqual([]);
-        store.setProductsLoading();
-        tick();
-        expect(store.productsEntities()).toEqual(mockProducts);
-      });
-    }));
+      it('should setAllEntities if fetchEntities returns an a {entities: Entity[]} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall(() => ({
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of({ entities: result });
+              },
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts);
+        });
+      }));
 
-    it('should set[Collection]Result if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
-      TestBed.runInInjectionContext(() => {
-        const Store = signalStore(
-          withEntities({
-            entity,
-            collection,
-          }),
-          withCallStatus({ collection }),
-          withEntitiesRemotePagination({
-            entity,
-            collection,
-            pageSize: 10,
-          }),
-          withEntitiesLoadingCall({
-            collection,
-            fetchEntities: ({ productsPagedRequest }) => {
-              let result = [...mockProducts];
-              const total = result.length;
-              const options = {
-                skip: productsPagedRequest()?.startIndex,
-                take: productsPagedRequest()?.size,
-              };
-              if (options?.skip || options?.take) {
-                const skip = +(options?.skip ?? 0);
-                const take = +(options?.take ?? 0);
-                result = result.slice(skip, skip + take);
-              }
-              return of({ entities: result, total });
-            },
-          }),
-        );
-        const store = new Store();
-        TestBed.flushEffects();
-        expect(store.productsEntities()).toEqual([]);
-        store.setProductsLoading();
-        tick();
-        expect(store.productsEntities()).toEqual(mockProducts.slice(0, 30));
-      });
-    }));
+      it('should setEntitiesPagedResult if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesRemotePagination({
+              entity,
+              pageSize: 10,
+            }),
+            withEntitiesLoadingCall(({ entitiesPagedRequest }) => ({
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                const total = result.length;
+                const options = {
+                  skip: entitiesPagedRequest()?.startIndex,
+                  take: entitiesPagedRequest()?.size,
+                };
+                if (options?.skip || options?.take) {
+                  const skip = +(options?.skip ?? 0);
+                  const take = +(options?.take ?? 0);
+                  result = result.slice(skip, skip + take);
+                }
+                return of({ entities: result, total });
+              },
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts.slice(0, 30));
+        });
+      }));
+
+      it('should call setLoaded and onSuccess if fetchEntities call is successful', fakeAsync(() => {
+        const onSuccess = jest.fn();
+        const onError = jest.fn();
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall(() => ({
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of(result);
+              },
+              onSuccess,
+              onError,
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual(mockProducts);
+          expect(store.isLoaded()).toBeTruthy();
+          expect(onSuccess).toHaveBeenCalledWith(mockProducts);
+          expect(onError).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should call setError and onError if fetchEntities call fails ', fakeAsync(() => {
+        const onSuccess = jest.fn();
+        const onError = jest.fn();
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus(),
+            withEntitiesLoadingCall(() => ({
+              fetchEntities: () => {
+                return throwError(() => new Error('fail'));
+              },
+              onSuccess,
+              onError,
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual([]);
+          expect(store.error()).toEqual(new Error('fail'));
+          expect(onError).toHaveBeenCalledWith(new Error('fail'));
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should call setError and onError if fetchEntities call fails with correct type if mapError is used', fakeAsync(() => {
+        const onSuccess = jest.fn();
+        const onError = jest.fn();
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+            }),
+            withCallStatus({ errorType: type<string>() }),
+            withEntitiesLoadingCall(() => ({
+              fetchEntities: () => {
+                return throwError(() => new Error('fail'));
+              },
+              onSuccess,
+              mapError: (error) => (error as Error).message,
+              onError,
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.entities()).toEqual([]);
+          store.setLoading();
+          tick();
+          expect(store.entities()).toEqual([]);
+          expect(store.error()).toEqual('fail');
+          expect(onError).toHaveBeenCalledWith('fail');
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+      }));
+    });
+
+    describe('with collection set[Collection]Loading should call fetch entities', () => {
+      it('should setAllEntities if fetchEntities returns an Entity[] ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+              collection,
+            }),
+            withCallStatus({ collection }),
+            withEntitiesLoadingCall(() => ({
+              collection,
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of(result);
+              },
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.productsEntities()).toEqual([]);
+          store.setProductsLoading();
+          tick();
+          expect(store.productsEntities()).toEqual(mockProducts);
+        });
+      }));
+
+      it('should setAllEntities if fetchEntities returns an a {entities: Entity[]} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+              collection,
+            }),
+            withCallStatus({ collection }),
+            withEntitiesLoadingCall(() => ({
+              collection,
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                return of({ entities: result });
+              },
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.productsEntities()).toEqual([]);
+          store.setProductsLoading();
+          tick();
+          expect(store.productsEntities()).toEqual(mockProducts);
+        });
+      }));
+
+      it('should set[Collection]Result if fetchEntities returns an a {entities: Entity[], total: number} ', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const Store = signalStore(
+            withEntities({
+              entity,
+              collection,
+            }),
+            withCallStatus({ collection }),
+            withEntitiesRemotePagination({
+              entity,
+              collection,
+              pageSize: 10,
+            }),
+            withEntitiesLoadingCall(({ productsPagedRequest }) => ({
+              collection,
+              fetchEntities: () => {
+                let result = [...mockProducts];
+                const total = result.length;
+                const options = {
+                  skip: productsPagedRequest()?.startIndex,
+                  take: productsPagedRequest()?.size,
+                };
+                if (options?.skip || options?.take) {
+                  const skip = +(options?.skip ?? 0);
+                  const take = +(options?.take ?? 0);
+                  result = result.slice(skip, skip + take);
+                }
+                return of({ entities: result, total });
+              },
+            })),
+          );
+          const store = new Store();
+          TestBed.flushEffects();
+          expect(store.productsEntities()).toEqual([]);
+          store.setProductsLoading();
+          tick();
+          expect(store.productsEntities()).toEqual(mockProducts.slice(0, 30));
+        });
+      }));
+    });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
@@ -65,7 +65,7 @@ import { getWithEntitiesRemotePaginationKeys } from '../with-entities-pagination
  *
  * Requires withEntities and withCallStatus to be present in the store.
  *
- * @param config - Configuration object
+ * @param config - Configuration object or factory function that returns the configuration object
  * @param config.fetchEntities - A function that fetches the entities from a remote source the return type
  * @param config.collection - The collection name
  * @param config.onSuccess - A function that is called when the fetchEntities is successful
@@ -170,7 +170,7 @@ export function withEntitiesLoadingCall<
  *
  * Requires withEntities and withCallStatus to be present in the store.
  *
- * @param config - Configuration object
+ * @param config - Configuration object or factory function that returns the configuration object
  * @param config.fetchEntities - A function that fetches the entities from a remote source the return type
  * @param config.collection - The collection name
  * @param config.onSuccess - A function that is called when the fetchEntities is successful
@@ -279,105 +279,273 @@ export function withEntitiesLoadingCall<
   EmptyFeatureResult
 >;
 
+/**
+ * Generates a onInit hook that fetches entities from a remote source
+ * when the [collection]Loading is true, by calling the fetchEntities function
+ * and if successful, it will call set[Collection]Loaded and also set the entities
+ * to the store using the setAllEntities method or the setEntitiesPagedResult method
+ * if it exists (comes from withEntitiesRemotePagination),
+ * if an error occurs it will set the error to the store using set[Collection]Error with the error.
+ *
+ * Requires withEntities and withCallStatus to be present in the store.
+ *
+ * @param config - Configuration object or factory function that returns the configuration object
+ * @param config.fetchEntities - A function that fetches the entities from a remote source the return type
+ * @param config.collection - The collection name
+ * @param config.onSuccess - A function that is called when the fetchEntities is successful
+ * @param config.mapError - A function to transform the error before setting it to the store, requires withCallStatus errorType to be set
+ * @param config.onError - A function that is called when the fetchEntities fails
+ * can be an array of entities or an object with entities and total
+ *
+ * @example
+ * export const ProductsRemoteStore = signalStore(
+ *   { providedIn: 'root' },
+ *   // requires at least withEntities and withCallStatus
+ *   withEntities({ entity, collection }),
+ *   withCallStatus({ prop: collection, initialValue: 'loading' }),
+ *   // other features
+ *   withEntitiesRemoteFilter({
+ *     entity,
+ *     collection,
+ *     defaultFilter: { name: '' },
+ *   }),
+ *   withEntitiesRemotePagination({
+ *     entity,
+ *     collection,
+ *     pageSize: 5,
+ *     pagesToCache: 2,
+ *   }),
+ *   withEntitiesRemoteSort({
+ *     entity,
+ *     collection,
+ *     defaultSort: { field: 'name', direction: 'asc' },
+ *   }),
+ *   // now we add the withEntitiesLoadingCall, in this case any time the filter,
+ *   // pagination or sort changes they call set[Collection]Loading() which then
+ *   // triggers the onInit effect that checks if [collection]Loading(), if true
+ *   // then calls fetchEntities function
+ *   withEntitiesLoadingCall({
+ *     collection,
+ *     fetchEntities: ({ productsFilter, productsPagedRequest, productsSort }) => {
+ *       return inject(ProductService)
+ *         .getProducts({
+ *           search: productsFilter().name,
+ *           take: productsPagedRequest().size,
+ *           skip: productsPagedRequest().startIndex,
+ *           sortColumn: productsSort().field,
+ *           sortAscending: productsSort().direction === 'asc',
+ *         })
+ *         .pipe(
+ *           map((d) => ({
+ *             entities: d.resultList,
+ *             total: d.total,
+ *           })),
+ *         );
+ *     },
+ *   }),
+ */
+export function withEntitiesLoadingCall<
+  Input extends SignalStoreFeatureResult,
+  Entity extends { id: string | number },
+  const Collection extends string = '',
+  Error = unknown,
+>(
+  config: (
+    store: Prettify<
+      SignalStoreSlices<Input['state']> &
+        Input['signals'] &
+        Input['methods'] &
+        StateSignal<Prettify<Input['state']>>
+    >,
+  ) => {
+    collection?: Collection;
+    fetchEntities: () =>
+      | Observable<
+          Collection extends ''
+            ? Input['methods'] extends SetEntitiesResult<infer ResultParam>
+              ? ResultParam
+              : Entity[] | { entities: Entity[] }
+            : Input['methods'] extends NamedSetEntitiesResult<
+                  Collection,
+                  infer ResultParam
+                >
+              ? ResultParam
+              : Entity[] | { entities: Entity[] }
+        >
+      | Promise<
+          Collection extends ''
+            ? Input['methods'] extends SetEntitiesResult<infer ResultParam>
+              ? ResultParam
+              : Entity[] | { entities: Entity[] }
+            : Input['methods'] extends NamedSetEntitiesResult<
+                  Collection,
+                  infer ResultParam
+                >
+              ? ResultParam
+              : Entity[] | { entities: Entity[] }
+        >;
+    mapPipe?: 'switchMap' | 'concatMap' | 'exhaustMap';
+    onSuccess?: (
+      result: Input['methods'] extends NamedSetEntitiesResult<
+        Collection,
+        infer ResultParam
+      >
+        ? ResultParam
+        : Entity[] | { entities: Entity[] },
+    ) => void;
+    mapError?: (error: unknown) => Error;
+    onError?: (error: Error) => void;
+  },
+): SignalStoreFeature<
+  Input &
+    (Collection extends ''
+      ? {
+          state: EntityState<Entity> & CallStatusState;
+          signals: EntitySignals<Entity> & CallStatusComputed<Error>;
+          methods: CallStatusMethods<Error>;
+        }
+      : {
+          state: NamedEntityState<Entity, Collection> &
+            NamedCallStatusState<Collection>;
+          signals: NamedEntitySignals<Entity, Collection> &
+            NamedCallStatusComputed<Collection, Error>;
+          methods: NamedCallStatusMethods<Collection, Error>;
+        }),
+  EmptyFeatureResult
+>;
+
 export function withEntitiesLoadingCall<
   Input extends SignalStoreFeatureResult,
   Entity extends { id: string | number },
   Collection extends string,
   Error = unknown,
->({
-  collection,
-  fetchEntities,
-  ...config
-}: {
-  collection?: Collection;
-  fetchEntities: (
-    store: SignalStoreSlices<Input['state']> &
-      Input['signals'] &
-      Input['methods'] &
-      StateSignal<Prettify<Input['state']>>,
-  ) => Observable<any> | Promise<any>;
-  mapPipe?: 'switchMap' | 'concatMap' | 'exhaustMap';
-  onSuccess?: (result: any) => void;
-  mapError?: (error: unknown) => Error;
-  onError?: (error: Error) => void;
-}): SignalStoreFeature<Input, EmptyFeatureResult> {
-  const { loadingKey, setErrorKey, setLoadedKey } = getWithCallStatusKeys({
-    prop: collection,
-  });
-  const { setEntitiesPagedResultKey } = getWithEntitiesRemotePaginationKeys({
-    collection,
-  });
-
-  return signalStoreFeature(
-    withHooks(
-      (
-        store: Record<string, Signal<unknown>>,
-        environmentInjector = inject(EnvironmentInjector),
+>(
+  configFactory:
+    | {
+        collection?: Collection;
+        fetchEntities: (
+          store: SignalStoreSlices<Input['state']> &
+            Input['signals'] &
+            Input['methods'] &
+            StateSignal<Prettify<Input['state']>>,
+        ) => Observable<any> | Promise<any>;
+        mapPipe?: 'switchMap' | 'concatMap' | 'exhaustMap';
+        onSuccess?: (result: any) => void;
+        mapError?: (error: unknown) => Error;
+        onError?: (error: Error) => void;
+      }
+    | ((
+        store: Prettify<
+          SignalStoreSlices<Input['state']> &
+            Input['signals'] &
+            Input['methods'] &
+            StateSignal<Prettify<Input['state']>>
+        >,
       ) => {
-        const loading = store[loadingKey] as Signal<boolean>;
-        const setLoaded = store[setLoadedKey] as () => void;
-        const setError = store[setErrorKey] as (error: unknown) => void;
-        const setEntitiesPagedResult = store[
-          setEntitiesPagedResultKey
-        ] as (result: { entities: Entity[] }) => void;
-        return {
-          onInit: () => {
-            const loading$ = toObservable(loading);
-            const mapPipe = config.mapPipe
-              ? mapPipes[config.mapPipe]
-              : switchMap;
+        collection?: Collection;
+        fetchEntities: () => Observable<any> | Promise<any>;
+        mapPipe?: 'switchMap' | 'concatMap' | 'exhaustMap';
+        onSuccess?: (result: any) => void;
+        mapError?: (error: unknown) => Error;
+        onError?: (error: Error) => void;
+      }),
+): SignalStoreFeature<Input, EmptyFeatureResult> {
+  return (store) => {
+    const { slices, methods, signals, hooks, ...rest } = store;
+    const {
+      collection,
+      fetchEntities,
+      onSuccess,
+      onError,
+      mapError,
+      mapPipe: mapPipeType,
+    } = typeof configFactory === 'function'
+      ? configFactory({
+          ...slices,
+          ...signals,
+          ...methods,
+          ...rest,
+        } as Prettify<
+          SignalStoreSlices<Input['state']> &
+            Input['signals'] &
+            Input['methods'] &
+            StateSignal<Prettify<Input['state']>>
+        >)
+      : configFactory;
+    const { loadingKey, setErrorKey, setLoadedKey } = getWithCallStatusKeys({
+      prop: collection,
+    });
+    const { setEntitiesPagedResultKey } = getWithEntitiesRemotePaginationKeys({
+      collection,
+    });
 
-            loading$
-              .pipe(
-                filter(Boolean),
-                mapPipe(() =>
-                  runInInjectionContext(environmentInjector, () =>
-                    from(
-                      fetchEntities(
-                        store as SignalStoreSlices<Input['state']> &
-                          Input['signals'] &
-                          Input['methods'] &
-                          StateSignal<Prettify<Input['state']>>,
+    return signalStoreFeature(
+      withHooks(
+        (
+          store: Record<string, Signal<unknown>>,
+          environmentInjector = inject(EnvironmentInjector),
+        ) => {
+          const loading = store[loadingKey] as Signal<boolean>;
+          const setLoaded = store[setLoadedKey] as () => void;
+          const setError = store[setErrorKey] as (error: unknown) => void;
+          const setEntitiesPagedResult = store[
+            setEntitiesPagedResultKey
+          ] as (result: { entities: Entity[] }) => void;
+          return {
+            onInit: () => {
+              const loading$ = toObservable(loading);
+              const mapPipe = mapPipeType ? mapPipes[mapPipeType] : switchMap;
+
+              loading$
+                .pipe(
+                  filter(Boolean),
+                  mapPipe(() =>
+                    runInInjectionContext(environmentInjector, () =>
+                      from(
+                        fetchEntities(
+                          store as SignalStoreSlices<Input['state']> &
+                            Input['signals'] &
+                            Input['methods'] &
+                            StateSignal<Prettify<Input['state']>>,
+                        ),
                       ),
+                    ).pipe(
+                      map((result) => {
+                        if (setEntitiesPagedResult)
+                          setEntitiesPagedResult(result);
+                        else {
+                          const entities = Array.isArray(result)
+                            ? result
+                            : result.entities;
+                          patchState(
+                            store as StateSignal<object>,
+                            collection
+                              ? setAllEntities(entities as Entity[], {
+                                  collection,
+                                })
+                              : setAllEntities(entities),
+                          );
+                        }
+                        setLoaded();
+                        if (onSuccess) onSuccess(result);
+                      }),
+                      first(),
+                      catchError((error: unknown) => {
+                        const e = mapError ? mapError(error) : error;
+                        setError(e);
+                        if (onError) onError(e as Error);
+                        return of();
+                      }),
                     ),
-                  ).pipe(
-                    map((result) => {
-                      if (setEntitiesPagedResult)
-                        setEntitiesPagedResult(result);
-                      else {
-                        const entities = Array.isArray(result)
-                          ? result
-                          : result.entities;
-                        patchState(
-                          store as StateSignal<object>,
-                          collection
-                            ? setAllEntities(entities as Entity[], {
-                                collection,
-                              })
-                            : setAllEntities(entities),
-                        );
-                      }
-                      setLoaded();
-                      if (config.onSuccess) config.onSuccess(result);
-                    }),
-                    first(),
-                    catchError((error: unknown) => {
-                      const e = config.mapError
-                        ? config.mapError(error)
-                        : error;
-                      setError(e);
-                      if (config.onError) config.onError(e as Error);
-                      return of();
-                    }),
                   ),
-                ),
-              )
-              .subscribe();
-          },
-        };
-      },
-    ),
-  );
+                )
+                .subscribe();
+            },
+          };
+        },
+      ),
+    )(store);
+  };
 }
 const mapPipes = {
   switchMap: switchMap,


### PR DESCRIPTION
  the factory function config will receive the store, and allow access to it in the fetchEntities,
    onSuccess and onErrors methods
    
    Fix #95
