### PR TITLE
fix(signals): fix Sort model type so it can autocomplet Entity type props

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
@@ -1,7 +1,7 @@
 export type SortDirection = 'asc' | 'desc' | '';
 export type Sort<Entity> = {
   /** The id of the column being sorted. */
-  field: keyof Entity | string;
+  field: keyof Entity | (string & {});
   /** The sort direction. */
   direction: SortDirection;
 };


### PR DESCRIPTION


Fix the Sort type of withEntitiesLocalSort, so intelli sence on the field prop of the Sort type , automcompletes the props of the Entity

fix #138