### PR TITLE
fix(signals): fix return type for some of the traits

### DIFF
--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -17,7 +17,11 @@ call and store the result of the call. The generated methods are rxMethods with
 the same name as the original call, which accepts either the original parameters
 or a Signal or Observable of the same type as the original parameters.
 The original call can only have zero or one parameter, use an object with multiple
-props as first param if you need more.</p></dd>
+props as first param if you need more.
+If the name start with an underscore, the call will be private and all generated methods
+will also start with an underscore, making it only accessible inside the store.</p></dd>
+<dt><a href="#typedCallConfig">typedCallConfig(config)</a></dt>
+<dd><p>Call configuration object for withCalls</p></dd>
 <dt><a href="#withEntitiesLocalFilter">withEntitiesLocalFilter(configFactory)</a></dt>
 <dd><p>Generates necessary state, computed and methods for locally filtering entities in the store,
 the generated filter[collenction]Entities method will filter the entities based on the filter function
@@ -172,7 +176,9 @@ call and store the result of the call. The generated methods are rxMethods with
 the same name as the original call, which accepts either the original parameters
 or a Signal or Observable of the same type as the original parameters.
 The original call can only have zero or one parameter, use an object with multiple
-props as first param if you need more.</p>
+props as first param if you need more.
+If the name start with an underscore, the call will be private and all generated methods
+will also start with an underscore, making it only accessible inside the store.</p>
 
 **Kind**: global function  
 **Warning**: The default mapPipe is [exhaustMap](https://www.learnrxjs.io/learn-rxjs/operators/transformation/exhaustmap). If your call returns an observable that does not complete after the first value is emitted, any changes to the input params will be ignored. Either specify [switchMap](https://www.learnrxjs.io/learn-rxjs/operators/transformation/switchmap) as mapPipe, or use [take(1)](https://www.learnrxjs.io/learn-rxjs/operators/filtering/take) or [first()](https://www.learnrxjs.io/learn-rxjs/operators/filtering/first) as part of your call.  
@@ -199,6 +205,10 @@ withCalls(({ productsSelectedEntity }) => ({
       onError: (error, callParam) => {
       // do something with the error
       },
+      skipWhen: (callParam) => {
+        // if return true, the call will be skip, if false, the call will execute as usual
+        return // boolean | Promise<boolean> | Observable<boolean>
+      },
     }),
     checkout: () =>
       inject(OrderService).checkout({
@@ -223,6 +233,25 @@ withCalls(({ productsSelectedEntity }) => ({
   store.loadProductDetail // ({id: string} | Signal<{id: string}> | Observable<{id: string}>) => void
   store.checkout // () => void
 ```
+<a name="typedCallConfig"></a>
+
+## typedCallConfig(config)
+<p>Call configuration object for withCalls</p>
+
+**Kind**: global function  
+
+| Param | Description |
+| --- | --- |
+| config | <p>the call configuration</p> |
+| config.call | <p>required, the function that will be called</p> |
+| config.mapPipe | <p>optional, default exhaustMap the pipe operator that will be used to map the call result</p> |
+| config.storeResult | <p>optional, default true, if false, the result will not be stored in the store</p> |
+| config.resultProp | <p>optional, default callName + 'Result', the name of the prop where the result will be stored</p> |
+| config.onSuccess | <p>optional, a function that will be called when the call is successful</p> |
+| config.mapError | <p>optional, a function that will be called to transform the error before storing it</p> |
+| config.onError | <p>optional, a function that will be called when the call fails</p> |
+| config.skipWhen | <p>optional, a function that will be called to determine if the call should be skipped</p> |
+
 <a name="withEntitiesLocalFilter"></a>
 
 ## withEntitiesLocalFilter(configFactory)

--- a/libs/ngrx-traits/signals/src/lib/with-logger/with-state-logger.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-logger/with-state-logger.ts
@@ -1,6 +1,8 @@
 import { effect } from '@angular/core';
 import {
+  EmptyFeatureResult,
   getState,
+  SignalStoreFeature,
   signalStoreFeature,
   SignalStoreFeatureResult,
   type,
@@ -18,7 +20,7 @@ export function withStateLogger<Input extends SignalStoreFeatureResult>({
 }: {
   name: string;
   filterState?: (state: Input['state']) => Partial<Input['state']>;
-}) {
+}): SignalStoreFeature<Input, EmptyFeatureResult> {
   return signalStoreFeature(
     type<Input>(),
     withHooks({

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
@@ -2,7 +2,9 @@ import { computed, inject } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
+  EmptyFeatureResult,
   Prettify,
+  SignalStoreFeature,
   signalStoreFeature,
   SignalStoreFeatureResult,
   StateSignals,
@@ -58,7 +60,10 @@ export function withSyncToRouteQueryParams<
   Input extends SignalStoreFeatureResult,
   Params extends Record<string, any>,
   Mappers extends ReadonlyArray<QueryMapper<any, StoreSource<Input>>>,
->(config: { mappers: Mappers; defaultDebounce?: number }) {
+>(config: {
+  mappers: Mappers;
+  defaultDebounce?: number;
+}): SignalStoreFeature<Input, EmptyFeatureResult> {
   return signalStoreFeature(
     type<Input>(),
     withState({}),

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.ts
@@ -4,6 +4,7 @@ import {
   getState,
   patchState,
   Prettify,
+  SignalStoreFeature,
   signalStoreFeature,
   SignalStoreFeatureResult,
   StateSignals,
@@ -67,7 +68,18 @@ export function withSyncToWebStorage<Input extends SignalStoreFeatureResult>({
         WritableStateSource<Prettify<Input['state']>>
     >,
   ) => void;
-}) {
+}): SignalStoreFeature<
+  Input,
+  {
+    state: {};
+    computed: {};
+    methods: {
+      saveToStorage: () => void;
+      loadFromStorage: () => void;
+      clearFromStore: () => void;
+    };
+  }
+> {
   return signalStoreFeature(
     type<Input>(),
     withState({}),


### PR DESCRIPTION
Made the return type explicit for withSyncToWebStorage, withStateLogger and withSyncToRouteQueryParams, before the were inferred which worked fine in the examples inside the project but when compiled as lib, causes a problem were the functions inside the traits can not correctly infer the store , this also fixes using the library with skipLibCheck: false

Fixes #145 , #91