### PR TITLE
Fix: withEntitiesSyncToRouteQueryParams requires to have sort, filter and pagination

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -112,13 +112,15 @@ export function getQueryMapperForEntitiesFilter<Filter>(config?: {
       const filter = store[filterKey] as Signal<
         EntitiesFilterState<any>['entitiesFilter']
       >;
-      return computed(() =>
-        config?.filterMapper
-          ? (config?.filterMapper.filterToQueryParams(filter()) as any)
-          : {
-              filter: JSON.stringify({ ...filter() }),
-            },
-      );
+      return filter
+        ? computed(() =>
+            config?.filterMapper
+              ? (config?.filterMapper.filterToQueryParams(filter()) as any)
+              : {
+                  filter: JSON.stringify({ ...filter() }),
+                },
+          )
+        : null;
     },
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
@@ -83,9 +83,11 @@ export function getQueryMapperForEntitiesPagination(config?: {
       const pagination = store[paginationKey] as Signal<
         EntitiesPaginationLocalState['entitiesPagination']
       >;
-      return computed(() => ({
-        page: (pagination().currentPage + 1).toString(),
-      }));
+      return pagination
+        ? computed(() => ({
+            page: (pagination().currentPage + 1).toString(),
+          }))
+        : null;
     },
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.util.ts
@@ -116,10 +116,12 @@ export function getQueryMapperForEntitiesSort(config?: {
       const sort = store[sortKey] as Signal<
         EntitiesSortState<any>['entitiesSort']
       >;
-      return computed(() => ({
-        sortBy: sort().field as string,
-        sortDirection: sort().direction,
-      }));
+      return sort
+        ? computed(() => ({
+            sortBy: sort().field as string,
+            sortDirection: sort().direction,
+          }))
+        : null;
     },
   };
 }


### PR DESCRIPTION
A bug in withEntitiesSyncToRouteQueryParams, was making it only work if the store have withEntities for all 3 sort, filter and pagination, this fix allows to have any one or two

fix #140