### PR TITLE
Don't unsubscribe from response observable after first response

### DIFF
--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -151,6 +151,7 @@ The original call can only have zero or one parameter, use an object with multip
 props as first param if you need more.</p>
 
 **Kind**: global function  
+**Warning**: The default mapPipe is [exhaustMap](https://www.learnrxjs.io/learn-rxjs/operators/transformation/exhaustmap). If your call returns an observable that does not complete after the first value is emitted, any changes to the input params will be ignored. Either specify [switchMap](https://www.learnrxjs.io/learn-rxjs/operators/transformation/switchmap) as mapPipe, or use [take(1)](https://www.learnrxjs.io/learn-rxjs/operators/filtering/take) or [first()](https://www.learnrxjs.io/learn-rxjs/operators/filtering/first) as part of your call.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -1,9 +1,15 @@
 import { Signal } from '@angular/core';
 import { Observable } from 'rxjs';
 
-export type Call<Param extends any = any, Result = any> =
-  | (() => Observable<Result> | Promise<Result>)
-  | ((arg: Param) => Observable<Result> | Promise<Result>);
+export type ObservableCall<Param = any, Result = any> =
+  | (() => Observable<Result>)
+  | ((arg: Param) => Observable<Result>);
+export type PromiseCall<Param = any, Result = any> =
+  | (() => Promise<Result>)
+  | ((arg: Param) => Promise<Result>);
+export type Call<Param = any, Result = any> =
+  | ObservableCall<Param, Result>
+  | PromiseCall<Param, Result>;
 export type CallConfig<
   Param = any,
   Result = any,


### PR DESCRIPTION
Removes the `first()` operator from the `withCalls` response pipe. Allowing observables that emit multiple values to be returned, with an initial loading state and then no further loading state until the params trigger a new request.

*Warning:* Potentially breaking change, as if the response does not complete, then the default `exhaustMap` operator will mean that subsequent triggers are ignored. The solution is to either use `switchMap` or ensure that you complete.

@gabrielguerrero Keen to discuss whether `exhaustMap` is still the best default operator. Or whether you want different behaviour depending on whether the call is promise-returning or observable-returning? One other idea is that we could add a check that if the call returns an observable and doesn't complete after the first value is output and the `mapPipe` has not been specified then have it throw some kind of error/warning.