### PR TITLE
fix(signals): fix callWith type when call has no params

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -90,15 +90,15 @@ export type CallConfig<
    * To override this behavior, define a skipWhen with your own rule or skipWhen: () => false
    * to always execute on any value.
    */
-  callWith?: Param extends Record<string, any> | string | number | boolean
-    ?
+  callWith?: Param extends undefined
+    ? Signal<boolean> | Observable<boolean> | (() => boolean) | boolean
+    :
         | NoInfer<Param>
         | null
         | undefined
         | Signal<NoInfer<Param | null | undefined>>
         | Observable<NoInfer<Param | null | undefined>>
-        | (() => NoInfer<Param> | null | undefined)
-    : Signal<boolean> | Observable<boolean> | (() => boolean) | boolean;
+        | (() => NoInfer<Param> | null | undefined);
 };
 
 export type ExtractCallResultPropName<

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.model.ts
@@ -96,15 +96,15 @@ export type EntityCallConfig<
    * To override this behavior, define a skipWhen with your own rule or skipWhen: () => false
    * to always execute on any value.
    */
-  callWith?: Param extends Record<string, any> | string | number | boolean
-    ?
+  callWith?: Param extends undefined
+    ? Signal<boolean> | Observable<boolean> | (() => boolean) | boolean
+    :
         | NoInfer<Param>
         | null
         | undefined
         | Signal<NoInfer<Param | null | undefined>>
         | Observable<NoInfer<Param | null | undefined>>
-        | (() => NoInfer<Param> | null | undefined)
-    : Signal<boolean> | Observable<boolean> | (() => boolean) | boolean;
+        | (() => NoInfer<Param> | null | undefined);
 };
 
 export type NamedEntitiesCallsStatusComputed<


### PR DESCRIPTION
callWith should accept true when the call has no params but was not working sometimes

Fix #188