### PR TITLE
Fix/with calls skip when type

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -73,13 +73,10 @@ export type CallConfig<
    * A function with condition that determines whether the call should be skipped.
    * The function accepts the  call parameter and must return a boolean | Signal<boolean> | Observable<boolean>.
    */
-  skipWhen?:
-    | Call<NoInfer<Param>, boolean>
-    | (() => boolean)
-    | ((
-        param: NoInfer<Param>,
-        previousResult: NoInfer<Result> | undefined,
-      ) => boolean);
+  skipWhen?: (
+    param: NoInfer<Param>,
+    previousResult: NoInfer<Result> | undefined,
+  ) => boolean | Promise<boolean> | Observable<boolean>;
 
   /**
    * Reactively execute the call with the provided params.

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
@@ -600,16 +600,17 @@ describe('withCalls', () => {
         const Store = signalStore(
           withCalls(() => ({
             testCall: callConfig({
-              call: () => apiResponse.pipe(first()),
+              call: ({ id }: { id: string }) => apiResponse.pipe(first()),
               mapPipe: 'exhaustMap',
-              skipWhen: (param, previousResult) => previousResult === 'test',
+              skipWhen: ({ id }, previousResult) =>
+                id.length > 0 && previousResult === 'test',
             }),
           })),
         );
         const store = new Store();
         expect(store.isTestCallLoading()).toBeFalsy();
 
-        store.testCall();
+        store.testCall({ id: 'ss' });
         expect(store.isTestCallLoading()).toBeFalsy();
         apiResponse.next('test');
         expect(store.isTestCallLoaded()).toBeTruthy();

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -151,7 +151,7 @@ export function withCalls<
           ? Parameters<Calls[K]['call']> extends undefined[]
             ? () => void
             : {
-                (...param: Parameters<Calls[K]['call']>): void;
+                (param: Parameters<Calls[K]['call']>[0]): void;
                 (
                   param:
                     | Observable<Parameters<Calls[K]['call']>[0]>


### PR DESCRIPTION
skipWhen prop in call calll config was loosing the type for the params