### PR TITLE
feat(signals): implemented withAnyCallsStatus to track status changes…

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/index.ts
+++ b/libs/ngrx-traits/signals/src/lib/index.ts
@@ -29,3 +29,5 @@ export * from './with-sync-to-route-query-params/with-sync-to-route-query-params
 export * from './with-route-params/with-route-params';
 export * from './with-input-bindings/with-input-bindings';
 export * from './with-feature-factory/with-feature-factory';
+export * from './with-all-call-status/with-all-call-status';
+export * from './with-all-call-status/with-all-call-status.util';

--- a/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.model.ts
@@ -1,0 +1,6 @@
+import { Signal } from '@angular/core';
+
+export type CallStatus = {
+  loading: Signal<boolean>;
+  error: Signal<unknown>;
+};

--- a/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { withCalls, withCallStatus } from '@ngrx-traits/signals';
+import { signalStore } from '@ngrx/signals';
+import { first, Subject } from 'rxjs';
+
+import { withAllCallStatus } from './with-all-call-status';
+
+describe('withAllCallStatus', () => {
+  it('isAnyCallLoading should be true if any call in the store is loading', async () => {
+    let apiResponse = new Subject<string>();
+    await TestBed.runInInjectionContext(async () => {
+      const Store = signalStore(
+        withAllCallStatus(),
+        withCalls(() => ({
+          testCall: (param: { id: string }) => {
+            return apiResponse.pipe(first());
+          },
+        })),
+        withCallStatus({ collection: 'test' }),
+      );
+      const store = new Store();
+
+      expect(store.isAnyCallLoading()).toEqual(false);
+      store.testCall({ id: '1' });
+      expect(store.isAnyCallLoading()).toEqual(true);
+      apiResponse.next('test response');
+      expect(store.isAnyCallLoading()).toEqual(false);
+
+      store.setTestLoading();
+      expect(store.isAnyCallLoading()).toEqual(true);
+      store.setTestLoaded();
+      expect(store.isAnyCallLoading()).toEqual(false);
+    });
+  });
+
+  it('callsErrors should return the errors of any call in error state', async () => {
+    let apiResponse = new Subject<string>();
+    await TestBed.runInInjectionContext(async () => {
+      const Store = signalStore(
+        withAllCallStatus(),
+        withCalls(() => ({
+          testCall: (param: { id: string }) => {
+            return apiResponse.pipe(first());
+          },
+        })),
+        withCallStatus({ collection: 'test2' }),
+      );
+      const store = new Store();
+
+      expect(store.isAnyCallLoading()).toEqual(false);
+      store.testCall({ id: '1' });
+      expect(store.isAnyCallLoading()).toEqual(true);
+      apiResponse.error(new Error('fail'));
+      expect(store.callsErrors()[0]).toEqual(new Error('fail'));
+
+      store.setTest2Error(new Error('fail2'));
+      expect(store.isAnyCallLoading()).toEqual(false);
+      expect(store.callsErrors()[0]).toEqual(new Error('fail'));
+      expect(store.callsErrors()[1]).toEqual(new Error('fail2'));
+
+      store.setTest2Loaded();
+      apiResponse = new Subject<string>();
+      store.testCall({ id: '1' });
+      apiResponse.next('test response');
+      expect(store.isAnyCallLoading()).toEqual(false);
+      expect(store.callsErrors()).toEqual([]);
+    });
+  });
+});

--- a/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.ts
@@ -1,0 +1,63 @@
+import { computed } from '@angular/core';
+import {
+  patchState,
+  signalStoreFeature,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+
+import { CallStatus } from './with-all-call-status.model';
+
+/**
+ * Adds methods to the store to track the status of all calls in the store
+ * @example
+ * export const ProductsLocalStore = signalStore(
+ *   withAllCallStatus(), // <-- add this line
+ *   withEntities({ entity, collection }),
+ *   withCallStatus({ collection, initialValue: 'loading' }),
+ *   withEntitiesLoadingCall({
+ *     collection,
+ *     fetchEntities: () => {
+ *       return inject(ProductService)
+ *         .getProducts()
+ *         .pipe(map((d) => d.resultList));
+ *     },
+ *   }),
+ *   withCalls(() => ({
+ *     loadProductDetail: callConfig({
+ *       call: ({ id }: { id: string }) =>
+ *         inject(ProductService).getProductDetail(id),
+ *       resultProp: 'productDetail',
+ *     }),
+ *     checkout: () => inject(OrderService).checkout(),
+ *   })),
+ * );
+ * // generates the following methods
+ *  store.isAnyCallLoading() // Signal<boolean>
+ *  store.callsErrors // () => Signals<unknown[]>
+ */
+export function withAllCallStatus() {
+  return signalStoreFeature(
+    withState({
+      _allCallStatus: [] as CallStatus[],
+    }),
+    withComputed(({ _allCallStatus }) => ({
+      isAnyCallLoading: computed(() =>
+        _allCallStatus().some((callStatus) => callStatus.loading()),
+      ),
+      callsErrors: computed(() =>
+        _allCallStatus()
+          .map((callStatus) => callStatus.error())
+          .filter(Boolean),
+      ),
+    })),
+    withMethods(({ _allCallStatus, ...store }) => ({
+      _registerCallStatus: (callStatus: CallStatus) => {
+        patchState(store, {
+          _allCallStatus: [..._allCallStatus(), callStatus],
+        });
+      },
+    })),
+  );
+}

--- a/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-all-call-status/with-all-call-status.util.ts
@@ -1,0 +1,14 @@
+import { Signal } from '@angular/core';
+
+import { CallStatus } from './with-all-call-status.model';
+
+export function registerCallState(
+  store: Record<string, any>,
+  callStatus: CallStatus,
+) {
+  if ('_registerCallStatus' in store) {
+    (
+      store as { _registerCallStatus: (callStatus: CallStatus) => void }
+    )._registerCallStatus(callStatus);
+  }
+}

--- a/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.ts
@@ -9,6 +9,7 @@ import {
   withState,
 } from '@ngrx/signals';
 
+import { registerCallState } from '../with-all-call-status/with-all-call-status.util';
 import { withFeatureFactory } from '../with-feature-factory/with-feature-factory';
 import {
   FeatureConfigFactory,
@@ -103,15 +104,19 @@ export function withCallStatus<
       withComputed((state: Record<string, Signal<unknown>>) => {
         const callState = state[callStatusKey] as Signal<CallStatus>;
 
+        const isLoading = computed(() => {
+          return callState() === 'loading';
+        });
+        const isLoaded = computed(() => callState() === 'loaded');
+        const error = computed(() => {
+          const v = callState();
+          return typeof v === 'object' ? v.error : undefined;
+        });
+        registerCallState(store, { loading: isLoading, error });
         return {
-          [loadingKey]: computed(() => {
-            return callState() === 'loading';
-          }),
-          [loadedKey]: computed(() => callState() === 'loaded'),
-          [errorKey]: computed(() => {
-            const v = callState();
-            return typeof v === 'object' ? v.error : undefined;
-          }),
+          [loadingKey]: isLoading,
+          [loadedKey]: isLoaded,
+          [errorKey]: error,
         };
       }),
       withMethods((store) => ({

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -44,6 +44,7 @@ import {
 import { filter } from 'rxjs/operators';
 
 import { insertIf } from '../util';
+import { registerCallState } from '../with-all-call-status/with-all-call-status.util';
 import {
   CallStatus,
   NamedCallStatusState,
@@ -196,12 +197,15 @@ export function withCalls<
             const { loadingKey, loadedKey, errorKey, callStatusKey } =
               getWithCallStatusKeys({ prop: callName, supportPrivate: true });
             const callState = state[callStatusKey] as Signal<CallStatus>;
-            acc[loadingKey] = computed(() => callState() === 'loading');
-            acc[loadedKey] = computed(() => callState() === 'loaded');
-            acc[errorKey] = computed(() => {
+            const isLoading = computed(() => callState() === 'loading');
+            const error = computed(() => {
               const v = callState();
               return typeof v === 'object' ? v.error : null;
             });
+            registerCallState(store, { loading: isLoading, error });
+            acc[loadingKey] = isLoading;
+            acc[errorKey] = error;
+            acc[loadedKey] = computed(() => callState() === 'loaded');
 
             return acc;
           },


### PR DESCRIPTION
feat(signals): implemented withAnyCallsStatus to track status changes on any call inside the store

withAnyCallsStatus adds isAnyCallLoading that returns true if any of the calls in the store are loading and callsErrors that returns an array with the erros of any call if any

Fix #155