### PR TITLE
fix(signals): fix withEntitiesCalls callStatus type

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.spec.ts
@@ -108,31 +108,43 @@ describe('withEntitiesCalls', () => {
         },
       };
       expect(store.isLoadProductDetailLoading(product.id)).toBeFalsy();
+      expect(store.loadProductDetailCallStatus()[product.id] === 'init');
       store.loadProductDetail({ entity: product, is: 'test' });
       expect(store.isLoadProductDetailLoading(product.id)).toBeTruthy();
+      expect(store.loadProductDetailCallStatus()[product.id] === 'loading');
       apiResponse.next(productWithDetail);
       expect(store.isLoadProductDetailLoaded(product.id)).toBeTruthy();
+      expect(store.loadProductDetailCallStatus()[product.id] === 'loaded');
       expect(store.entityMap()[product.id]).toEqual(productWithDetail);
 
       expect(store.isLoadProductDetail2Loading(product2.id)).toBeFalsy();
+      expect(store.loadProductDetail2CallStatus()[product.id] === 'init');
       store.loadProductDetail2({ entity: product2, b: 'test' });
       expect(store.isLoadProductDetail2Loading(product2.id)).toBeTruthy();
+      expect(store.loadProductDetail2CallStatus()[product.id] === 'loading');
       apiResponse2.next(productWithDetail2);
       expect(store.isLoadProductDetail2Loaded(product2.id)).toBeTruthy();
+      expect(store.loadProductDetail2CallStatus()[product.id] === 'loaded');
       expect(store.entityMap()[product2.id]).toEqual(productWithDetail2);
 
       expect(store.isLoadProductDetail3Loading(product3.id)).toBeFalsy();
+      expect(store.loadProductDetail3CallStatus()[product.id] === 'init');
       store.loadProductDetail3(product3);
       expect(store.isLoadProductDetail3Loading(product3.id)).toBeTruthy();
+      expect(store.loadProductDetail3CallStatus()[product.id] === 'loading');
       apiResponse3.next(productWithDetail3);
       expect(store.isLoadProductDetail3Loaded(product3.id)).toBeTruthy();
+      expect(store.loadProductDetail3CallStatus()[product.id] === 'loaded');
       expect(store.entityMap()[product3.id]).toEqual(productWithDetail3);
 
       expect(store.isLoadProductDetail4Loading(product4.id)).toBeFalsy();
+      expect(store.loadProductDetail4CallStatus()[product.id] === 'init');
       store.loadProductDetail4(product4.id);
       expect(store.isLoadProductDetail4Loading(product4.id)).toBeTruthy();
+      expect(store.loadProductDetail4CallStatus()[product.id] === 'loading');
       apiResponse4.next(productWithDetail4);
       expect(store.isLoadProductDetail4Loaded(product4.id)).toBeTruthy();
+      expect(store.loadProductDetail4CallStatus()[product.id] === 'loaded');
       expect(store.entityMap()[product4.id]).toEqual(productWithDetail4);
     });
   });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
@@ -46,6 +46,7 @@ import { filter } from 'rxjs/operators';
 
 import { getWithEntitiesKeys, insertIf } from '../util';
 import { registerCallState } from '../with-all-call-status/with-all-call-status.util';
+import { NamedCallStatusMapState } from '../with-call-status-map/with-call-status-map.model';
 import {
   CallStatus,
   NamedCallStatusState,
@@ -152,7 +153,7 @@ export function withEntitiesCalls<
           methods: {};
         }),
   {
-    state: NamedCallStatusState<keyof Calls & string>;
+    state: NamedCallStatusMapState<keyof Calls & string>;
     props: NamedEntitiesCallsStatusComputed<Calls>;
     methods: NamedEntitiesCallsStatusMethods<Entity, Calls> & {
       [K in keyof Calls]: Calls[K] extends (...args: infer P) => any


### PR DESCRIPTION
change withEntitiesCalls to use NamedCallStatusMapState instead of NamedCallStatusState

Fix #212