### PR TITLE
feat(signals): add support for _ method names in withCalls

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.util.ts
@@ -1,15 +1,35 @@
 import { capitalize } from '../util';
 
-export function getWithCallStatusKeys(config?: { prop?: string }) {
-  const prop = config?.prop;
+export function getWithCallStatusKeys(config?: {
+  prop?: string;
+  supportPrivate?: boolean;
+}) {
+  let prop = config?.prop;
+  let prefix = '';
+
+  if (config?.supportPrivate && prop?.startsWith('_')) {
+    prop = prop.slice(1);
+    prefix = '_';
+  }
+
   const capitalizedProp = prop && capitalize(prop);
   return {
-    callStatusKey: prop ? `${config.prop}CallStatus` : 'callStatus',
-    loadingKey: prop ? `is${capitalizedProp}Loading` : 'isLoading',
-    loadedKey: prop ? `is${capitalizedProp}Loaded` : 'isLoaded',
-    errorKey: prop ? `${config.prop}Error` : 'error',
-    setLoadingKey: prop ? `set${capitalizedProp}Loading` : 'setLoading',
-    setLoadedKey: prop ? `set${capitalizedProp}Loaded` : 'setLoaded',
-    setErrorKey: prop ? `set${capitalizedProp}Error` : 'setError',
+    callStatusKey: prop ? `${prefix}${prop}CallStatus` : `${prefix}callStatus`,
+    loadingKey: prop
+      ? `${prefix}is${capitalizedProp}Loading`
+      : `${prefix}isLoading`,
+    loadedKey: prop
+      ? `${prefix}is${capitalizedProp}Loaded`
+      : `${prefix}isLoaded`,
+    errorKey: prop ? `${prefix}${prop}Error` : `${prefix}error`,
+    setLoadingKey: prop
+      ? `${prefix}set${capitalizedProp}Loading`
+      : `${prefix}setLoading`,
+    setLoadedKey: prop
+      ? `${prefix}set${capitalizedProp}Loaded`
+      : `${prefix}setLoaded`,
+    setErrorKey: prop
+      ? `${prefix}set${capitalizedProp}Error`
+      : `${prefix}setError`,
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -37,9 +37,13 @@ export type ExtractCallResultType<T extends Call | CallConfig> =
       : never;
 
 export type NamedCallsStatusComputed<Prop extends string> = {
-  [K in Prop as `is${Capitalize<string & K>}Loading`]: Signal<boolean>;
+  [K in Prop as K extends `_${infer J}`
+    ? `_is${Capitalize<string & J>}Loading`
+    : `is${Capitalize<string & K>}Loading`]: Signal<boolean>;
 } & {
-  [K in Prop as `is${Capitalize<string & K>}Loaded`]: Signal<boolean>;
+  [K in Prop as K extends `_${infer J}`
+    ? `_is${Capitalize<string & J>}Loaded`
+    : `is${Capitalize<string & K>}Loaded`]: Signal<boolean>;
 };
 export type NamedCallsStatusErrorComputed<
   Calls extends Record<string, Call | CallConfig>,

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -64,6 +64,8 @@ import { getWithCallKeys } from './with-calls.util';
  * or a Signal or Observable of the same type as the original parameters.
  * The original call can only have zero or one parameter, use an object with multiple
  * props as first param if you need more.
+ * If the name start with an underscore, the call will be private and all generated methods
+ * will also start with an underscore, making it only accessible inside the store.
  * @param {callsFactory} callsFactory - a factory function that receives the store and returns an object of type {Record<string, Call | CallConfig>} with the calls to be made
  *
  * @example
@@ -182,7 +184,7 @@ export function withCalls<
         const callsComputed = Object.keys(calls).reduce(
           (acc, callName) => {
             const { loadingKey, loadedKey, errorKey, callStatusKey } =
-              getWithCallStatusKeys({ prop: callName });
+              getWithCallStatusKeys({ prop: callName, supportPrivate: true });
             const callState = state[callStatusKey] as Signal<CallStatus>;
             acc[loadingKey] = computed(() => callState() === 'loading');
             acc[loadedKey] = computed(() => callState() === 'loaded');


### PR DESCRIPTION
Add support for private methods (methods with _ in the start of the name) to withCalls

fix #142