### PR TITLE
Feat/with sync improvements

### DIFF
--- a/apps/docs/src/app/pages/docs/getting-started/working-with-entities.md
+++ b/apps/docs/src/app/pages/docs/getting-started/working-with-entities.md
@@ -114,11 +114,7 @@ export const Store = signalStore(
         patchState(store, setAllEntities(res.resultList, productsEntityConfig));
         // force resort and refilter
         store.sortProductsEntities();
-        store.filterProductsEntities({
-          filter: store.productsFilter(),
-          debounce: 0,
-          forceLoad: true,
-        });
+        store.filterProductsEntities();
       },
     }),
   })),

--- a/apps/docs/src/app/pages/docs/traits/with-entities-local-filter.md
+++ b/apps/docs/src/app/pages/docs/traits/with-entities-local-filter.md
@@ -57,6 +57,7 @@ The second way is where there is no submit button, and the filter is connected t
     placeholder="Search"
     (input)="store.filterUsersEmtities({ filter:{ search: $event.target.value }, patch: true })"
 ```
+If you manually changed the entities and want to reapply the filter you can call the filter entities method without any param to reapply the last filter
 
 ### Mixing with other local store features
 You can mix this feature with other local store features like withEntitiesLocalSort, withEntitiesLocalPagination, etc. 

--- a/apps/docs/src/app/pages/docs/traits/with-entities-local-sort.md
+++ b/apps/docs/src/app/pages/docs/traits/with-entities-local-sort.md
@@ -45,6 +45,7 @@ To use you generally need either a sort dropdown if is a list or a table where c
 />
 ... show products list
 ```
+If you manually changed the entities and want to reapply the sort you can call the sort entities method without any param to reapply the last sort
 
 ### Mixing with other local store features
 You can mix this feature with other local store features like withEntitiesLocalFilter, withEntitiesLocalPagination, etc.

--- a/apps/docs/src/app/pages/docs/traits/with-sync-to-web-storage.md
+++ b/apps/docs/src/app/pages/docs/traits/with-sync-to-web-storage.md
@@ -70,6 +70,57 @@ const store = signalStore(
   }),
 );
 ```
+
+### Splitting the state in multiple store keys
+You can add withSyncToWebStorage multiple times with different keys, this can be useful if you are creating your own store features and each has a withSyncToWebStorage, or you need to split the state in two keys.
+
+```typescript
+import { signalStoreFeature } from '@ngrx/signals';
+
+// two custom store features, each with its own withSyncToWebStorage and key
+function withProductsList() {
+  const productsEntityConfig = entityConfig({
+    entity: type<Product>(),
+    collection: 'products',
+  });
+  return signalStoreFeature(
+    // following are not required, just an example it can have anything
+    withEntities(productsEntityConfig),
+    withCallStatus(productsEntityConfig),
+    withSyncToWebStorage({
+      key: 'my-products',
+      type: 'session',
+      restoreOnInit: true,
+      saveStateChangesAfterMs: 300,
+      expires: 1000 * 60 * 60 * 12, // 12 hours
+    }),
+  );
+}
+function withOrderList() {
+  const ordersEntityConfig = entityConfig({
+    entity: type<Order>(),
+    collection: 'orders',
+  });
+  return signalStoreFeature(
+    // following are not required, just an example it can have anything
+    withEntities(ordersEntityConfig),
+    withCallStatus(ordersEntityConfig),
+    withSyncToWebStorage({
+      key: 'my-orders',
+      type: 'session',
+      restoreOnInit: true,
+      saveStateChangesAfterMs: 300,
+      expires: 1000 * 60 * 60 * 12, // 12 hours
+    }),
+  );
+}
+const store = signalStore(
+  // using then will store each slice of state in its 
+  // own store key
+  withProductsList(),
+  withOrderList()
+  );
+```
 ## API Reference
 
 This trait receives and object to allow specific configurations:

--- a/libs/ngrx-traits/signals/src/lib/util.ts
+++ b/libs/ngrx-traits/signals/src/lib/util.ts
@@ -19,3 +19,60 @@ export function toMap(a: Array<string | number>) {
 export function insertIf<T>(condition: any, getElement: () => T): [T] {
   return (condition ? [getElement()] : []) as [T];
 }
+
+export type OverridableFunction = {
+  (...args: any[]): void;
+  impl?: (...args: unknown[]) => void;
+};
+
+export function combineFunctions(
+  previous?: OverridableFunction,
+  next?: (...args: any[]) => void,
+): OverridableFunction {
+  if (previous && !next) {
+    return previous;
+  }
+  const previousImplementation = previous?.impl;
+  const fun: OverridableFunction =
+    previous ??
+    ((...args: any[]) => {
+      fun.impl?.(...args);
+    });
+  fun.impl = next
+    ? (...args: any[]) => {
+        previousImplementation?.(...args);
+        next(...args);
+      }
+    : undefined;
+  return fun;
+}
+
+/**
+ * Combines the implementation of a function defined in the store with
+ * a new implementation of the same type
+ * the resulting call will execute both functions when called,
+ * @param param
+ * @param store
+ */
+export function combineFunctionsInObject<
+  T extends Record<string | symbol, Function | undefined>,
+>(param: T, store: Record<string | symbol, unknown>): T {
+  const replaceProps = (
+    acc: Record<string | symbol, Function>,
+    key: string | symbol,
+  ) => {
+    let value = param[key];
+    value = combineFunctions(
+      store[key] as OverridableFunction,
+      value as (...args: any[]) => void,
+    );
+    if (!store[key]) acc[key] = value;
+    return acc;
+  };
+  let result = Object.keys(param).reduce(
+    replaceProps,
+    {} as Record<string | symbol, Function>,
+  );
+  result = Object.getOwnPropertySymbols(param).reduce(replaceProps, result);
+  return result as T;
+}

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -953,4 +953,32 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       queryParamsHandling: 'merge',
     });
   }));
+
+  it('should not restore state from query params on init  if restoreOnInit is false', () => {
+    const Store = signalStore(
+      localStoreFeature(),
+      withEntitiesSyncToRouteQueryParams({ entity, restoreOnInit: false }),
+    );
+    const { store } = init({
+      Store,
+      queryParams: {
+        filter: JSON.stringify({ search: 'foo', foo: 'bar' }),
+        sortBy: 'description',
+        sortDirection: 'desc',
+      },
+    });
+    expect(store.entitiesFilter()).not.toEqual({ search: 'foo', foo: 'bar' });
+
+    expect(store.entitiesSort()).not.toEqual({
+      field: 'description',
+      direction: 'desc',
+    });
+    store.loadFromQueryParams();
+    expect(store.entitiesFilter()).toEqual({ search: 'foo', foo: 'bar' });
+
+    expect(store.entitiesSort()).toEqual({
+      field: 'description',
+      direction: 'desc',
+    });
+  });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
@@ -107,6 +107,7 @@ export function withEntitiesSyncToRouteQueryParams<
   prefix?: string | false;
   onQueryParamsLoaded?: (store: StoreSource<Input>) => void;
   defaultDebounce?: number;
+  restoreOnInit?: boolean;
 }): SignalStoreFeature<
   Input &
     (Collection extends ''
@@ -122,7 +123,13 @@ export function withEntitiesSyncToRouteQueryParams<
             NamedCallStatusComputed<Collection, Error>;
           methods: NamedCallStatusMethods<Collection, Error>;
         }),
-  EmptyFeatureResult
+  {
+    state: {};
+    props: {};
+    methods: {
+      loadFromQueryParams: () => void;
+    };
+  }
 > {
   const mappers = [
     getQueryMapperForEntitiesPagination(config),
@@ -146,13 +153,14 @@ export function withEntitiesSyncToRouteQueryParams<
             getQueryMapperWithPrefix({ prefix: prefixString, mapper }),
           )
         : mappers,
+      restoreOnInit: config?.restoreOnInit ?? true,
     }),
     withHooks((store) => {
       return {
         onInit: () => {
           if (config?.onQueryParamsLoaded) {
-            const loading = store[loadingKey] as unknown as  Signal<boolean>;
-            const loaded = store[loadedKey] as unknown as  Signal<boolean>;
+            const loading = store[loadingKey] as unknown as Signal<boolean>;
+            const loaded = store[loadedKey] as unknown as Signal<boolean>;
             const loaded$ = toObservable(loaded);
             toObservable(loading)
               .pipe(


### PR DESCRIPTION
   feat(signals): improved withSync store features
    
    - Added restoreOnInit prop to withSyncToRouteQueryParams withEntitiesSyncToRouteQueryParams to have more granular control when loading the url params
    - Small refactor to withSyncToWebStorage to allow it be multiple times in the store with different
    key
    
    Fix #199