### PR TITLE
Allow filterEntities to force reapply the previous filter

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
@@ -75,6 +75,44 @@ describe('withEntitiesHybridFilter', () => {
       });
     }));
 
+    it('should filter without params should reapply filter', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.filterEntities({
+          filter: { search: 'zero', categoryId: 'snes' },
+        });
+        expect(store.entities().length).toEqual(mockProducts.length);
+        tick(400);
+        patchState(store, setAllEntities(mockProducts));
+        expect(store.entities().length).toEqual(mockProducts.length);
+        store.filterEntities();
+        tick(400);
+        expect(store.entities().length).toEqual(2);
+        expect(store.entities()).toEqual([
+          {
+            description: 'Super Nintendo Game',
+            id: '1',
+            name: 'F-Zero',
+            price: 12,
+            categoryId: 'snes',
+          },
+          {
+            description: 'GameCube Game',
+            id: '80',
+            name: 'F-Zero GX',
+            price: 55,
+            categoryId: 'gamecube',
+          },
+        ]);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'snes',
+        });
+        expect(store.entitiesFilter.search()).toEqual('zero');
+      });
+    }));
+
     it('should allow to set default filter from previous state', fakeAsync(() => {
       TestBed.runInInjectionContext(() => {
         const Store = signalStore(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -26,7 +26,7 @@ export type FilterOptions<Filter> =
     };
 export type EntitiesFilterMethods<Filter> = {
   filterEntities: (
-    options:
+    options?:
       | FilterOptions<Filter>
       | Observable<FilterOptions<Filter>>
       | Signal<FilterOptions<Filter>>,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
@@ -64,6 +64,42 @@ describe('withEntitiesLocalFilter', () => {
     });
   }));
 
+  it('should filter without params should reapply filter', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      expect(store.entities().length).toEqual(mockProducts.length);
+      store.filterEntities({
+        filter: { search: 'zero', foo: 'bar2' },
+        debounce: 0,
+      });
+      tick(400);
+      patchState(store, setAllEntities(mockProducts));
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      store.filterEntities();
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entities()).toEqual([
+        {
+          description: 'Super Nintendo Game',
+          id: '1',
+          name: 'F-Zero',
+          price: 12,
+          categoryId: 'snes',
+        },
+        {
+          description: 'GameCube Game',
+          id: '80',
+          name: 'F-Zero GX',
+          price: 55,
+          categoryId: 'gamecube',
+        },
+      ]);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      expect(store.entitiesFilter.search()).toEqual('zero');
+    });
+  }));
+
   it('should allow to set default filter from previous state', fakeAsync(() => {
     TestBed.runInInjectionContext(() => {
       const Store = signalStore(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -5,7 +5,7 @@ import { FilterOptions } from './with-entities-local-filter.model';
 
 export type EntitiesRemoteFilterMethods<Filter> = {
   filterEntities: (
-    options:
+    options?:
       | (FilterOptions<Filter> & { skipLoadingCall?: boolean })
       | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
       | Signal<FilterOptions<Filter> & { skipLoadingCall?: boolean }>,


### PR DESCRIPTION
feat(signals): allow filterEntities to force reapply the previous filter
    
    Now calling filterEntities without params will force apply the previous filter
    
    Fix #194