### PR TITLE
Feat/clean on filter and bug fix

### DIFF
--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -645,6 +645,8 @@ correctly in using remote pagination, because they cant select all the data.</p>
 | config |  |
 | config.entity | <p>the entity type</p> |
 | config.collection | <p>the collection name</p> |
+| config.clearOnFilter | <p>Clear the selected entity when the filter changes (default: true)</p> |
+| config.clearOnRemoteSort | <p>Clear the selected entity when the remote sort changes (default: true)</p> |
 
 **Example**  
 ```js
@@ -680,6 +682,8 @@ store.toggleSelectAllProducts // () => void;
 | config |  |
 | config.collection | <p>The collection name</p> |
 | config.entity | <p>The entity type</p> |
+| config.clearOnFilter | <p>Clear the selected entity when the filter changes (default: true)</p> |
+| config.clearOnRemoteSort | <p>Clear the selected entity when the remote sort changes (default: true)</p> |
 
 **Example**  
 ```js

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.spec.ts
@@ -130,26 +130,27 @@ describe('withEntitiesRemotePagination', () => {
       expect(store.entitiesCurrentPage().hasNext).toEqual(true);
 
       store.loadEntitiesPage({ pageIndex: 1, pageSize: 15 });
+      tick();
       // check the second page
       expect(store.entitiesCurrentPage().entities.length).toEqual(15);
       expect(store.entitiesCurrentPage().entities).toEqual(
-        mockProducts.slice(15, 30),
+        mockProducts.slice(0, 15),
       );
-      expect(store.entitiesCurrentPage().pageIndex).toEqual(1);
+      expect(store.entitiesCurrentPage().pageIndex).toEqual(0);
       expect(store.entitiesCurrentPage().pageSize).toEqual(15);
       expect(store.entitiesCurrentPage().pagesCount).toEqual(3);
       expect(store.entitiesCurrentPage().total).toEqual(40);
-      expect(store.entitiesCurrentPage().hasPrevious).toEqual(true);
+      expect(store.entitiesCurrentPage().hasPrevious).toEqual(false);
       expect(store.entitiesCurrentPage().hasNext).toEqual(true);
 
       store.loadEntitiesPage({ pageIndex: 2 });
       tick();
       // check the third page
+      expect(store.entitiesCurrentPage().pageIndex).toEqual(2);
       expect(store.entitiesCurrentPage().entities.length).toEqual(10);
       expect(store.entitiesCurrentPage().entities).toEqual(
         mockProducts.slice(30, 40),
       );
-      expect(store.entitiesCurrentPage().pageIndex).toEqual(2);
       expect(store.entitiesCurrentPage().pageSize).toEqual(15);
       expect(store.entitiesCurrentPage().pagesCount).toEqual(3);
       expect(store.entitiesCurrentPage().total).toEqual(40);

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.ts
@@ -39,6 +39,8 @@ import { getEntitiesSingleSelectionKeys } from './with-entities-single-selection
  * @param config
  * @param config.collection - The collection name
  * @param config.entity - The entity type
+ * @param config.clearOnFilter - Clear the selected entity when the filter changes (default: true)
+ * @param config.clearOnRemoteSort - Clear the selected entity when the remote sort changes (default: true)
  *
  * @example
  * const entity = type<Product>();
@@ -69,6 +71,8 @@ export function withEntitiesSingleSelection<
   Entity extends { id: string | number },
 >(config?: {
   entity: Entity;
+  clearOnFilter?: boolean;
+  clearOnRemoteSort?: boolean;
 }): SignalStoreFeature<
   {
     state: EntityState<Entity>;
@@ -88,6 +92,8 @@ export function withEntitiesSingleSelection<
  * @param config
  * @param config.collection - The collection name
  * @param config.entity - The entity type
+ * @param config.clearOnFilter - Clear the selected entity when the filter changes (default: true)
+ * @param config.clearOnRemoteSort - Clear the selected entity when the remote sort changes (default: true)
  *
  * @example
  * const entity = type<Product>();
@@ -119,6 +125,8 @@ export function withEntitiesSingleSelection<
 >(config?: {
   entity: Entity;
   collection?: Collection;
+  clearOnFilter?: boolean;
+  clearOnRemoteSort?: boolean;
 }): SignalStoreFeature<
   // TODO: the problem seems be with the state pro, when set to empty
   //  it works but is it has a namedstate it doesnt
@@ -139,6 +147,8 @@ export function withEntitiesSingleSelection<
 >(config?: {
   entity: Entity;
   collection?: Collection;
+  clearOnFilter?: boolean;
+  clearOnRemoteSort?: boolean;
 }): SignalStoreFeature<any, any> {
   const { entityMapKey } = getWithEntitiesKeys(config);
   const {
@@ -190,12 +200,26 @@ export function withEntitiesSingleSelection<
       };
     }),
     withEventHandler((state) => {
-      return [
-        onEvent(entitiesFilterChanged, entitiesRemoteSortChanged, () => {
-          const deselectEntity = state[deselectEntityKey] as () => void;
-          deselectEntity();
-        }),
-      ];
+      const clearOnFilter = config?.clearOnFilter ?? true;
+      const clearOnRemoteSort = config?.clearOnRemoteSort ?? true;
+      const events = [];
+      if (clearOnFilter) {
+        events.push(
+          onEvent(entitiesFilterChanged, () => {
+            const deselectEntity = state[deselectEntityKey] as () => void;
+            deselectEntity();
+          }),
+        );
+      }
+      if (clearOnRemoteSort) {
+        events.push(
+          onEvent(entitiesRemoteSortChanged, () => {
+            const deselectEntity = state[deselectEntityKey] as () => void;
+            deselectEntity();
+          }),
+        );
+      }
+      return events;
     }),
   );
 }


### PR DESCRIPTION
-  Fix #98  change page size on withEntitiesRemotePagination corrupts data
- Fix #97 allow disabling clear selection on filter an sort