### PR TITLE
fix(signals): fix withEntitiesSingleSelection deselect methods type

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
@@ -17,7 +17,7 @@ export type NamedEntitiesSingleSelectionComputed<
 };
 export type EntitiesSingleSelectionMethods = {
   selectEntity: (options: { id: string | number }) => void;
-  deselectEntity: (options: { id: string | number }) => void;
+  deselectEntity: () => void;
   toggleEntity: (options: { id: string | number }) => void;
 };
 export type NamedEntitiesSingleSelectionMethods<Collection extends string> = {
@@ -25,9 +25,7 @@ export type NamedEntitiesSingleSelectionMethods<Collection extends string> = {
     id: string | number;
   }) => void;
 } & {
-  [K in Collection as `deselect${Capitalize<string & K>}Entity`]: (options: {
-    id: string | number;
-  }) => void;
+  [K in Collection as `deselect${Capitalize<string & K>}Entity`]: () => void;
 } & {
   [K in Collection as `toggle${Capitalize<string & K>}Entity`]: (options: {
     id: string | number;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.spec.ts
@@ -24,7 +24,7 @@ describe('withEntitiesSingleSelection', () => {
       const store = new Store();
       patchState(store, setAllEntities(mockProducts));
       store.selectEntity({ id: mockProducts[4].id });
-      store.deselectEntity({ id: mockProducts[4].id });
+      store.deselectEntity();
       expect(store.entitySelected()).toEqual(undefined);
     });
 
@@ -55,7 +55,7 @@ describe('withEntitiesSingleSelection', () => {
       const store = new Store();
       patchState(store, setAllEntities(mockProducts, { collection }));
       store.selectProductsEntity({ id: mockProducts[4].id });
-      store.deselectProductsEntity({ id: mockProducts[4].id });
+      store.deselectProductsEntity();
       expect(store.productsEntitySelected()).toEqual(undefined);
     });
 


### PR DESCRIPTION
    
    fix for withEntitiesSingleSelection to remove params of deselectEntity and
    deselect[Collection]Entity
    
    fix #112
