### PR TITLE
feat(deepComputed): apply deepcomputed to non flat computed

### DIFF
--- a/libs/ngrx-traits/signals/package.json
+++ b/libs/ngrx-traits/signals/package.json
@@ -7,7 +7,7 @@
   },
   "peerDependencies": {
     "@angular/core": "^18.0.5",
-    "@ngrx/signals": "^18.0.0",
+    "@ngrx/signals": "^18.1.0",
     "rxjs": "^7.8.1"
   },
   "optionalDependencies": {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
@@ -11,7 +11,6 @@ import {
   signalStoreFeature,
   SignalStoreFeature,
   SignalStoreFeatureResult,
-  StateSignals,
   withHooks,
   WritableStateSource,
 } from '@ngrx/signals';
@@ -23,7 +22,6 @@ import {
   SelectEntityId,
   setAllEntities,
 } from '@ngrx/signals/entities';
-import { Prettify } from '@ngrx/signals/src/ts-helpers';
 import {
   catchError,
   concatMap,
@@ -48,7 +46,6 @@ import {
 import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
 import {
   NamedSetEntitiesResult,
-  SetEntitiesResult,
 } from '../with-entities-pagination/with-entities-local-pagination.model';
 import { getWithEntitiesRemotePaginationKeys } from '../with-entities-pagination/with-entities-remote-pagination.util';
 import { withFeatureFactory } from '../with-feature-factory/with-feature-factory';

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.model.ts
@@ -1,4 +1,4 @@
-import { Signal } from '@angular/core';
+import { DeepSignal } from '@ngrx/signals';
 
 export type EntitiesPaginationLocalState = {
   entitiesPagination: {
@@ -13,7 +13,7 @@ export type NamedEntitiesPaginationLocalState<Collection extends string> = {
   };
 };
 export type EntitiesPaginationLocalComputed<Entity> = {
-  entitiesCurrentPage: Signal<{
+  entitiesCurrentPage: DeepSignal<{
     entities: Entity[];
     pageIndex: number;
     total: number | undefined;
@@ -27,7 +27,7 @@ export type NamedEntitiesPaginationLocalComputed<
   Entity,
   Collection extends string,
 > = {
-  [K in Collection as `${K}CurrentPage`]: Signal<{
+  [K in Collection as `${K}CurrentPage`]: DeepSignal<{
     entities: Entity[];
     pageIndex: number;
     total: number | undefined;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.spec.ts
@@ -276,4 +276,40 @@ describe('withEntitiesLocalPagination', () => {
       expect(store.entitiesCurrentPage().pageIndex).toEqual(0);
     });
   }));
+
+  it('should check deepsignals', () => {
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities({ entity }),
+      withEntitiesLocalPagination({ entity, pageSize: 10 }),
+    );
+
+    const store = new Store();
+    patchState(store, setAllEntities(mockProducts.slice(0, 25)));
+
+    // Check deep signals
+    expect(store.entitiesCurrentPage.entities().length).toEqual(10);
+    expect(store.entitiesCurrentPage.entities()).toEqual(
+      mockProducts.slice(0, 10),
+    );
+    expect(store.entitiesCurrentPage.pageIndex()).toEqual(0);
+    expect(store.entitiesCurrentPage.pageSize()).toEqual(10);
+    expect(store.entitiesCurrentPage.pagesCount()).toEqual(3);
+    expect(store.entitiesCurrentPage.total()).toEqual(25);
+    expect(store.entitiesCurrentPage.hasPrevious()).toEqual(false);
+    expect(store.entitiesCurrentPage.hasNext()).toEqual(true);
+
+    store.loadEntitiesPage({ pageIndex: 1 });
+
+    expect(store.entitiesCurrentPage.entities().length).toEqual(10);
+    expect(store.entitiesCurrentPage.entities()).toEqual(
+      mockProducts.slice(10, 20),
+    );
+    expect(store.entitiesCurrentPage.pageIndex()).toEqual(1);
+    expect(store.entitiesCurrentPage.pageSize()).toEqual(10);
+    expect(store.entitiesCurrentPage.pagesCount()).toEqual(3);
+    expect(store.entitiesCurrentPage.total()).toEqual(25);
+    expect(store.entitiesCurrentPage.hasPrevious()).toEqual(true);
+    expect(store.entitiesCurrentPage.hasNext()).toEqual(true);
+  });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.ts
@@ -1,5 +1,6 @@
 import { computed, Signal } from '@angular/core';
 import {
+  deepComputed,
   patchState,
   signalStoreFeature,
   SignalStoreFeature,
@@ -163,7 +164,7 @@ export function withEntitiesLocalPagination<
           pageSize: number;
           currentPage: number;
         }>;
-        const entitiesCurrentPage = computed(() => {
+        const entitiesCurrentPage = deepComputed(() => {
           const page = pagination().currentPage;
           const startIndex = page * pagination().pageSize;
           let endIndex = startIndex + pagination().pageSize;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.model.ts
@@ -6,6 +6,7 @@ import {
   NamedSetEntitiesResult,
   SetEntitiesResult,
 } from './with-entities-local-pagination.model';
+import { DeepSignal } from '@ngrx/signals';
 
 export type PaginationState = {
   currentPage: number;
@@ -25,7 +26,7 @@ export type NamedEntitiesPaginationRemoteState<Collection extends string> = {
   [K in Collection as `${K}Pagination`]: PaginationState;
 };
 export type EntitiesPaginationRemoteComputed<Entity> = {
-  entitiesCurrentPage: Signal<{
+  entitiesCurrentPage: DeepSignal<{
     entities: Entity[];
     pageIndex: number;
     total: number | undefined;
@@ -35,7 +36,7 @@ export type EntitiesPaginationRemoteComputed<Entity> = {
     hasNext: boolean;
     isLoading: boolean;
   }>;
-  entitiesPagedRequest: Signal<{
+  entitiesPagedRequest: DeepSignal<{
     startIndex: number;
     size: number;
     page: number;
@@ -45,13 +46,13 @@ export type NamedEntitiesPaginationRemoteComputed<
   Entity,
   Collection extends string,
 > = {
-  [K in Collection as `${K}PagedRequest`]: Signal<{
+  [K in Collection as `${K}PagedRequest`]: DeepSignal<{
     startIndex: number;
     size: number;
     page: number;
   }>;
 } & {
-  [K in Collection as `${K}CurrentPage`]: Signal<{
+  [K in Collection as `${K}CurrentPage`]: DeepSignal<{
     entities: Entity[];
     pageIndex: number;
     total: number | undefined;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.ts
@@ -1,6 +1,7 @@
 import { computed, Signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import {
+  deepComputed,
   patchState,
   signalStoreFeature,
   SignalStoreFeature,
@@ -248,7 +249,7 @@ export function withEntitiesRemotePagination<
           return entities().slice(startIndex, endIndex);
         });
 
-        const entitiesCurrentPage = computed(() => {
+        const entitiesCurrentPage = deepComputed(() => {
           const pagesCount =
             pagination().total && pagination().total! > 0
               ? Math.ceil(pagination().total! / pagination().pageSize)

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.model.ts
@@ -4,6 +4,7 @@ import {
   NamedSetEntitiesResult,
   SetEntitiesResult,
 } from './with-entities-local-pagination.model';
+import { DeepSignal } from '@ngrx/signals';
 
 export type ScrollPaginationState = {
   hasMore: boolean;
@@ -19,7 +20,7 @@ export type NamedEntitiesScrollPaginationState<Collection extends string> = {
   [K in Collection as `${K}Pagination`]: ScrollPaginationState;
 };
 export type EntitiesScrollPaginationComputed<Entity> = {
-  entitiesCurrentPage: Signal<{
+  entitiesCurrentPage: DeepSignal<{
     entities: Entity[];
     pageIndex: number;
     pageSize: number;
@@ -27,7 +28,7 @@ export type EntitiesScrollPaginationComputed<Entity> = {
     hasNext: boolean;
     isLoading: boolean;
   }>;
-  entitiesPagedRequest: Signal<{
+  entitiesPagedRequest: DeepSignal<{
     startIndex: number;
     size: number;
   }>;
@@ -36,12 +37,12 @@ export type NamedEntitiesScrollPaginationComputed<
   Entity,
   Collection extends string,
 > = {
-  [K in Collection as `${K}PagedRequest`]: Signal<{
+  [K in Collection as `${K}PagedRequest`]: DeepSignal<{
     startIndex: number;
     size: number;
   }>;
 } & {
-  [K in Collection as `${K}CurrentPage`]: Signal<{
+  [K in Collection as `${K}CurrentPage`]: DeepSignal<{
     entities: Entity[];
     pageIndex: number;
     pageSize: number;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-scroll-pagination.ts
@@ -1,6 +1,7 @@
 import { computed, Signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import {
+  deepComputed,
   patchState,
   signalStoreFeature,
   SignalStoreFeature,
@@ -242,7 +243,7 @@ export function withEntitiesRemoteScrollPagination<
           paginationKey
         ] as Signal<ScrollPaginationState>;
 
-        const entitiesPagedRequest = computed(() => ({
+        const entitiesPagedRequest = deepComputed(() => ({
           startIndex: entities().length,
           size: pagination().pageSize * pagination().pagesToCache,
         }));
@@ -256,7 +257,7 @@ export function withEntitiesRemoteScrollPagination<
           return entities().slice(startIndex, endIndex);
         });
 
-        const entitiesCurrentPage = computed(() => {
+        const entitiesCurrentPage = deepComputed(() => {
           return {
             entities: entitiesCurrentPageList(),
             pageIndex: pagination().currentPage,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "18.0.0",
         "@ngrx/effects": "18.0.1",
         "@ngrx/entity": "18.0.1",
-        "@ngrx/signals": "^18.0.0",
+        "@ngrx/signals": "^18.1.0",
         "@ngrx/store": "18.0.0",
         "@ngrx/store-devtools": "18.0.1",
         "msw": "^0.39.2",
@@ -7622,9 +7622,9 @@
       }
     },
     "node_modules/@ngrx/signals": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-18.0.0.tgz",
-      "integrity": "sha512-zAWlsRqBbP/JsLmXHupfRb/BD5Xe2I03hLIB+q+vmXwAf29KCwRMVPLpWWu0DEgJvM0dVklP9WIgcG/D1pKScg==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-18.1.0.tgz",
+      "integrity": "sha512-ivuOyCPXoysUxvCRotRAMtwo+ObfWN06kHz/Nnlp8GyCB6wgZaUUGe6luOQyWhrZkbu3K+oCu7HB6YCSY6zT+A==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@angular/platform-browser": "18.0.0",
     "@ngrx/effects": "18.0.1",
     "@ngrx/entity": "18.0.1",
-    "@ngrx/signals": "^18.0.0",
+    "@ngrx/signals": "^18.1.0",
     "@ngrx/store": "18.0.0",
     "@ngrx/store-devtools": "18.0.1",
     "msw": "^0.39.2",


### PR DESCRIPTION
- Update @ngrx/signals to version 18.1.0
- Removed unused imports
- Applied deepComputed to non flat computeds:  withEntitiesLocalPagination, withRemotePagination, withEntitiesRemoteScroll
