### PR TITLE
feat(signals): add support to call entities methods with signals an o…

### DIFF
--- a/apps/example-app/src/app/examples/models/index.ts
+++ b/apps/example-app/src/app/examples/models/index.ts
@@ -5,6 +5,14 @@ export interface Product {
   price: number;
   categoryId?: string;
 }
+export type Category =
+  | 'snes'
+  | 'nes'
+  | 'gamecube'
+  | 'n64'
+  | 'wii'
+  | 'wiiu'
+  | 'switch';
 export interface ProductOrder extends Product {
   quantity?: number;
 }

--- a/apps/example-app/src/app/examples/services/mock-backend/product.handler.ts
+++ b/apps/example-app/src/app/examples/services/mock-backend/product.handler.ts
@@ -1,7 +1,7 @@
 import { sortData } from '@ngrx-traits/common';
 import { rest } from 'msw';
 
-import { Product, ProductDetail } from '../../models';
+import { Category, Product, ProductDetail } from '../../models';
 import { getRandomInteger } from '../../utils/form-utils';
 
 export const productHandlers = [
@@ -36,6 +36,7 @@ export const productHandlers = [
         search: req.url.searchParams.get('search'),
         sortColumn: req.url.searchParams.get('sortColumn'),
         sortAscending: req.url.searchParams.get('sortAscending'),
+        category: req.url.searchParams.get('category') as Category,
         skip: req.url.searchParams.get('skip'),
         take: req.url.searchParams.get('take'),
       };
@@ -45,6 +46,18 @@ export const productHandlers = [
             ? entity.name.toLowerCase().includes(options?.search.toLowerCase())
             : false;
         });
+
+      if (options?.category) {
+        const description =
+          options.category === 'snes'
+            ? 'Super Nintendo Game'
+            : options.category === 'gamecube'
+              ? 'GameCube Game'
+              : '';
+        result = mockProducts.filter((entity) => {
+          return options?.category ? entity.description === description : false;
+        });
+      }
       const total = result.length;
       if (options?.skip || options?.take) {
         const skip = +(options?.skip ?? 0);

--- a/apps/example-app/src/app/examples/services/product.service.ts
+++ b/apps/example-app/src/app/examples/services/product.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { delay } from 'rxjs/operators';
 
-import { Product, ProductDetail } from '../models';
+import { Category, Product, ProductDetail } from '../models';
 
 @Injectable({ providedIn: 'root' })
 export class ProductService {
@@ -14,13 +14,18 @@ export class ProductService {
     sortAscending?: boolean | undefined;
     skip?: number | undefined;
     take?: number | undefined;
+    category?: Category;
   }) {
     return this.httpClient
       .get<{
         resultList: Product[];
         total: number;
       }>('/products', {
-        params: { ...options, search: options?.search ?? '' },
+        params: {
+          ...options,
+          search: options?.search ?? '',
+          category: options?.category ?? '',
+        },
       })
       .pipe(delay(500));
   }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -1,5 +1,6 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from '@ngrx/signals';
+import { Observable } from 'rxjs';
 
 export type EntitiesFilterComputed<Filter> = {
   entitiesFilter: DeepSignal<Filter>;
@@ -10,39 +11,34 @@ export type NamedEntitiesFilterComputed<Collection extends string, Filter> = {
   [K in Collection as `is${Capitalize<string & K>}FilterChanged`]: Signal<boolean>;
 } & { [K in Collection as `${K}Filter`]: DeepSignal<Filter> };
 
+export type FilterOptions<Filter> =
+  | {
+      filter: Filter;
+      debounce?: number;
+      patch?: false | undefined;
+      forceLoad?: boolean;
+    }
+  | {
+      filter: Partial<Filter>;
+      debounce?: number;
+      patch: true;
+      forceLoad?: boolean;
+    };
 export type EntitiesFilterMethods<Filter> = {
   filterEntities: (
     options:
-      | {
-          filter: Filter;
-          debounce?: number;
-          patch?: false | undefined;
-          forceLoad?: boolean;
-        }
-      | {
-          filter: Partial<Filter>;
-          debounce?: number;
-          patch: true;
-          forceLoad?: boolean;
-        },
+      | FilterOptions<Filter>
+      | Observable<FilterOptions<Filter>>
+      | Signal<FilterOptions<Filter>>,
   ) => void;
   resetEntitiesFilter: () => void;
 };
 export type NamedEntitiesFilterMethods<Collection extends string, Filter> = {
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: (
     options:
-      | {
-          filter: Filter;
-          debounce?: number;
-          patch?: false | undefined;
-          forceLoad?: boolean;
-        }
-      | {
-          filter: Partial<Filter>;
-          debounce?: number;
-          patch: true;
-          forceLoad?: boolean;
-        },
+      | FilterOptions<Filter>
+      | Observable<FilterOptions<Filter>>
+      | Signal<FilterOptions<Filter>>,
   ) => void;
 } & {
   [K in Collection as `reset${Capitalize<string & K>}Filter`]: () => void;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -1,20 +1,14 @@
+import { Signal } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { FilterOptions } from './with-entities-local-filter.model';
+
 export type EntitiesRemoteFilterMethods<Filter> = {
   filterEntities: (
     options:
-      | {
-          filter: Filter;
-          debounce?: number;
-          patch?: false | undefined;
-          forceLoad?: boolean;
-          skipLoadingCall?: boolean;
-        }
-      | {
-          filter: Partial<Filter>;
-          debounce?: number;
-          patch: true;
-          forceLoad?: boolean;
-          skipLoadingCall?: boolean;
-        },
+      | (FilterOptions<Filter> & { skipLoadingCall?: boolean })
+      | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+      | Signal<FilterOptions<Filter> & { skipLoadingCall?: boolean }>,
   ) => void;
   resetEntitiesFilter: (options?: {
     debounce?: number;
@@ -28,20 +22,9 @@ export type NamedEntitiesRemoteFilterMethods<
 > = {
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: (
     options:
-      | {
-          filter: Filter;
-          debounce?: number;
-          patch?: false | undefined;
-          forceLoad?: boolean;
-          skipLoadingCall?: boolean;
-        }
-      | {
-          filter: Partial<Filter>;
-          debounce?: number;
-          patch: true;
-          forceLoad?: boolean;
-          skipLoadingCall?: boolean;
-        },
+      | (FilterOptions<Filter> & { skipLoadingCall?: boolean })
+      | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+      | Signal<FilterOptions<Filter> & { skipLoadingCall?: boolean }>,
   ) => void;
 } & {
   [K in Collection as `reset${Capitalize<string & K>}Filter`]: (options?: {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.model.ts
@@ -1,4 +1,5 @@
 import { Signal } from '@angular/core';
+import { Observable } from 'rxjs';
 
 export type EntitiesMultiSelectionState = {
   idsSelectedMap: Record<string | number, boolean>;
@@ -23,30 +24,39 @@ export type NamedEntitiesMultiSelectionComputed<
     'all' | 'none' | 'some'
   >;
 };
+type EntitySelectOptions =
+  | { id: string | number }
+  | { ids: (string | number)[] };
 export type EntitiesMultiSelectionMethods = {
   selectEntities: (
-    options: { id: string | number } | { ids: (string | number)[] },
+    options:
+      | (EntitySelectOptions & { clearSelectionBeforeSelect?: boolean })
+      | Observable<
+          EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }
+        >
+      | Signal<EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }>,
   ) => void;
-  deselectEntities: (
-    options: { id: string | number } | { ids: (string | number)[] },
-  ) => void;
-  toggleSelectEntities: (
-    options: { id: string | number } | { ids: (string | number)[] },
-  ) => void;
+  deselectEntities: (options: EntitySelectOptions) => void;
+  toggleSelectEntities: (options: EntitySelectOptions) => void;
   toggleSelectAllEntities: () => void;
   clearEntitiesSelection: () => void;
 };
 export type NamedEntitiesMultiSelectionMethods<Collection extends string> = {
   [K in Collection as `select${Capitalize<string & K>}Entities`]: (
-    options: { id: string | number } | { ids: (string | number)[] },
+    options:
+      | (EntitySelectOptions & { clearSelectionBeforeSelect?: boolean })
+      | Observable<
+          EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }
+        >
+      | Signal<EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }>,
   ) => void;
 } & {
   [K in Collection as `deselect${Capitalize<string & K>}Entities`]: (
-    options: { id: string | number } | { ids: (string | number)[] },
+    options: EntitySelectOptions,
   ) => void;
 } & {
   [K in Collection as `toggleSelect${Capitalize<string & K>}Entities`]: (
-    options: { id: string | number } | { ids: (string | number)[] },
+    options: EntitySelectOptions,
   ) => void;
 } & {
   [K in Collection as `toggleSelectAll${Capitalize<

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { patchState, signalStore, type, withState } from '@ngrx/signals';
 import { setAllEntities, withEntities } from '@ngrx/signals/entities';
 
@@ -15,73 +16,104 @@ describe('withEntitiesMultiSelection', () => {
       withEntitiesMultiSelection({ entity }),
     );
     it('selectEntities should select the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
-      expect(store.idsSelected()).toEqual(['4', '8']);
-      expect(store.entitiesSelected()).toEqual([
-        mockProducts[4],
-        mockProducts[8],
-      ]);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        expect(store.idsSelected()).toEqual(['4', '8']);
+        expect(store.entitiesSelected()).toEqual([
+          mockProducts[4],
+          mockProducts[8],
+        ]);
+      });
+    });
+
+    it('selectEntities with clearSelectionBeforeSelect should clear selectin and select the entities', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ ids: [mockProducts[1].id, mockProducts[5].id] });
+        store.selectEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+          clearSelectionBeforeSelect: true,
+        });
+        expect(store.idsSelected()).toEqual(['4', '8']);
+        expect(store.entitiesSelected()).toEqual([
+          mockProducts[4],
+          mockProducts[8],
+        ]);
+      });
     });
 
     it('deselectEntities should deselect the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
-      store.deselectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
-      expect(store.idsSelected()).toEqual([]);
-      expect(store.entitiesSelected()).toEqual([]);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        store.deselectEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        expect(store.idsSelected()).toEqual([]);
+        expect(store.entitiesSelected()).toEqual([]);
+      });
     });
 
     it('toggleSelectEntities should toggle selection of the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.toggleSelectEntities({ id: mockProducts[4].id });
-      expect(store.entitiesSelected()).toEqual([mockProducts[4]]);
-      expect(store.idsSelected()).toEqual(['4']);
-      store.toggleSelectEntities({ id: mockProducts[4].id });
-      expect(store.entitiesSelected()).toEqual([]);
-      expect(store.idsSelected()).toEqual([]);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.toggleSelectEntities({ id: mockProducts[4].id });
+        expect(store.entitiesSelected()).toEqual([mockProducts[4]]);
+        expect(store.idsSelected()).toEqual(['4']);
+        store.toggleSelectEntities({ id: mockProducts[4].id });
+        expect(store.entitiesSelected()).toEqual([]);
+        expect(store.idsSelected()).toEqual([]);
+      });
     });
 
     it('toggleSelectAllEntities should toggle selection of the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.toggleSelectAllEntities();
-      expect(store.entitiesSelected().length).toEqual(mockProducts.length);
-      expect(store.idsSelected().length).toEqual(mockProducts.length);
-      store.toggleSelectAllEntities();
-      expect(store.entitiesSelected()).toEqual([]);
-      expect(store.idsSelected()).toEqual([]);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.toggleSelectAllEntities();
+        expect(store.entitiesSelected().length).toEqual(mockProducts.length);
+        expect(store.idsSelected().length).toEqual(mockProducts.length);
+        store.toggleSelectAllEntities();
+        expect(store.entitiesSelected()).toEqual([]);
+        expect(store.idsSelected()).toEqual([]);
+      });
     });
 
     it('isAllEntitiesSelected should toggle selection of the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.toggleSelectAllEntities();
-      expect(store.isAllEntitiesSelected()).toEqual('all');
-      store.toggleSelectAllEntities();
-      expect(store.isAllEntitiesSelected()).toEqual('none');
-      store.toggleSelectEntities({ ids: mockProducts.map((p) => p.id) });
-      expect(store.isAllEntitiesSelected()).toEqual('all');
-      store.toggleSelectEntities({ id: mockProducts[4].id });
-      expect(store.isAllEntitiesSelected()).toEqual('some');
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.toggleSelectAllEntities();
+        expect(store.isAllEntitiesSelected()).toEqual('all');
+        store.toggleSelectAllEntities();
+        expect(store.isAllEntitiesSelected()).toEqual('none');
+        store.toggleSelectEntities({ ids: mockProducts.map((p) => p.id) });
+        expect(store.isAllEntitiesSelected()).toEqual('all');
+        store.toggleSelectEntities({ id: mockProducts[4].id });
+        expect(store.isAllEntitiesSelected()).toEqual('some');
+      });
     });
 
     it('cleanEntitiesSelected should clear selection', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.toggleSelectAllEntities();
-      expect(store.isAllEntitiesSelected()).toEqual('all');
-      store.clearEntitiesSelection();
-      expect(store.isAllEntitiesSelected()).toEqual('none');
-      store.toggleSelectEntities({ ids: mockProducts.map((p) => p.id) });
-      expect(store.isAllEntitiesSelected()).toEqual('all');
-      store.toggleSelectEntities({ id: mockProducts[4].id });
-      expect(store.isAllEntitiesSelected()).toEqual('some');
-      store.clearEntitiesSelection();
-      expect(store.isAllEntitiesSelected()).toEqual('none');
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.toggleSelectAllEntities();
+        expect(store.isAllEntitiesSelected()).toEqual('all');
+        store.clearEntitiesSelection();
+        expect(store.isAllEntitiesSelected()).toEqual('none');
+        store.toggleSelectEntities({ ids: mockProducts.map((p) => p.id) });
+        expect(store.isAllEntitiesSelected()).toEqual('all');
+        store.toggleSelectEntities({ id: mockProducts[4].id });
+        expect(store.isAllEntitiesSelected()).toEqual('some');
+        store.clearEntitiesSelection();
+        expect(store.isAllEntitiesSelected()).toEqual('none');
+      });
     });
   });
 
@@ -93,92 +125,104 @@ describe('withEntitiesMultiSelection', () => {
       withEntitiesMultiSelection({ entity, collection }),
     );
     it('select[Collection]Entities should select the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.selectProductsEntities({
-        ids: [mockProducts[4].id, mockProducts[8].id],
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.selectProductsEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        expect(store.productsIdsSelected()).toEqual(['4', '8']);
+        expect(store.productsEntitiesSelected()).toEqual([
+          mockProducts[4],
+          mockProducts[8],
+        ]);
       });
-      expect(store.productsIdsSelected()).toEqual(['4', '8']);
-      expect(store.productsEntitiesSelected()).toEqual([
-        mockProducts[4],
-        mockProducts[8],
-      ]);
     });
 
     it('defaultSelectedIds should select the entity', () => {
-      const Store = signalStore(
-        { protectedState: false },
-        withState({ myDefaultIds: [mockProducts[4].id, mockProducts[8].id] }),
-        withEntities({ entity, collection }),
-        withEntitiesMultiSelection(({ myDefaultIds }) => ({
-          entity,
-          collection,
-          defaultSelectedIds: myDefaultIds(),
-        })),
-      );
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      expect(store.productsIdsSelected()).toEqual(['4', '8']);
-      expect(store.productsEntitiesSelected()).toEqual([
-        mockProducts[4],
-        mockProducts[8],
-      ]);
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          { protectedState: false },
+          withState({ myDefaultIds: [mockProducts[4].id, mockProducts[8].id] }),
+          withEntities({ entity, collection }),
+          withEntitiesMultiSelection(({ myDefaultIds }) => ({
+            entity,
+            collection,
+            defaultSelectedIds: myDefaultIds(),
+          })),
+        );
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        expect(store.productsIdsSelected()).toEqual(['4', '8']);
+        expect(store.productsEntitiesSelected()).toEqual([
+          mockProducts[4],
+          mockProducts[8],
+        ]);
+      });
     });
 
     it('deselect[Collection]Entities should deselect the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.selectProductsEntities({
-        ids: [mockProducts[4].id, mockProducts[8].id],
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.selectProductsEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        store.deselectProductsEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        expect(store.productsEntitiesSelected()).toEqual([]);
+        expect(store.productsIdsSelected()).toEqual([]);
       });
-      store.deselectProductsEntities({
-        ids: [mockProducts[4].id, mockProducts[8].id],
-      });
-      expect(store.productsEntitiesSelected()).toEqual([]);
-      expect(store.productsIdsSelected()).toEqual([]);
     });
 
     it('toggle[Collection]Entities should toggle selection of the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.toggleSelectProductsEntities({ id: mockProducts[4].id });
-      expect(store.productsEntitiesSelected()).toEqual([mockProducts[4]]);
-      expect(store.productsIdsSelected()).toEqual(['4']);
-      store.toggleSelectProductsEntities({ id: mockProducts[4].id });
-      expect(store.productsEntitiesSelected()).toEqual([]);
-      expect(store.productsIdsSelected()).toEqual([]);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.toggleSelectProductsEntities({ id: mockProducts[4].id });
+        expect(store.productsEntitiesSelected()).toEqual([mockProducts[4]]);
+        expect(store.productsIdsSelected()).toEqual(['4']);
+        store.toggleSelectProductsEntities({ id: mockProducts[4].id });
+        expect(store.productsEntitiesSelected()).toEqual([]);
+        expect(store.productsIdsSelected()).toEqual([]);
+      });
     });
 
     it('isAll[Collection]Selected should toggle selection of the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.toggleSelectAllProductsEntities();
-      expect(store.isAllProductsSelected()).toEqual('all');
-      store.toggleSelectAllProductsEntities();
-      expect(store.isAllProductsSelected()).toEqual('none');
-      store.toggleSelectProductsEntities({
-        ids: mockProducts.map((p) => p.id),
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.toggleSelectAllProductsEntities();
+        expect(store.isAllProductsSelected()).toEqual('all');
+        store.toggleSelectAllProductsEntities();
+        expect(store.isAllProductsSelected()).toEqual('none');
+        store.toggleSelectProductsEntities({
+          ids: mockProducts.map((p) => p.id),
+        });
+        expect(store.isAllProductsSelected()).toEqual('all');
+        store.toggleSelectProductsEntities({ id: mockProducts[4].id });
+        expect(store.isAllProductsSelected()).toEqual('some');
       });
-      expect(store.isAllProductsSelected()).toEqual('all');
-      store.toggleSelectProductsEntities({ id: mockProducts[4].id });
-      expect(store.isAllProductsSelected()).toEqual('some');
     });
 
     it('clean[Collection]Selected should clear selection', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.toggleSelectAllProductsEntities();
-      expect(store.isAllProductsSelected()).toEqual('all');
-      store.clearProductsSelection();
-      expect(store.isAllProductsSelected()).toEqual('none');
-      store.toggleSelectProductsEntities({
-        ids: mockProducts.map((p) => p.id),
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.toggleSelectAllProductsEntities();
+        expect(store.isAllProductsSelected()).toEqual('all');
+        store.clearProductsSelection();
+        expect(store.isAllProductsSelected()).toEqual('none');
+        store.toggleSelectProductsEntities({
+          ids: mockProducts.map((p) => p.id),
+        });
+        expect(store.isAllProductsSelected()).toEqual('all');
+        store.toggleSelectProductsEntities({ id: mockProducts[4].id });
+        expect(store.isAllProductsSelected()).toEqual('some');
+        store.clearProductsSelection();
+        expect(store.isAllProductsSelected()).toEqual('none');
       });
-      expect(store.isAllProductsSelected()).toEqual('all');
-      store.toggleSelectProductsEntities({ id: mockProducts[4].id });
-      expect(store.isAllProductsSelected()).toEqual('some');
-      store.clearProductsSelection();
-      expect(store.isAllProductsSelected()).toEqual('none');
     });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
@@ -1,4 +1,5 @@
 import { Signal } from '@angular/core';
+import { Observable } from 'rxjs';
 
 export type EntitiesSingleSelectionState = {
   idSelected: string | number | undefined;
@@ -15,19 +16,36 @@ export type NamedEntitiesSingleSelectionComputed<
 > = {
   [K in Collection as `${K}EntitySelected`]: Signal<Entity | undefined>;
 };
+type EntitySelectOptions = { id: string | number } | undefined;
 export type EntitiesSingleSelectionMethods = {
-  selectEntity: (options: { id: string | number }) => void;
+  selectEntity: (
+    options:
+      | EntitySelectOptions
+      | Observable<EntitySelectOptions>
+      | Signal<EntitySelectOptions>,
+  ) => void;
   deselectEntity: () => void;
-  toggleSelectEntity: (options: { id: string | number }) => void;
+  toggleSelectEntity: (
+    options:
+      | EntitySelectOptions
+      | Observable<EntitySelectOptions>
+      | Signal<EntitySelectOptions>,
+  ) => void;
 };
 export type NamedEntitiesSingleSelectionMethods<Collection extends string> = {
-  [K in Collection as `select${Capitalize<string & K>}Entity`]: (options: {
-    id: string | number;
-  }) => void;
+  [K in Collection as `select${Capitalize<string & K>}Entity`]: (
+    options:
+      | EntitySelectOptions
+      | Observable<EntitySelectOptions>
+      | Signal<EntitySelectOptions>,
+  ) => void;
 } & {
   [K in Collection as `deselect${Capitalize<string & K>}Entity`]: () => void;
 } & {
-  [K in Collection as `toggleSelect${Capitalize<string & K>}Entity`]: (options: {
-    id: string | number;
-  }) => void;
+  [K in Collection as `toggleSelect${Capitalize<string & K>}Entity`]: (
+    options:
+      | EntitySelectOptions
+      | Observable<EntitySelectOptions>
+      | Signal<EntitySelectOptions>,
+  ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { patchState, signalStore, type, withState } from '@ngrx/signals';
 import { setAllEntities, withEntities } from '@ngrx/signals/entities';
 
@@ -16,42 +17,50 @@ describe('withEntitiesSingleSelection', () => {
     );
 
     it('selectEntity should select the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.selectEntity({ id: mockProducts[4].id });
-      expect(store.entitySelected()).toEqual(mockProducts[4]);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntity({ id: mockProducts[4].id });
+        expect(store.entitySelected()).toEqual(mockProducts[4]);
+      });
     });
 
     it('defaultSelectedId should select the entity', () => {
-      const Store = signalStore(
-        { protectedState: false },
-        withState({ myDefault: { id: mockProducts[4].id } }),
-        withEntities({ entity }),
-        withEntitiesSingleSelection(({ myDefault }) => ({
-          entity,
-          defaultSelectedId: myDefault().id,
-        })),
-      );
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      expect(store.entitySelected()).toEqual(mockProducts[4]);
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          { protectedState: false },
+          withState({ myDefault: { id: mockProducts[4].id } }),
+          withEntities({ entity }),
+          withEntitiesSingleSelection(({ myDefault }) => ({
+            entity,
+            defaultSelectedId: myDefault().id,
+          })),
+        );
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        expect(store.entitySelected()).toEqual(mockProducts[4]);
+      });
     });
 
     it('deselectEntity should deselect the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.selectEntity({ id: mockProducts[4].id });
-      store.deselectEntity();
-      expect(store.entitySelected()).toEqual(undefined);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntity({ id: mockProducts[4].id });
+        store.deselectEntity();
+        expect(store.entitySelected()).toEqual(undefined);
+      });
     });
 
     it('toggleEntity should toggle selection of the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts));
-      store.toggleSelectEntity({ id: mockProducts[4].id });
-      expect(store.entitySelected()).toEqual(mockProducts[4]);
-      store.toggleSelectEntity({ id: mockProducts[4].id });
-      expect(store.entitySelected()).toEqual(undefined);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.toggleSelectEntity({ id: mockProducts[4].id });
+        expect(store.entitySelected()).toEqual(mockProducts[4]);
+        store.toggleSelectEntity({ id: mockProducts[4].id });
+        expect(store.entitySelected()).toEqual(undefined);
+      });
     });
   });
 
@@ -63,27 +72,43 @@ describe('withEntitiesSingleSelection', () => {
       withEntitiesSingleSelection({ entity, collection }),
     );
     it('selectEntity should select the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.selectProductsEntity({ id: mockProducts[4].id });
-      expect(store.productsEntitySelected()).toEqual(mockProducts[4]);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.selectProductsEntity({ id: mockProducts[4].id });
+        expect(store.productsEntitySelected()).toEqual(mockProducts[4]);
+      });
+    });
+
+    it('selectEntity with undefined should deselect the entity', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.selectProductsEntity({ id: mockProducts[4].id });
+        store.selectProductsEntity(undefined);
+        expect(store.productsEntitySelected()).toEqual(undefined);
+      });
     });
 
     it('deselectEntity should deselect the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.selectProductsEntity({ id: mockProducts[4].id });
-      store.deselectProductsEntity();
-      expect(store.productsEntitySelected()).toEqual(undefined);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.selectProductsEntity({ id: mockProducts[4].id });
+        store.deselectProductsEntity();
+        expect(store.productsEntitySelected()).toEqual(undefined);
+      });
     });
 
     it('toggleEntity should toggle selection of the entity', () => {
-      const store = new Store();
-      patchState(store, setAllEntities(mockProducts, { collection }));
-      store.toggleSelectProductsEntity({ id: mockProducts[4].id });
-      expect(store.productsEntitySelected()).toEqual(mockProducts[4]);
-      store.toggleSelectProductsEntity({ id: mockProducts[4].id });
-      expect(store.productsEntitySelected()).toEqual(undefined);
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts, { collection }));
+        store.toggleSelectProductsEntity({ id: mockProducts[4].id });
+        expect(store.productsEntitySelected()).toEqual(mockProducts[4]);
+        store.toggleSelectProductsEntity({ id: mockProducts[4].id });
+        expect(store.productsEntitySelected()).toEqual(undefined);
+      });
     });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
@@ -1,3 +1,6 @@
+import { Signal } from '@angular/core';
+import { Observable } from 'rxjs';
+
 export type SortDirection = 'asc' | 'desc' | '';
 export type Sort<Entity> = {
   /** The id of the column being sorted. */
@@ -13,10 +16,18 @@ export type NamedEntitiesSortState<Entity, Collection extends string> = {
   [K in Collection as `${K}Sort`]: Sort<Entity>;
 };
 export type EntitiesSortMethods<Entity> = {
-  sortEntities: (options?: { sort: Sort<Entity> }) => void;
+  sortEntities: (
+    options?:
+      | { sort: Sort<Entity> }
+      | Observable<{ sort: Sort<Entity> }>
+      | Signal<{ sort: Sort<Entity> }>,
+  ) => void;
 };
 export type NamedEntitiesSortMethods<Entity, Collection extends string> = {
-  [K in Collection as `sort${Capitalize<string & K>}Entities`]: (options?: {
-    sort: Sort<Entity>;
-  }) => void;
+  [K in Collection as `sort${Capitalize<string & K>}Entities`]: (
+    options?:
+      | { sort: Sort<Entity> }
+      | Observable<{ sort: Sort<Entity> }>
+      | Signal<{ sort: Sort<Entity> }>,
+  ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.spec.ts
@@ -35,47 +35,49 @@ const mockProducts = mockProductsOld.map(
 describe('withEntitiesLocalSort', () => {
   const entity = type<ProductWithReleaseDate>();
   it('should sort entities and store sort', () => {
-    const Store = signalStore(
-      { protectedState: false },
-      withEntities({
-        entity,
-      }),
-      withEntitiesLocalSort({
-        entity,
-        defaultSort: { field: 'name', direction: 'asc' },
-      }),
-    );
-    const store = new Store();
-    patchState(store, setAllEntities(mockProducts));
-    expect(store.entitiesSort()).toEqual({ field: 'name', direction: 'asc' });
-    // check default sort
-    store.sortEntities();
-    expect(
-      store
-        .entities()
-        .map((e) => e.name)
-        .slice(0, 5),
-    ).toEqual([
-      '1080° Avalanche',
-      'Animal Crossing',
-      'Arkanoid: Doh it Again',
-      'Battalion Wars',
-      'BattleClash',
-    ]);
-    // sort by price
-    store.sortEntities({
-      sort: { field: 'price', direction: 'desc' },
-    });
-    expect(
-      store
-        .entities()
-        .map((e) => e.price)
-        .slice(0, 5),
-    ).toEqual([178, 175, 172, 169, 166]);
-    expect(store.entities().length).toEqual(mockProducts.length);
-    expect(store.entitiesSort()).toEqual({
-      field: 'price',
-      direction: 'desc',
+    TestBed.runInInjectionContext(() => {
+      const Store = signalStore(
+        { protectedState: false, providedIn: 'root' },
+        withEntities({
+          entity,
+        }),
+        withEntitiesLocalSort({
+          entity,
+          defaultSort: { field: 'name', direction: 'asc' },
+        }),
+      );
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      expect(store.entitiesSort()).toEqual({ field: 'name', direction: 'asc' });
+      // check default sort
+      store.sortEntities();
+      expect(
+        store
+          .entities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+      // sort by price
+      store.sortEntities({
+        sort: { field: 'price', direction: 'desc' },
+      });
+      expect(
+        store
+          .entities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.entities().length).toEqual(mockProducts.length);
+      expect(store.entitiesSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
     });
   });
 
@@ -99,37 +101,39 @@ describe('withEntitiesLocalSort', () => {
         defaultSort: { field: 'name', direction: 'asc' },
       }),
     );
-    const store = new Store();
-    patchState(store, setAllEntities(mockProductsCustom, config));
-    expect(store.entitiesSort()).toEqual({ field: 'name', direction: 'asc' });
-    // check default sort
-    store.sortEntities();
-    expect(
-      store
-        .entities()
-        .map((e) => e.name)
-        .slice(0, 5),
-    ).toEqual([
-      '1080° Avalanche',
-      'Animal Crossing',
-      'Arkanoid: Doh it Again',
-      'Battalion Wars',
-      'BattleClash',
-    ]);
-    // sort by price
-    store.sortEntities({
-      sort: { field: 'price', direction: 'desc' },
-    });
-    expect(
-      store
-        .entities()
-        .map((e) => e.price)
-        .slice(0, 5),
-    ).toEqual([178, 175, 172, 169, 166]);
-    expect(store.entities().length).toEqual(mockProducts.length);
-    expect(store.entitiesSort()).toEqual({
-      field: 'price',
-      direction: 'desc',
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProductsCustom, config));
+      expect(store.entitiesSort()).toEqual({ field: 'name', direction: 'asc' });
+      // check default sort
+      store.sortEntities();
+      expect(
+        store
+          .entities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+      // sort by price
+      store.sortEntities({
+        sort: { field: 'price', direction: 'desc' },
+      });
+      expect(
+        store
+          .entities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.entities().length).toEqual(mockProducts.length);
+      expect(store.entitiesSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
     });
   });
 
@@ -147,37 +151,39 @@ describe('withEntitiesLocalSort', () => {
         defaultSort: { field: 'name', direction: 'asc' },
       }),
     );
-    const store = new Store();
-    patchState(store, setAllEntities(mockProducts, { collection }));
-    expect(store.productsSort()).toEqual({ field: 'name', direction: 'asc' });
-    // check default sort
-    store.sortProductsEntities();
-    expect(
-      store
-        .productsEntities()
-        .map((e) => e.name)
-        .slice(0, 5),
-    ).toEqual([
-      '1080° Avalanche',
-      'Animal Crossing',
-      'Arkanoid: Doh it Again',
-      'Battalion Wars',
-      'BattleClash',
-    ]);
-    // sort by price
-    store.sortProductsEntities({
-      sort: { field: 'price', direction: 'desc' },
-    });
-    expect(
-      store
-        .productsEntities()
-        .map((e) => e.price)
-        .slice(0, 5),
-    ).toEqual([178, 175, 172, 169, 166]);
-    expect(store.productsEntities().length).toEqual(mockProducts.length);
-    expect(store.productsSort()).toEqual({
-      field: 'price',
-      direction: 'desc',
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts, { collection }));
+      expect(store.productsSort()).toEqual({ field: 'name', direction: 'asc' });
+      // check default sort
+      store.sortProductsEntities();
+      expect(
+        store
+          .productsEntities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+      // sort by price
+      store.sortProductsEntities({
+        sort: { field: 'price', direction: 'desc' },
+      });
+      expect(
+        store
+          .productsEntities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.productsEntities().length).toEqual(mockProducts.length);
+      expect(store.productsSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
     });
   });
 
@@ -202,37 +208,41 @@ describe('withEntitiesLocalSort', () => {
         defaultSort: { field: 'name', direction: 'asc' },
       }),
     );
-    const store = new Store();
-    patchState(store, setAllEntities(mockProductsCustom, config));
-    expect(store.productsSort()).toEqual({ field: 'name', direction: 'asc' });
-    // check default sort
-    store.sortProductsEntities();
-    expect(
-      store
-        .productsEntities()
-        .map((e) => e.name)
-        .slice(0, 5),
-    ).toEqual([
-      '1080° Avalanche',
-      'Animal Crossing',
-      'Arkanoid: Doh it Again',
-      'Battalion Wars',
-      'BattleClash',
-    ]);
-    // sort by price
-    store.sortProductsEntities({
-      sort: { field: 'price', direction: 'desc' },
-    });
-    expect(
-      store
-        .productsEntities()
-        .map((e) => e.price)
-        .slice(0, 5),
-    ).toEqual([178, 175, 172, 169, 166]);
-    expect(store.productsEntities().length).toEqual(mockProductsCustom.length);
-    expect(store.productsSort()).toEqual({
-      field: 'price',
-      direction: 'desc',
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProductsCustom, config));
+      expect(store.productsSort()).toEqual({ field: 'name', direction: 'asc' });
+      // check default sort
+      store.sortProductsEntities();
+      expect(
+        store
+          .productsEntities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+      // sort by price
+      store.sortProductsEntities({
+        sort: { field: 'price', direction: 'desc' },
+      });
+      expect(
+        store
+          .productsEntities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.productsEntities().length).toEqual(
+        mockProductsCustom.length,
+      );
+      expect(store.productsSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
     });
   });
 
@@ -545,46 +555,48 @@ describe('withEntitiesLocalSort', () => {
         defaultSort: { field: 'releaseDate', direction: 'desc' },
       }),
     );
-    const store = new Store();
-    patchState(store, setAllEntities(mockProducts));
-    expect(store.entitiesSort()).toEqual({
-      field: 'releaseDate',
-      direction: 'desc',
-    });
-    // check default sort
-    store.sortEntities();
-    expect(
-      store
-        .entities()
-        .map((e) => e.releaseDate.toDateString())
-        .slice(0, 5),
-    ).toEqual([
-      'Fri Jun 28 2137',
-      'Thu Jun 28 2136',
-      'Tue Jun 28 2135',
-      'Mon Jun 28 2134',
-      'Sun Jun 28 2133',
-    ]);
-    // sort by price
-    store.sortEntities({
-      sort: { field: 'releaseDate', direction: 'asc' },
-    });
-    expect(
-      store
-        .entities()
-        .map((e) => e.releaseDate.toDateString())
-        .slice(0, 5),
-    ).toEqual([
-      'Tue Jun 28 2016',
-      'Wed Jun 28 2017',
-      'Thu Jun 28 2018',
-      'Fri Jun 28 2019',
-      'Sun Jun 28 2020',
-    ]);
-    expect(store.entities().length).toEqual(mockProducts.length);
-    expect(store.entitiesSort()).toEqual({
-      field: 'releaseDate',
-      direction: 'asc',
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      expect(store.entitiesSort()).toEqual({
+        field: 'releaseDate',
+        direction: 'desc',
+      });
+      // check default sort
+      store.sortEntities();
+      expect(
+        store
+          .entities()
+          .map((e) => e.releaseDate.toDateString())
+          .slice(0, 5),
+      ).toEqual([
+        'Fri Jun 28 2137',
+        'Thu Jun 28 2136',
+        'Tue Jun 28 2135',
+        'Mon Jun 28 2134',
+        'Sun Jun 28 2133',
+      ]);
+      // sort by price
+      store.sortEntities({
+        sort: { field: 'releaseDate', direction: 'asc' },
+      });
+      expect(
+        store
+          .entities()
+          .map((e) => e.releaseDate.toDateString())
+          .slice(0, 5),
+      ).toEqual([
+        'Tue Jun 28 2016',
+        'Wed Jun 28 2017',
+        'Thu Jun 28 2018',
+        'Fri Jun 28 2019',
+        'Sun Jun 28 2020',
+      ]);
+      expect(store.entities().length).toEqual(mockProducts.length);
+      expect(store.entitiesSort()).toEqual({
+        field: 'releaseDate',
+        direction: 'asc',
+      });
     });
   });
 
@@ -612,46 +624,48 @@ describe('withEntitiesLocalSort', () => {
         },
       }),
     );
-    const store = new Store();
-    patchState(store, setAllEntities(mockProducts));
-    expect(store.entitiesSort()).toEqual({
-      field: 'sortBySecondWordInName',
-      direction: 'desc',
-    });
-    // check default sort
-    store.sortEntities();
-    expect(
-      store
-        .entities()
-        .map((e) => e.name)
-        .slice(0, 5),
-    ).toEqual([
-      'Pokémon XD: Gale of Darkness',
-      'Wario World',
-      "Wario's Woods",
-      'Battalion Wars',
-      'Uniracers',
-    ]);
-    // sort by price
-    store.sortEntities({
-      sort: { field: 'sortBySecondWordInName', direction: 'asc' },
-    });
-    expect(
-      store
-        .entities()
-        .map((e) => e.name)
-        .slice(0, 5),
-    ).toEqual([
-      'Mario & Wario',
-      'Tetris & Dr. Mario',
-      'Tetris 2',
-      'Pikmin 2',
-      'Kirby Air Ride',
-    ]);
-    expect(store.entities().length).toEqual(mockProducts.length);
-    expect(store.entitiesSort()).toEqual({
-      field: 'sortBySecondWordInName',
-      direction: 'asc',
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      expect(store.entitiesSort()).toEqual({
+        field: 'sortBySecondWordInName',
+        direction: 'desc',
+      });
+      // check default sort
+      store.sortEntities();
+      expect(
+        store
+          .entities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        'Pokémon XD: Gale of Darkness',
+        'Wario World',
+        "Wario's Woods",
+        'Battalion Wars',
+        'Uniracers',
+      ]);
+      // sort by price
+      store.sortEntities({
+        sort: { field: 'sortBySecondWordInName', direction: 'asc' },
+      });
+      expect(
+        store
+          .entities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        'Mario & Wario',
+        'Tetris & Dr. Mario',
+        'Tetris 2',
+        'Pikmin 2',
+        'Kirby Air Ride',
+      ]);
+      expect(store.entities().length).toEqual(mockProducts.length);
+      expect(store.entitiesSort()).toEqual({
+        field: 'sortBySecondWordInName',
+        direction: 'asc',
+      });
     });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.model.ts
@@ -1,17 +1,42 @@
+import { Signal } from '@angular/core';
+import { Observable } from 'rxjs';
+
 import { Sort } from './with-entities-local-sort.model';
 
 export type EntitiesRemoteSortMethods<Entity> = {
-  sortEntities: (options?: {
-    sort: Sort<Entity>;
-    skipLoadingCall?: boolean;
-  }) => void;
+  sortEntities: (
+    options?:
+      | {
+          sort: Sort<Entity>;
+          skipLoadingCall?: boolean;
+        }
+      | Observable<{
+          sort: Sort<Entity>;
+          skipLoadingCall?: boolean;
+        }>
+      | Signal<{
+          sort: Sort<Entity>;
+          skipLoadingCall?: boolean;
+        }>,
+  ) => void;
 };
 export type NamedEntitiesRemoteSortMethods<
   Entity,
   Collection extends string,
 > = {
-  [K in Collection as `sort${Capitalize<string & K>}Entities`]: (options?: {
-    sort: Sort<Entity>;
-    skipLoadingCall?: boolean;
-  }) => void;
+  [K in Collection as `sort${Capitalize<string & K>}Entities`]: (
+    options?:
+      | {
+          sort: Sort<Entity>;
+          skipLoadingCall?: boolean;
+        }
+      | Observable<{
+          sort: Sort<Entity>;
+          skipLoadingCall?: boolean;
+        }>
+      | Signal<{
+          sort: Sort<Entity>;
+          skipLoadingCall?: boolean;
+        }>,
+  ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-input-bindings/with-input-bindings.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-input-bindings/with-input-bindings.spec.ts
@@ -1,9 +1,6 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { callConfig, withCalls } from '@ngrx-traits/signals';
-import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
-import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { of, pipe, tap } from 'rxjs';
+import { signalStore } from '@ngrx/signals';
 
 import { withInputBindings } from './with-input-bindings';
 
@@ -32,16 +29,18 @@ describe('withInputBindings', () => {
   );
 
   it('should initialize state with inputs', () => {
-    const store = new Store();
-    expect(store.pageIndex()).toBe(0);
-    expect(store.length()).toBe(0);
-    expect(store.pageSize()).toBe(10);
-    expect(store.pageSizeOptions()).toEqual([5, 10, 20]);
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      expect(store.pageIndex()).toBe(0);
+      expect(store.length()).toBe(0);
+      expect(store.pageSize()).toBe(10);
+      expect(store.pageSizeOptions()).toEqual([5, 10, 20]);
+    });
   });
 
   it('should pass components inputs to the store and any updates', () => {
-    const store = new Store();
     TestBed.runInInjectionContext(() => {
+      const store = new Store();
       const component = new PaginatorComponent(store);
       TestBed.flushEffects();
       expect(store.pageIndex()).toBe(3);


### PR DESCRIPTION
feat(signals): add support to call entities methods with signals an observables

This allows to some of the methods of the entities stores to be called with signals and observables by making them use rxMethod

Fix #192