### PR TITLE
fix(signals): withCalls mapPipe not working correctly

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -238,9 +238,9 @@ export function withCalls<
 
               acc[callNameKey] = rxMethod<unknown[]>(
                 pipe(
-                  concatMap((params) => {
+                  mapPipe((params) => {
                     const skip = skipWhenFn?.(params) ?? false;
-                    const process$ = mapPipe((params) => {
+                    const process$ = concatMap((params) => {
                       setLoading();
                       return runInInjectionContext(environmentInjector, () => {
                         return callFn(params).pipe(


### PR DESCRIPTION
Due to a bug when using mapPipe: exhaustMap or switchMap was always behaving like a concatMap, this pr fixes the issue and adds tests

fix #148