### PR TITLE
Feat with sync to route query params

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci --legacy-peer-deps
-      - run: npm run build
+      - run: npm run build && npm run api-docs
       - run: npm run semantic-release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/example-app/src/app/app.module.ts
+++ b/apps/example-app/src/app/app.module.ts
@@ -1,4 +1,7 @@
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import {
   MAT_FORM_FIELD_DEFAULT_OPTIONS,
@@ -16,26 +19,32 @@ import { AppComponent } from './app.component';
 import { ExamplesModule } from './examples/examples.module';
 import './examples/services/mock-backend';
 
-@NgModule({ declarations: [AppComponent],
-    bootstrap: [AppComponent], imports: [BrowserModule,
-        BrowserAnimationsModule,
-        ExamplesModule,
-        StoreModule.forRoot({}),
-        StoreDevtoolsModule.instrument({
-            maxAge: 25, // Retains last 25 states
-            logOnly: environment.production, // Restrict extension to log-only mode
-            autoPause: true, // Pauses recording actions and state changes when the extension window is not open
-            connectInZone: true,
-        }),
-        EffectsModule.forRoot(),
-        RouterModule], providers: [
-        {
-            provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
-            useValue: {
-                appearance: 'outline',
-                subscriptSizing: 'dynamic',
-            } satisfies MatFormFieldDefaultOptions,
-        },
-        provideHttpClient(withInterceptorsFromDi()),
-    ] })
+@NgModule({
+  declarations: [AppComponent],
+  bootstrap: [AppComponent],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    ExamplesModule,
+    StoreModule.forRoot({}),
+    StoreDevtoolsModule.instrument({
+      maxAge: 25, // Retains last 25 states
+      logOnly: environment.production, // Restrict extension to log-only mode
+      autoPause: true, // Pauses recording actions and state changes when the extension window is not open
+      connectInZone: true,
+    }),
+    EffectsModule.forRoot(),
+    RouterModule,
+  ],
+  providers: [
+    {
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
+      useValue: {
+        appearance: 'outline',
+        subscriptSizing: 'dynamic',
+      } satisfies MatFormFieldDefaultOptions,
+    },
+    provideHttpClient(withInterceptorsFromDi()),
+  ],
+})
 export class AppModule {}

--- a/apps/example-app/src/app/examples/signals/product-list-paginated-page/product.store.ts
+++ b/apps/example-app/src/app/examples/signals/product-list-paginated-page/product.store.ts
@@ -1,4 +1,5 @@
 import { inject } from '@angular/core';
+import { Params } from '@angular/router';
 import {
   withCalls,
   withCallStatus,
@@ -7,6 +8,7 @@ import {
   withEntitiesLocalPagination,
   withEntitiesLocalSort,
   withEntitiesSingleSelection,
+  withEntitiesSyncToRouteQueryParams,
 } from '@ngrx-traits/signals';
 import { signalStore, type } from '@ngrx/signals';
 import { withEntities } from '@ngrx/signals/entities';
@@ -64,4 +66,12 @@ export const ProductsLocalStore = signalStore(
     },
     checkout: () => inject(OrderService).checkout(),
   })),
+  withEntitiesSyncToRouteQueryParams({
+    collection,
+    entity,
+    onQueryParamsLoaded: ({ productsEntitySelected, loadProductDetail }) => {
+      if (productsEntitySelected())
+        loadProductDetail(productsEntitySelected()!);
+    },
+  }),
 );

--- a/libs/ngrx-traits/signals/src/lib/index.ts
+++ b/libs/ngrx-traits/signals/src/lib/index.ts
@@ -22,3 +22,6 @@ export * from './with-logger/with-state-logger';
 export * from './with-calls/with-calls';
 export * from './with-calls/with-calls.model';
 export * from './with-sync-to-web-storage/with-sync-to-web-storage';
+export * from './with-sync-to-route-query-params/with-entities-sync-to-route-query-params';
+export * from './with-sync-to-route-query-params/with-sync-to-route-query-params';
+export * from './with-sync-to-route-query-params/with-sync-to-route-query-params.util';

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
@@ -287,7 +287,7 @@ export function withEntitiesLoadingCall<
 
 export function withEntitiesLoadingCall<
   Input extends SignalStoreFeatureResult,
-  Entity extends { id: string | number },
+  Entity,
   const Collection extends string = '',
   Error = unknown,
 >(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
@@ -1,12 +1,16 @@
-import { Signal } from '@angular/core';
-import { patchState } from '@ngrx/signals';
-import type { StateSignal } from '@ngrx/signals/src/state-signal';
+import { computed, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { EntitiesPaginationState } from '@ngrx-traits/common';
+import { concatMap, first } from 'rxjs';
 
 import { capitalize } from '../util';
+import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
 import {
   createEvent,
   props,
 } from '../with-event-handler/with-event-handler.util';
+import { QueryMapper } from '../with-sync-to-route-query-params/with-sync-to-route-query-params.util';
+import { EntitiesPaginationLocalMethods } from './with-entities-local-pagination.model';
 
 export function getWithEntitiesLocalPaginationKeys(config?: {
   collection?: string;
@@ -25,24 +29,6 @@ export function getWithEntitiesLocalPaginationKeys(config?: {
       : 'loadEntitiesPage',
   };
 }
-export function setCurrentPage(
-  state: Record<string, Signal<unknown>>,
-  paginationKey: string,
-  pageIndex: number,
-  pageSize?: number,
-) {
-  const pagination = state[paginationKey] as Signal<{
-    pageSize: number;
-    currentPage: number;
-  }>;
-  patchState(state as StateSignal<object>, {
-    [paginationKey]: {
-      ...pagination(),
-      currentPage: pageIndex,
-      pageSize: pageSize ?? pagination().pageSize,
-    },
-  });
-}
 
 export function getWithEntitiesLocalPaginationEvents(config?: {
   collection?: string;
@@ -53,5 +39,51 @@ export function getWithEntitiesLocalPaginationEvents(config?: {
       `${collection}.entitiesLocalPageChanged`,
       props<{ pageIndex: number }>(),
     ),
+  };
+}
+
+export function getQueryMapperForEntitiesPagination(config?: {
+  collection?: string;
+}): QueryMapper<{
+  page: string;
+}> {
+  const { loadEntitiesPageKey, paginationKey } =
+    getWithEntitiesLocalPaginationKeys(config);
+  const { loadingKey, loadedKey } = getWithCallStatusKeys({
+    prop: config?.collection,
+  });
+  return {
+    queryParamsToState: (query, store) => {
+      const page = query.page;
+
+      if (page) {
+        const loadEntitiesPage = store[
+          loadEntitiesPageKey
+        ] as EntitiesPaginationLocalMethods['loadEntitiesPage'];
+        const loading = store[loadingKey] as Signal<boolean>;
+        const loaded = store[loadedKey] as Signal<boolean>;
+        const loaded$ = toObservable(loaded);
+        // TODO: how do we support ssr hydration? maybe if is loaded set the page inmediatly
+        toObservable(loading)
+          .pipe(
+            first((v) => v),
+            concatMap(() => loaded$.pipe(first((v) => v))),
+            takeUntilDestroyed(),
+          )
+          .subscribe(() => {
+            loadEntitiesPage({
+              pageIndex: +page - 1,
+            });
+          });
+      }
+    },
+    stateToQueryParams: (store) => {
+      const pagination = store[paginationKey] as Signal<
+        EntitiesPaginationState['pagination']
+      >;
+      return computed(() => ({
+        page: (pagination().currentPage + 1).toString(),
+      }));
+    },
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
@@ -1,10 +1,10 @@
 import { Signal } from '@angular/core';
 
 export type EntitiesSingleSelectionState = {
-  idSelected?: string | number;
+  idSelected: string | number | undefined;
 };
 export type NamedEntitiesSingleSelectionState<Collection extends string> = {
-  [K in Collection as `${K}IdSelected`]?: string | number;
+  [K in Collection as `${K}IdSelected`]: string | number | undefined;
 };
 export type EntitiesSingleSelectionComputed<Entity> = {
   entitySelected: Signal<Entity | undefined>;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.ts
@@ -173,6 +173,7 @@ export function withEntitiesSingleSelection<
       };
     }),
     withMethods((state: Record<string, Signal<unknown>>) => {
+      const entityMap = state[entityMapKey] as Signal<EntityMap<Entity>>;
       const selectedId = state[selectedIdKey] as Signal<
         string | number | undefined
       >;
@@ -184,7 +185,7 @@ export function withEntitiesSingleSelection<
       return {
         [selectEntityKey]: ({ id }: { id: string | number }) => {
           patchState(state as StateSignal<object>, {
-            [selectedIdKey]: id,
+            [selectedIdKey]: entityMap()[id] ? id : undefined,
           });
         },
         [deselectEntityKey]: deselectEntity,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.util.ts
@@ -1,4 +1,14 @@
+import { computed, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { concatMap, first } from 'rxjs';
+
 import { capitalize } from '../util';
+import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
+import { QueryMapper } from '../with-sync-to-route-query-params/with-sync-to-route-query-params.util';
+import {
+  EntitiesSingleSelectionMethods,
+  EntitiesSingleSelectionState,
+} from './with-entities-single-selection.model';
 
 export function getEntitiesSingleSelectionKeys(config?: {
   collection?: string;
@@ -19,5 +29,53 @@ export function getEntitiesSingleSelectionKeys(config?: {
     toggleEntityKey: collection
       ? `toggle${capitalizedProp}Entity`
       : 'toggleEntity',
+  };
+}
+
+export function getQueryMapperForSingleSelection(config?: {
+  collection?: string;
+}): QueryMapper<{
+  selectedId: string | number | undefined;
+}> {
+  const { selectedIdKey, selectEntityKey } =
+    getEntitiesSingleSelectionKeys(config);
+  const { loadingKey, loadedKey } = getWithCallStatusKeys({
+    prop: config?.collection,
+  });
+  return {
+    queryParamsToState: (query, store) => {
+      const selectedId = query.selectedId;
+      if (selectedId) {
+        const selectEntity = store[
+          selectEntityKey
+        ] as EntitiesSingleSelectionMethods['selectEntity'];
+
+        const loading = store[loadingKey] as Signal<boolean>;
+        const loaded = store[loadedKey] as Signal<boolean>;
+        const loaded$ = toObservable(loaded);
+
+        toObservable(loading)
+          .pipe(
+            first((v) => v),
+            concatMap(() => loaded$.pipe(first((v) => v))),
+            takeUntilDestroyed(),
+          )
+          .subscribe(() => {
+            selectEntity({
+              id: selectedId,
+            });
+          });
+      }
+    },
+    stateToQueryParams: (store) => {
+      const selectedId = store[selectedIdKey] as Signal<
+        EntitiesSingleSelectionState['idSelected']
+      >;
+      return selectedId
+        ? computed(() => ({
+            selectedId: selectedId(),
+          }))
+        : undefined;
+    },
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
@@ -153,7 +153,7 @@ export function withEntitiesLocalSort<Entity, Collection extends string>({
         }: { sort?: Sort<Entity> } = {}) => {
           const sort = newSort ?? defaultSort;
           patchState(state as StateSignal<object>, {
-            [sortKey]: sort,
+            [sortKey]: newSort ?? (state[sortKey]() as Sort<Entity>),
             [idsKey]: sortData(state[entitiesKey]() as Entity[], sort).map(
               (entity) =>
                 config.selectId ? config.selectId(entity) : (entity as any).id,

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -1,0 +1,834 @@
+import { Type } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ActivatedRoute, Params, provideRouter, Router } from '@angular/router';
+import {
+  withCallStatus,
+  withEntitiesLoadingCall,
+  withEntitiesLocalFilter,
+  withEntitiesLocalPagination,
+  withEntitiesLocalSort,
+  withEntitiesRemoteFilter,
+  withEntitiesRemotePagination,
+  withEntitiesRemoteSort,
+  withEntitiesSingleSelection,
+  withEntitiesSyncToRouteQueryParams,
+} from '@ngrx-traits/signals';
+import { signalStore, signalStoreFeature, type } from '@ngrx/signals';
+import { withEntities } from '@ngrx/signals/entities';
+import { map, of, Subject } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
+import { mockProducts } from '../test.mocks';
+import { Product } from '../test.model';
+import { sortData } from '../with-entities-sort/with-entities-local-sort.util';
+
+describe('withEntitiesSyncToRouteQueryParams', () => {
+  const entity = type<Product>();
+  const collection = 'products';
+
+  const remoteStoreFeature = ({ load }: { load?: Subject<boolean> } = {}) => {
+    return signalStoreFeature(
+      signalStoreFeature(
+        withEntities({ entity }),
+        withCallStatus(),
+        withEntitiesRemotePagination({ entity, pageSize: 10 }),
+        withEntitiesRemoteSort({
+          entity,
+          defaultSort: { field: 'name', direction: 'asc' },
+        }),
+        withEntitiesRemoteFilter({
+          entity,
+          defaultFilter: { search: '', foo: 'bar' },
+        }),
+      ),
+      withEntitiesSingleSelection({ entity }),
+      withEntitiesLoadingCall({
+        fetchEntities: ({
+          entitiesFilter,
+          entitiesPagedRequest,
+          entitiesSort,
+        }) => {
+          let result = [...mockProducts.slice(0, 40)];
+          const total = result.length;
+          const options = {
+            skip: entitiesPagedRequest()?.startIndex,
+            take: entitiesPagedRequest()?.size,
+          };
+          if (entitiesFilter()?.search) {
+            result = mockProducts.filter((entity) =>
+              entitiesFilter()?.search
+                ? entity.name
+                    .toLowerCase()
+                    .includes(entitiesFilter()?.search.toLowerCase())
+                : false,
+            );
+          }
+          if (entitiesSort()?.field) {
+            result = sortData(result, {
+              field: entitiesSort()?.field as any,
+              direction: entitiesSort().direction,
+            });
+          }
+          if (options?.skip || options?.take) {
+            const skip = +(options?.skip ?? 0);
+            const take = +(options?.take ?? 0);
+            result = result.slice(skip, skip + take);
+          }
+          const response = { entities: result, total };
+          return load
+            ? load.pipe(
+                filter(Boolean),
+                map(() => response),
+              )
+            : of(response);
+        },
+      }),
+    );
+  };
+
+  const localStoreFeature = ({ load }: { load?: Subject<boolean> } = {}) => {
+    return signalStoreFeature(
+      signalStoreFeature(
+        withEntities({ entity }),
+        withCallStatus({ initialValue: 'loading' }),
+        withEntitiesLocalPagination({ entity, pageSize: 10 }),
+        withEntitiesLocalSort({
+          entity,
+          defaultSort: { field: 'name', direction: 'asc' },
+        }),
+        withEntitiesLocalFilter({
+          entity,
+          defaultFilter: { search: '', foo: 'bar' },
+          filterFn: (entity, filter) =>
+            !filter?.search ||
+            entity?.name.toLowerCase().includes(filter?.search.toLowerCase()),
+        }),
+      ),
+      withEntitiesSingleSelection({ entity }),
+      withEntitiesLoadingCall({
+        fetchEntities: ({}) => {
+          let result = [...mockProducts.slice(0, 40)];
+          const total = result.length;
+          const response = { entities: result, total };
+          return load
+            ? load.pipe(
+                filter(Boolean),
+                map(() => response),
+              )
+            : of(response);
+        },
+      }),
+    );
+  };
+
+  const localCollectionStoreFeature = ({
+    load,
+  }: { load?: Subject<boolean> } = {}) => {
+    return signalStoreFeature(
+      signalStoreFeature(
+        withEntities({ entity, collection }),
+        withCallStatus({ initialValue: 'loading', collection }),
+        withEntitiesLocalPagination({ entity, collection, pageSize: 10 }),
+        withEntitiesLocalSort({
+          entity,
+          collection,
+          defaultSort: { field: 'name', direction: 'asc' },
+        }),
+        withEntitiesLocalFilter({
+          entity,
+          collection,
+          defaultFilter: { search: '', foo: 'bar' },
+          filterFn: (entity, filter) =>
+            !filter?.search ||
+            entity?.name.toLowerCase().includes(filter?.search.toLowerCase()),
+        }),
+      ),
+      withEntitiesSingleSelection({ entity, collection }),
+      withEntitiesLoadingCall({
+        collection,
+        fetchEntities: ({}) => {
+          let result = [...mockProducts.slice(0, 40)];
+          const total = result.length;
+          const response = { entities: result, total };
+          return load
+            ? load.pipe(
+                filter(Boolean),
+                map(() => response),
+              )
+            : of(response);
+        },
+      }),
+    );
+  };
+
+  const localCollectionStoreFeature2 = ({
+    load,
+  }: { load?: Subject<boolean> } = {}) => {
+    const collection = 'orders';
+    return signalStoreFeature(
+      signalStoreFeature(
+        withEntities({ entity, collection }),
+        withCallStatus({ initialValue: 'loading', collection }),
+        withEntitiesLocalPagination({ entity, collection, pageSize: 10 }),
+        withEntitiesLocalSort({
+          entity,
+          collection,
+          defaultSort: { field: 'name', direction: 'asc' },
+        }),
+        withEntitiesLocalFilter({
+          entity,
+          collection,
+          defaultFilter: { search: '', foo: 'bar' },
+          filterFn: (entity, filter) =>
+            !filter?.search ||
+            entity?.name.toLowerCase().includes(filter?.search.toLowerCase()),
+        }),
+      ),
+      withEntitiesSingleSelection({ entity, collection }),
+      withEntitiesLoadingCall({
+        collection,
+        fetchEntities: ({}) => {
+          let result = [...mockProducts.slice(0, 40)];
+          const total = result.length;
+          const response = { entities: result, total };
+          return load
+            ? load.pipe(
+                filter(Boolean),
+                map(() => response),
+              )
+            : of(response);
+        },
+      }),
+    );
+  };
+
+  function init<S extends Type<any>>({
+    queryParams,
+    Store,
+  }: {
+    Store: S;
+    queryParams?: Record<string, any>;
+  }) {
+    TestBed.configureTestingModule({
+      providers: [
+        Store,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            queryParams: of(queryParams ?? {}),
+          }),
+        },
+      ],
+    });
+    const router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate');
+    return { store: TestBed.inject(Store) as InstanceType<S>, router };
+  }
+
+  describe('filter entities', () => {
+    it('filter url query params  should update store', () => {
+      const Store = signalStore(
+        localStoreFeature(),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { filter: JSON.stringify({ search: 'foo', foo: 'bar' }) },
+      });
+      expect(store.entitiesFilter()).toEqual({ search: 'foo', foo: 'bar' });
+    });
+
+    it('changes on entities filter should update url query params', fakeAsync(() => {
+      const Store = signalStore(
+        localStoreFeature(),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store, router } = init({
+        Store,
+        queryParams: { filter: JSON.stringify({ search: 'foo', foo: 'bar' }) },
+      });
+      store.filterEntities({
+        filter: { search: 'foo3', foo: 'bar4' },
+        forceLoad: true,
+      });
+      tick(400);
+      expect(router.navigate).toBeCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          filter: JSON.stringify({ search: 'foo3', foo: 'bar4' }),
+        }),
+        queryParamsHandling: 'merge',
+      });
+    }));
+
+    it('filter url query params  should update store, with custom filterMapper', () => {
+      const Store = signalStore(
+        localStoreFeature(),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          filterMapper: {
+            filterToQueryParams: (filter: { search: string; foo: string }) =>
+              filter,
+            queryParamsToFilter: (queryParams: Params) => ({
+              search: queryParams['search'] as string,
+              foo: queryParams['foo'] as string,
+            }),
+          },
+        }),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { search: 'foo', foo: 'bar' },
+      });
+      expect(store.entitiesFilter()).toEqual({ search: 'foo', foo: 'bar' });
+    });
+
+    it('changes on entities filter should update url query params, with custom filterMapper', fakeAsync(() => {
+      const Store = signalStore(
+        localStoreFeature(),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          filterMapper: {
+            filterToQueryParams: (filter: { search: string; foo: string }) =>
+              filter,
+            queryParamsToFilter: (queryParams: Params) => ({
+              search: queryParams['search'] as string,
+              foo: queryParams['foo'] as string,
+            }),
+          },
+        }),
+      );
+
+      const { store, router } = init({
+        Store,
+        queryParams: { filter: JSON.stringify({ search: 'foo', foo: 'bar' }) },
+      });
+      store.filterEntities({
+        filter: { search: 'foo3', foo: 'bar4' },
+        forceLoad: true,
+      });
+      tick(400);
+      expect(router.navigate).toBeCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          search: 'foo3',
+          foo: 'bar4',
+        }),
+        queryParamsHandling: 'merge',
+      });
+    }));
+  });
+
+  describe('sort entities', () => {
+    it('url query params sort should update store', () => {
+      const Store = signalStore(
+        localStoreFeature(),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { sortBy: 'description', sortDirection: 'desc' },
+      });
+      expect(store.entitiesSort()).toEqual({
+        field: 'description',
+        direction: 'desc',
+      });
+    });
+
+    it('changes on entities sort should update url query params', fakeAsync(() => {
+      const Store = signalStore(
+        localStoreFeature(),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store, router } = init({
+        Store,
+        queryParams: { sortBy: 'description', sortDirection: 'desc' },
+      });
+      store.sortEntities({
+        sort: { field: 'name', direction: 'asc' },
+      });
+      tick(400);
+      expect(router.navigate).toBeCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          sortBy: 'name',
+          sortDirection: 'asc',
+        }),
+        queryParamsHandling: 'merge',
+      });
+    }));
+  });
+
+  describe('entities single selection', () => {
+    it('url query params selectedId should update store', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        localStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { selectedId: '2' },
+      });
+      TestBed.flushEffects();
+      load.next(true);
+      tick(400);
+      expect(store.idSelected()).toEqual('2');
+    }));
+
+    it('url query params selectedId with invalid id should set the id as undefined in store', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        localStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { selectedId: '2ASDASD' },
+      });
+      TestBed.flushEffects();
+      load.next(true);
+      tick(400);
+      expect(store.idSelected()).toBeUndefined();
+    }));
+
+    it('changes on entities selectedId should update url query params', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        localStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store, router } = init({
+        Store,
+        queryParams: { selectedId: '2' },
+      });
+      TestBed.flushEffects();
+      load.next(true);
+      tick(400);
+      store.selectEntity({ id: '3' });
+      tick(400);
+      expect(router.navigate).toBeCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          selectedId: '3',
+        }),
+        queryParamsHandling: 'merge',
+      });
+    }));
+  });
+
+  describe('entities pagination', () => {
+    it('url query params page should update store', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        localStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { page: '2' },
+      });
+      TestBed.flushEffects();
+      load.next(true);
+      tick(400);
+      expect(store.entitiesPagination().currentPage).toEqual(1);
+    }));
+
+    it('url query params with invalid page not updated store', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        localStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { page: '9999' },
+      });
+      TestBed.flushEffects();
+      load.next(true);
+      tick(400);
+      expect(store.entitiesPagination().currentPage).toEqual(0);
+    }));
+
+    it('changes on entities page should update url query params', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        localStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams(),
+      );
+      const { store, router } = init({
+        Store,
+        queryParams: { page: '2' },
+      });
+      TestBed.flushEffects();
+      load.next(true);
+      tick(400);
+      store.loadEntitiesPage({ pageIndex: 2 });
+      tick(400);
+      expect(router.navigate).toBeCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          page: '3',
+        }),
+        queryParamsHandling: 'merge',
+      });
+    }));
+  });
+
+  it('multiple url and state changes should sync correctly', fakeAsync(() => {
+    // Arrange
+    const load = new Subject<boolean>();
+    const Store = signalStore(
+      localStoreFeature({ load }),
+      withEntitiesSyncToRouteQueryParams(),
+    );
+    const { store, router } = init({
+      Store,
+      queryParams: {
+        page: '2',
+        filter: JSON.stringify({ search: '', foo: 'bar' }),
+        sortBy: 'description',
+        sortDirection: 'desc',
+        selectedId: '2',
+      },
+    });
+    TestBed.flushEffects();
+    load.next(true);
+    tick(400);
+    // Act
+    store.filterEntities({
+      filter: { search: 'a', foo: 'bar2' },
+      forceLoad: true,
+    });
+    store.sortEntities({ sort: { field: 'name', direction: 'asc' } });
+    store.selectEntity({ id: '35' });
+    store.loadEntitiesPage({ pageIndex: 2 });
+    tick(10000);
+    // Assert
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: expect.objectContaining({
+        page: '3',
+        filter: JSON.stringify({ search: 'a', foo: 'bar2' }),
+        sortBy: 'name',
+        sortDirection: 'asc',
+        selectedId: '35',
+      }),
+      queryParamsHandling: 'merge',
+    });
+  }));
+
+  it('multiple url and state changes should sync correctly using remote store features', fakeAsync(() => {
+    // Arrange
+    const load = new Subject<boolean>();
+    const Store = signalStore(
+      remoteStoreFeature({ load }),
+      withEntitiesSyncToRouteQueryParams(),
+    );
+    const { store, router } = init({
+      Store,
+      queryParams: {
+        page: '2',
+        filter: JSON.stringify({ search: '', foo: 'bar' }),
+        sortBy: 'description',
+        sortDirection: 'desc',
+        selectedId: '2',
+      },
+    });
+    TestBed.flushEffects();
+    load.next(true);
+    tick(400);
+    expect(store.entitiesFilter()).toEqual({ search: '', foo: 'bar' });
+    expect(store.entitiesSort()).toEqual({
+      field: 'description',
+      direction: 'desc',
+    });
+    expect(store.idSelected()).toEqual('2');
+    expect(store.entitiesPagination().currentPage).toEqual(1);
+
+    // Act
+    store.filterEntities({
+      filter: { search: 'a', foo: 'bar2' },
+      forceLoad: true,
+    });
+    load.next(true);
+    tick(400);
+    store.sortEntities({ sort: { field: 'name', direction: 'asc' } });
+    load.next(true);
+    tick(400);
+    store.loadEntitiesPage({ pageIndex: 2 });
+    load.next(true);
+    tick(400);
+    store.selectEntity({ id: '35' });
+    load.next(true);
+    tick(400);
+    // Assert
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: expect.objectContaining({
+        page: '3',
+        filter: JSON.stringify({ search: 'a', foo: 'bar2' }),
+        sortBy: 'name',
+        sortDirection: 'asc',
+        selectedId: '35',
+      }),
+      queryParamsHandling: 'merge',
+    });
+  }));
+
+  it('prefix should be added to the url query params keys, with custom prefix', fakeAsync(() => {
+    // Arrange
+    const load = new Subject<boolean>();
+    const Store = signalStore(
+      localStoreFeature({ load }),
+      withEntitiesSyncToRouteQueryParams({ entity, prefix: 'p' }),
+    );
+    const { store, router } = init({
+      Store,
+      queryParams: {
+        'p-page': '2',
+        'p-filter': JSON.stringify({ search: '', foo: 'bar' }),
+        'p-sortBy': 'description',
+        'p-sortDirection': 'desc',
+        'p-selectedId': '2',
+      },
+    });
+    TestBed.flushEffects();
+    load.next(true);
+    tick(400);
+    // Act
+    store.filterEntities({
+      filter: { search: 'a', foo: 'bar2' },
+      forceLoad: true,
+    });
+    store.sortEntities({ sort: { field: 'name', direction: 'asc' } });
+    store.selectEntity({ id: '35' });
+    store.loadEntitiesPage({ pageIndex: 2 });
+    tick(400);
+    // Assert
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: expect.objectContaining({
+        'p-page': '3',
+        'p-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
+        'p-sortBy': 'name',
+        'p-sortDirection': 'asc',
+        'p-selectedId': '35',
+      }),
+      queryParamsHandling: 'merge',
+    });
+  }));
+
+  it('collection should be use as prefix to the url query params keys, if prefix is not provided', fakeAsync(() => {
+    // Arrange
+    const load = new Subject<boolean>();
+    const Store = signalStore(
+      localCollectionStoreFeature({ load }),
+      withEntitiesSyncToRouteQueryParams({ entity, collection }),
+    );
+    const { store, router } = init({
+      Store,
+      queryParams: {
+        'products-page': '2',
+        'products-filter': JSON.stringify({ search: '', foo: 'bar' }),
+        'products-sortBy': 'description',
+        'products-sortDirection': 'desc',
+        'products-selectedId': '2',
+      },
+    });
+    TestBed.flushEffects();
+    load.next(true);
+    tick(400);
+    expect(store.productsFilter()).toEqual({ search: '', foo: 'bar' });
+    expect(store.productsSort()).toEqual({
+      field: 'description',
+      direction: 'desc',
+    });
+    expect(store.productsIdSelected()).toEqual('2');
+    expect(store.productsPagination().currentPage).toEqual(1);
+    // Act
+    store.filterProductsEntities({
+      filter: { search: 'a', foo: 'bar2' },
+      forceLoad: true,
+    });
+    store.sortProductsEntities({ sort: { field: 'name', direction: 'asc' } });
+    store.selectProductsEntity({ id: '35' });
+    store.loadProductsPage({ pageIndex: 2 });
+    tick(400);
+    // Assert
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: expect.objectContaining({
+        'products-page': '3',
+        'products-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
+        'products-sortBy': 'name',
+        'products-sortDirection': 'asc',
+        'products-selectedId': '35',
+      }),
+      queryParamsHandling: 'merge',
+    });
+  }));
+
+  it('prefix false should remove collection prefix', fakeAsync(() => {
+    // Arrange
+    const load = new Subject<boolean>();
+    const Store = signalStore(
+      localCollectionStoreFeature({ load }),
+      withEntitiesSyncToRouteQueryParams({ entity, collection, prefix: false }),
+    );
+    const { store, router } = init({
+      Store,
+      queryParams: {
+        page: '2',
+        filter: JSON.stringify({ search: '', foo: 'bar' }),
+        sortBy: 'description',
+        sortDirection: 'desc',
+        selectedId: '2',
+      },
+    });
+    TestBed.flushEffects();
+    load.next(true);
+    tick(400);
+    // Act
+    store.filterProductsEntities({
+      filter: { search: 'a', foo: 'bar2' },
+      forceLoad: true,
+    });
+    store.sortProductsEntities({ sort: { field: 'name', direction: 'asc' } });
+    store.selectProductsEntity({ id: '35' });
+    store.loadProductsPage({ pageIndex: 2 });
+    tick(400);
+    // Assert
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: expect.objectContaining({
+        page: '3',
+        filter: JSON.stringify({ search: 'a', foo: 'bar2' }),
+        sortBy: 'name',
+        sortDirection: 'asc',
+        selectedId: '35',
+      }),
+      queryParamsHandling: 'merge',
+    });
+  }));
+
+  it('onQueryParamsLoaded should called after query params are set in the store', fakeAsync(() => {
+    // Arrange
+    const load = new Subject<boolean>();
+    const queryLoaded = jest.fn();
+    const Store = signalStore(
+      localStoreFeature({ load }),
+      withEntitiesSyncToRouteQueryParams({
+        entity,
+        onQueryParamsLoaded: (store) => {
+          queryLoaded(store.entitiesFilter(), store.idSelected());
+        },
+      }),
+    );
+    // Act
+    init({
+      Store,
+      queryParams: {
+        page: '2',
+        filter: JSON.stringify({ search: 'a', foo: 'bar' }),
+        sortBy: 'description',
+        sortDirection: 'desc',
+        selectedId: '35',
+      },
+    });
+    TestBed.flushEffects();
+    load.next(true);
+    tick(400);
+
+    // Assert
+    expect(queryLoaded).toBeCalledWith({ search: 'a', foo: 'bar' }, '35');
+  }));
+
+  it('multiple collections should be supported', fakeAsync(() => {
+    // Arrange
+    const load = new Subject<boolean>();
+    const load2 = new Subject<boolean>();
+    const Store = signalStore(
+      localCollectionStoreFeature({ load }),
+      withEntitiesSyncToRouteQueryParams({ entity, collection }),
+      localCollectionStoreFeature2({ load: load2 }),
+      withEntitiesSyncToRouteQueryParams({ entity, collection: 'orders' }),
+    );
+    const { store, router } = init({
+      Store,
+      queryParams: {
+        'products-page': '2',
+        'products-filter': JSON.stringify({ search: '', foo: 'bar' }),
+        'products-sortBy': 'description',
+        'products-sortDirection': 'desc',
+        'products-selectedId': '2',
+        'orders-page': '2',
+        'orders-filter': JSON.stringify({ search: '', foo: 'bar2' }),
+        'orders-sortBy': 'description',
+        'orders-sortDirection': 'desc',
+        'orders-selectedId': '2',
+      },
+    });
+    TestBed.flushEffects();
+    load.next(true);
+    load2.next(true);
+    tick(400);
+    expect(store.productsFilter()).toEqual({ search: '', foo: 'bar' });
+    expect(store.productsSort()).toEqual({
+      field: 'description',
+      direction: 'desc',
+    });
+    expect(store.productsIdSelected()).toEqual('2');
+    expect(store.productsPagination().currentPage).toEqual(1);
+
+    expect(store.ordersFilter()).toEqual({ search: '', foo: 'bar2' });
+    expect(store.ordersSort()).toEqual({
+      field: 'description',
+      direction: 'desc',
+    });
+    expect(store.ordersIdSelected()).toEqual('2');
+    expect(store.ordersPagination().currentPage).toEqual(1);
+    // Act
+    store.filterProductsEntities({
+      filter: { search: 'a', foo: 'bar2' },
+      forceLoad: true,
+    });
+    store.sortProductsEntities({ sort: { field: 'name', direction: 'asc' } });
+    store.selectProductsEntity({ id: '35' });
+    store.loadProductsPage({ pageIndex: 2 });
+
+    store.filterOrdersEntities({
+      filter: { search: 'a', foo: 'bar2' },
+      forceLoad: true,
+    });
+    store.sortOrdersEntities({ sort: { field: 'name', direction: 'asc' } });
+    store.selectOrdersEntity({ id: '35' });
+    store.loadOrdersPage({ pageIndex: 2 });
+    tick(400);
+    // Assert
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: expect.objectContaining({
+        'products-page': '3',
+        'products-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
+        'products-sortBy': 'name',
+        'products-sortDirection': 'asc',
+        'products-selectedId': '35',
+      }),
+      queryParamsHandling: 'merge',
+    });
+
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: expect.objectContaining({
+        'orders-page': '3',
+        'orders-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
+        'orders-sortBy': 'name',
+        'orders-sortDirection': 'asc',
+        'orders-selectedId': '35',
+      }),
+      queryParamsHandling: 'merge',
+    });
+  }));
+});

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
@@ -1,0 +1,217 @@
+import { computed, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import {
+  SignalStoreFeature,
+  signalStoreFeature,
+  type,
+  withHooks,
+} from '@ngrx/signals';
+import { EntityState, NamedEntityState } from '@ngrx/signals/entities';
+import {
+  EntityComputed,
+  NamedEntityComputed,
+} from '@ngrx/signals/entities/src/models';
+import {
+  type EmptyFeatureResult,
+  SignalStoreFeatureResult,
+  type StateSignals,
+} from '@ngrx/signals/src/signal-store-models';
+import type { StateSignal } from '@ngrx/signals/src/state-signal';
+import { Prettify } from '@ngrx/signals/src/ts-helpers';
+import { concatMap, first } from 'rxjs';
+
+import {
+  CallStatusComputed,
+  CallStatusMethods,
+  CallStatusState,
+  NamedCallStatusComputed,
+  NamedCallStatusMethods,
+  NamedCallStatusState,
+} from '../with-call-status/with-call-status.model';
+import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
+import {
+  FilterQueryMapper,
+  getQueryMapperForEntitiesFilter,
+} from '../with-entities-filter/with-entities-filter.util';
+import { getQueryMapperForEntitiesPagination } from '../with-entities-pagination/with-entities-local-pagination.util';
+import { getQueryMapperForSingleSelection } from '../with-entities-selection/with-entities-single-selection.util';
+import { getQueryMapperForEntitiesSort } from '../with-entities-sort/with-entities-local-sort.util';
+import { withSyncToRouteQueryParams } from './with-sync-to-route-query-params';
+import { QueryMapper } from './with-sync-to-route-query-params.util';
+
+/**
+ * Syncs entities filter, pagination, sort and single selection to route query params for local or remote entities store features. If a collection is provided, it will be used as a prefix (if non is provided) for the query params.
+ * The prefix can be disabled by setting it to false, or changed by providing a string. The filterMapper can be used to customize how the filter object is map to a query params object,
+ * when is not provided the filter will use JSON.stringify to serialize the filter object.
+ *
+ * Requires withEntities and withCallStatus to be present in the store.
+ *
+ * @param config.collection The collection name to use as a prefix for the query params. If not provided, the collection name will be used.
+ * @param config.filterMapper A function to map the filter object to a query params object.
+ * @param config.prefix The prefix to use for the query params. If set to false, the prefix will be disabled.
+ * @param config.onQueryParamsLoaded A function to be called when the query params are loaded into the store, (only gets called once).
+ * @param config.defaultDebounce The default debounce time to use sync the store changes back to the route query params.
+ *
+ * @example
+ * export const ProductsRemoteStore = signalStore(
+ *   { providedIn: 'root' },
+ *   // requires at least withEntities and withCallStatus
+ *   withEntities({ entity, collection }),
+ *   withCallStatus({ prop: collection, initialValue: 'loading' }),
+ *   withEntitiesRemoteFilter({
+ *     entity,
+ *     collection,
+ *   }),
+ *   withEntitiesRemotePagination({
+ *     entity,
+ *     collection,
+ *   }),
+ *   withEntitiesRemoteSort({
+ *     entity,
+ *     collection,
+ *     defaultSort: { field: 'name', direction: 'asc' },
+ *   }),
+ *   withEntitiesLoadingCall({
+ *     collection,
+ *     fetchEntities: ({ productsFilter, productsPagedRequest, productsSort }) => {
+ *       return inject(ProductService)
+ *         .getProducts({
+ *           search: productsFilter().name,
+ *           take: productsPagedRequest().size,
+ *           skip: productsPagedRequest().startIndex,
+ *           sortColumn: productsSort().field,
+ *           sortAscending: productsSort().direction === 'asc',
+ *         })
+ *         .pipe(
+ *           map((d) => ({
+ *             entities: d.resultList,
+ *             total: d.total,
+ *           })),
+ *         );
+ *     },
+ *   }),
+ *   // syncs the entities filter, pagination, sort and single selection to the route query params
+ *   withEntitiesSyncToRouteQueryParams({
+ *     entity,
+ *     collection,
+ *   })
+ *);
+ */
+export function withEntitiesSyncToRouteQueryParams<
+  Input extends SignalStoreFeatureResult,
+  Entity,
+  Filter,
+  const Collection extends string = '',
+  Error = unknown,
+>(config?: {
+  collection?: Collection;
+  filterMapper?: FilterQueryMapper<Filter>;
+  prefix?: string | false;
+  entity: Entity;
+  onQueryParamsLoaded?: (
+    store: Prettify<
+      StateSignals<Input['state']> &
+        Input['computed'] &
+        Input['methods'] &
+        StateSignal<Prettify<Input['state']>>
+    >,
+  ) => void;
+  defaultDebounce?: number;
+}): SignalStoreFeature<
+  Input &
+    (Collection extends ''
+      ? {
+          state: EntityState<Entity> & CallStatusState;
+          computed: EntityComputed<Entity> & CallStatusComputed<Error>;
+          methods: CallStatusMethods<Error>;
+        }
+      : {
+          state: NamedEntityState<Entity, Collection> &
+            NamedCallStatusState<Collection>;
+          computed: NamedEntityComputed<Entity, Collection> &
+            NamedCallStatusComputed<Collection, Error>;
+          methods: NamedCallStatusMethods<Collection, Error>;
+        }),
+  EmptyFeatureResult
+> {
+  const mappers = [
+    getQueryMapperForEntitiesPagination(config),
+    getQueryMapperForEntitiesSort(config),
+    getQueryMapperForEntitiesFilter(config),
+    getQueryMapperForSingleSelection(config),
+  ];
+  const prefixString =
+    config?.prefix === false ? undefined : config?.prefix ?? config?.collection;
+
+  const { loadingKey, loadedKey } = getWithCallStatusKeys({
+    prop: config?.collection,
+  });
+
+  return signalStoreFeature(
+    type<Input>(),
+    withSyncToRouteQueryParams({
+      defaultDebounce: config?.defaultDebounce,
+      mappers: prefixString
+        ? mappers.map((mapper) =>
+            getQueryMapperWithPrefix({ prefix: prefixString, mapper }),
+          )
+        : mappers,
+    }),
+    withHooks((store) => {
+      return {
+        onInit: () => {
+          if (config?.onQueryParamsLoaded) {
+            const loading = store[loadingKey] as Signal<boolean>;
+            const loaded = store[loadedKey] as Signal<boolean>;
+            const loaded$ = toObservable(loaded);
+            toObservable(loading)
+              .pipe(
+                first((v) => v),
+                concatMap(() => loaded$.pipe(first((v) => v))),
+                takeUntilDestroyed(),
+              )
+              .subscribe(() => {
+                config?.onQueryParamsLoaded?.(store);
+              });
+          }
+        },
+      };
+    }),
+  ) as any;
+}
+
+export function getQueryMapperWithPrefix(config: {
+  prefix: string;
+  mapper: QueryMapper<any>;
+}): QueryMapper<any> {
+  return {
+    queryParamsToState: (query, store) => {
+      const newQuery = Object.entries(query).reduce(
+        (acc, [key, value]) => {
+          if (key.startsWith(config.prefix + '-')) {
+            const keyWithoutPrefix = key.replace(config?.prefix + '-', '');
+            acc[keyWithoutPrefix] = value;
+            return acc;
+          }
+          return acc;
+        },
+        {} as Record<string, any>,
+      );
+      config.mapper.queryParamsToState(newQuery, store);
+    },
+    stateToQueryParams: (store) => {
+      const query = config.mapper.stateToQueryParams(store);
+      return query
+        ? computed(() => {
+            return Object.entries(query()).reduce(
+              (acc, [key, value]) => {
+                acc[config.prefix + '-' + key] = value;
+                return acc;
+              },
+              {} as Record<string, any>,
+            );
+          })
+        : undefined;
+    },
+  };
+}

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
@@ -1,0 +1,102 @@
+import { computed } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter, Router } from '@angular/router';
+import { withSyncToRouteQueryParams } from '@ngrx-traits/signals';
+import { patchState, signalStore, withState } from '@ngrx/signals';
+import { of } from 'rxjs';
+
+describe('withSyncToRouteQueryParams', () => {
+  function init({ debounce }: { debounce?: number } = {}) {
+    const Store = signalStore(
+      withState({
+        test: 'test',
+        foo: 'foo',
+        bar: false,
+      }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          {
+            queryParamsToState: (query, store) => {
+              patchState(store, {
+                test: query.test,
+                foo: query.foo,
+                bar: query.bar === 'true',
+              });
+            },
+            stateToQueryParams: (store) =>
+              computed(() => ({
+                test: store.test(),
+                foo: store.foo(),
+                bar: store.bar().toString(),
+              })),
+          },
+        ],
+        defaultDebounce: debounce,
+      }),
+    );
+    TestBed.configureTestingModule({
+      providers: [
+        Store,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            queryParams: of({
+              test: 'test2',
+              foo: 'foo2',
+              bar: 'true',
+            }),
+          }),
+        },
+      ],
+    });
+    return { store: TestBed.inject(Store) };
+  }
+
+  it('url query params should be synced with store', () => {
+    const { store } = init();
+    expect(store.test()).toBe('test2');
+    expect(store.foo()).toBe('foo2');
+    expect(store.bar()).toBe(true);
+  });
+
+  it('store should be synced with url query params', fakeAsync(() => {
+    const { store } = init();
+
+    const router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate');
+
+    patchState(store, {
+      test: 'test3',
+      foo: 'foo3',
+      bar: false,
+    });
+    TestBed.flushEffects();
+    tick(400);
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: { test: 'test3', foo: 'foo3', bar: 'false' },
+      queryParamsHandling: 'merge',
+    });
+  }));
+
+  it('store should be synced with url query params with custom debounce', fakeAsync(() => {
+    const { store } = init({ debounce: 1000 });
+
+    const router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate');
+
+    patchState(store, {
+      test: 'test3',
+      foo: 'foo3',
+      bar: false,
+    });
+    TestBed.flushEffects();
+    tick(1100);
+    expect(router.navigate).toBeCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: { test: 'test3', foo: 'foo3', bar: 'false' },
+      queryParamsHandling: 'merge',
+    });
+  }));
+});

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
@@ -1,0 +1,113 @@
+import { computed, inject } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { signalStoreFeature, type, withHooks, withState } from '@ngrx/signals';
+import type {
+  SignalStoreFeatureResult,
+  StateSignals,
+} from '@ngrx/signals/src/signal-store-models';
+import type { StateSignal } from '@ngrx/signals/src/state-signal';
+import { Prettify } from '@ngrx/signals/src/ts-helpers';
+import { combineLatest, debounce, first, map, timer } from 'rxjs';
+
+import { QueryMapper } from './with-sync-to-route-query-params.util';
+
+/**
+ * Syncs the route query params with the store and back. On init it will load
+ * the query params once and set them in the store using the mapper.queryParamsToState, after that
+ * and change on the store will be reflected in the query params using the mapper.stateToQueryParams
+ * @param config.mappers - The mappers to sync the query params with the store
+ * @param config.defaultDebounce - The debounce time to wait before updating the query params from the store
+ *
+ * @example
+ *     const Store = signalStore(
+ *       withState({
+ *         test: 'test',
+ *         foo: 'foo',
+ *         bar: false,
+ *       }),
+ *       withSyncToRouteQueryParams({
+ *         mappers: [
+ *           {
+ *             queryParamsToState: (query, store) => {
+ *             // set the query params in the store (only called once on init)
+ *               patchState(store, {
+ *                 test: query.test,
+ *                 foo: query.foo,
+ *                 bar: query.bar === 'true',
+ *               });
+ *             },
+ *             stateToQueryParams: (store) =>
+ *               // return the query params to be set in the route
+ *               computed(() => ({
+ *                 test: store.test(),
+ *                 foo: store.foo(),
+ *                 bar: store.bar().toString(),
+ *               })),
+ *           },
+ *         ],
+ *         defaultDebounce: debounce,
+ *       }),
+ *     );
+ */
+export function withSyncToRouteQueryParams<
+  Input extends SignalStoreFeatureResult,
+  Params extends Record<string, any>,
+  Mappers extends ReadonlyArray<
+    QueryMapper<
+      any,
+      Prettify<
+        StateSignals<Input['state']> &
+          Input['computed'] &
+          Input['methods'] &
+          StateSignal<Prettify<Input['state']>>
+      >
+    >
+  >,
+>(config: { mappers: Mappers; defaultDebounce?: number }) {
+  return signalStoreFeature(
+    type<Input>(),
+    withState({}),
+    withHooks((store: Record<string, any>) => {
+      const router = inject(Router);
+
+      return {
+        onInit: () => {
+          const activatedRoute = inject(ActivatedRoute);
+          activatedRoute.queryParams
+            .pipe(first(), takeUntilDestroyed())
+            .subscribe((queryParams) => {
+              const queryMappers = config.mappers;
+              queryMappers.forEach((mapper) => {
+                mapper.queryParamsToState(queryParams as Params, store as any);
+              });
+            });
+
+          const changesSignals = config.mappers
+            .map((mapper) => mapper.stateToQueryParams(store as any))
+            .filter((mapper) => !!mapper);
+
+          const computedChanges = computed(() => {
+            const queryParams = changesSignals.reduce((acc, mapper) => {
+              return {
+                ...acc,
+                ...mapper?.(),
+              };
+            }, {});
+            return queryParams;
+          });
+
+          toObservable(computedChanges)
+            .pipe(debounce(() => timer(config.defaultDebounce ?? 300)))
+            .subscribe((queryParams) => {
+              router.navigate([], {
+                relativeTo: activatedRoute,
+                queryParams,
+                queryParamsHandling: 'merge',
+              });
+            });
+        },
+      };
+    }),
+  );
+}

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.util.ts
@@ -1,0 +1,10 @@
+import { Signal } from '@angular/core';
+import { Params } from '@angular/router';
+
+export type QueryMapper<
+  T extends Params = Params,
+  Store extends Record<string, any> = Record<string, any>,
+> = {
+  queryParamsToState: (query: T, store: Store) => void;
+  stateToQueryParams: (store: Store) => Signal<T> | undefined | null;
+};


### PR DESCRIPTION
 new withSyncToRouteQueryParams store feature that allows to sync parts of the state to the url query
    params, and withEntitiesSyncToRouteQueryParams which syncs entities filters, pagination sort and single selection state to the url query params
    
    fix #116
