### PR TITLE
feat(signals): improve log of errors for withCalls and others

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
@@ -418,6 +418,8 @@ describe('withCalls', () => {
   });
 
   it('returning an observable should update to error state when it errors', async () => {
+    const consoleError = jest.spyOn(console, 'error');
+    consoleError.mockReset();
     TestBed.runInInjectionContext(() => {
       const store = new Store();
       expect(store.isTestCallLoading()).toBeFalsy();
@@ -434,6 +436,7 @@ describe('withCalls', () => {
       expect(store.testCallResult()).toBe('test');
 
       expect(apiResponse.observed).toBe(false);
+      expect(consoleError).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -774,12 +777,15 @@ describe('withCalls', () => {
       });
     });
     it('Fail on a call should set status return error ', async () => {
+      const consoleError = jest.spyOn(console, 'error');
+      consoleError.mockReset();
       TestBed.runInInjectionContext(() => {
         const store = new Store();
         expect(store.privateIsTestCallLoading()).toBeFalsy();
         store.privateTestCall({ ok: false });
         expect(store.privateTestCallError()).toEqual(new Error('fail'));
         expect(store.privateTestCallResult()).toBe(undefined);
+        expect(consoleError).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -287,6 +287,11 @@ export function withCalls<
                                 call.mapError?.(error, params)) ||
                               error;
                             setError(e);
+                            console.error(
+                              `Call ${callName} fail `,
+                              { params },
+                              e,
+                            );
                             isCallConfig(call) &&
                               call.onError &&
                               call.onError(e, params);

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.spec.ts
@@ -175,6 +175,8 @@ describe('withEntitiesCalls', () => {
   });
 
   it('Fail on a call should set status return error ', async () => {
+    const consoleError = jest.spyOn(console, 'error');
+    consoleError.mockReset();
     TestBed.runInInjectionContext(() => {
       TestBed.runInInjectionContext(() => {
         const apiResponse = new Subject<{
@@ -214,6 +216,7 @@ describe('withEntitiesCalls', () => {
         );
         expect(store.loadProductDetailErrors()).toEqual([new Error('fail')]);
         expect(store.entityMap()[product.id].detail).toBe(undefined);
+        expect(consoleError).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
@@ -392,6 +392,11 @@ export function withEntitiesCalls<
                                     call.mapError?.(error, params)) ||
                                   error;
                                 setError(id, e);
+                                console.error(
+                                  `Call ${callName} fail `,
+                                  { params },
+                                  e,
+                                );
                                 isCallConfig(call) &&
                                   call.onError &&
                                   call.onError(e, params);

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.spec.ts
@@ -265,6 +265,8 @@ describe('withEntitiesLoadingCall', () => {
       }));
 
       it('should call setError and onError if fetchEntities call fails ', fakeAsync(() => {
+        const consoleError = jest.spyOn(console, 'error');
+        consoleError.mockReset();
         const onSuccess = jest.fn();
         const onError = jest.fn();
         TestBed.runInInjectionContext(() => {
@@ -290,6 +292,7 @@ describe('withEntitiesLoadingCall', () => {
           expect(store.error()).toEqual(new Error('fail'));
           expect(onError).toHaveBeenCalledWith(new Error('fail'));
           expect(onSuccess).not.toHaveBeenCalled();
+          expect(consoleError).toHaveBeenCalledTimes(1);
         });
       }));
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-loading-call/with-entities-loading-call.ts
@@ -2,6 +2,7 @@ import {
   computed,
   EnvironmentInjector,
   inject,
+  isDevMode,
   runInInjectionContext,
   Signal,
 } from '@angular/core';
@@ -256,6 +257,7 @@ export function withEntitiesLoadingCall<
               catchError((error: unknown) => {
                 const e = mapError ? mapError(error) : error;
                 setError(e);
+                console.error(`${collection ?? ''} fetchEntities fail `, e);
                 if (onError) onError(e as Error);
                 return of();
               }),

--- a/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.ts
@@ -61,7 +61,8 @@ export function withLogger<Input extends SignalStoreFeatureResult>({
                   if (!keys || keys.includes(key)) {
                     if (isSignal(store[key])) {
                       acc[key] = store[key]();
-                    } else {
+                    } else if (typeof store[key] != 'function') {
+                      // if not signal only log values that are not methods
                       acc[key] = store[key];
                     }
                   }


### PR DESCRIPTION
Log the error to console.error if in dev mode for withCalls withEntitiesLoading and withEntitiesCalls

Fix #184