### PR TITLE
fix(signals): fix to withEnttiesLoading mapPipe

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.util.ts
@@ -1,4 +1,8 @@
 import { capitalize } from '../util';
+import {
+  createEvent,
+  props,
+} from '../with-event-handler/with-event-handler.util';
 
 export function getWithCallStatusKeys(config?: {
   prop?: string;
@@ -31,5 +35,17 @@ export function getWithCallStatusKeys(config?: {
     setErrorKey: prop
       ? `${prefix}set${capitalizedProp}Error`
       : `${prefix}setError`,
+  };
+}
+
+export function getWithCallStatusEvents(config?: { prop?: string }) {
+  const collection = config?.prop;
+  return {
+    callLoading: createEvent(`${collection}.callLoading`),
+    callLoaded: createEvent(`${collection}.callLoaded`),
+    callError: createEvent(
+      `${collection}.callError`,
+      props<{ error: unknown }>(),
+    ),
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -202,7 +202,6 @@ export function withEntitiesRemoteFilter<
           pipe(
             debounceFilterPipe(filter, config.defaultDebounce),
             tap((value) => {
-              if (!value?.skipLoadingCall) setLoading();
               patchState(
                 state as WritableStateSource<EntitiesFilterState<Filter>>,
                 {
@@ -210,6 +209,7 @@ export function withEntitiesRemoteFilter<
                 },
               );
               broadcast(state, entitiesFilterChanged(value));
+              if (!value?.skipLoadingCall) setLoading();
             }),
           ),
         );

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
@@ -182,8 +182,8 @@ export function withEntitiesRemoteSort<
             patchState(state as WritableStateSource<object>, {
               [sortKey]: sort,
             });
-            if (!skipLoadingCall) setLoading();
             broadcast(state, entitiesRemoteSortChanged({ sort }));
+            if (!skipLoadingCall) setLoading();
           },
         };
       }),


### PR DESCRIPTION
This small refactor fixes a bug causing the swithMap impl not cancel request when new setLoading are trigger.

Fixes #162