### PR TITLE
feat(signals): allow withLogger to sort the state props alphabetically

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.spec.ts
@@ -160,4 +160,67 @@ describe('withLogger', () => {
       'color: green',
     );
   });
+
+  it('should sort properties alphabetically when no filter is defined', () => {
+    jest.resetAllMocks();
+    const Store = signalStore(
+      { providedIn: 'root', protectedState: false },
+      withState(() => ({ zebra: 1, apple: 2, banana: 3 })),
+      withComputed(({ zebra, apple }) => ({
+        computed1: computed(() => zebra() + apple()),
+      })),
+      withLogger({ name: 'Store' }),
+    );
+
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {
+      /* Empty */
+    });
+    TestBed.inject(Store);
+    TestBed.flushEffects();
+
+    // Extract the logged object to check key order
+    const loggedObject = consoleLog.mock.calls[0][1];
+    const keys = Object.keys(loggedObject);
+
+    // Keys should be sorted alphabetically
+    expect(keys).toEqual(['apple', 'banana', 'computed1', 'zebra']);
+    expect(loggedObject).toEqual({
+      apple: 2,
+      banana: 3,
+      computed1: 3,
+      zebra: 1,
+    });
+  });
+
+  it('should not sort properties when array filter is used', () => {
+    jest.resetAllMocks();
+    const Store = signalStore(
+      { providedIn: 'root', protectedState: false },
+      withState(() => ({ zebra: 1, apple: 2, banana: 3 })),
+      withComputed(({ zebra, apple }) => ({
+        computed1: computed(() => zebra() + apple()),
+      })),
+      withLogger({
+        name: 'Store',
+        filter: ['zebra', 'apple'],
+      }),
+    );
+
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {
+      /* Empty */
+    });
+    TestBed.inject(Store);
+    TestBed.flushEffects();
+
+    // Extract the logged object to check key order
+    const loggedObject = consoleLog.mock.calls[0][1];
+    const keys = Object.keys(loggedObject);
+
+    // Keys should maintain the original order from the filter array
+    expect(keys).toEqual(['zebra', 'apple']);
+    expect(loggedObject).toEqual({
+      zebra: 1,
+      apple: 2,
+    });
+  });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.ts
@@ -54,9 +54,9 @@ export function withLogger<Input extends SignalStoreFeatureResult>({
     type<Input>(),
     withHooks({
       onInit(store) {
-        function evaluateSignals(source: any, keys?: string[]) {
+        function evaluateSignals(source: any, keys?: string[], sort?: boolean) {
           return typeof source === 'object'
-            ? Object.keys(source).reduce(
+            ? (sort ? Object.keys(source).sort() : Object.keys(source)).reduce(
                 (acc, key) => {
                   if (!keys || keys.includes(key)) {
                     if (isSignal(store[key])) {
@@ -75,7 +75,7 @@ export function withLogger<Input extends SignalStoreFeatureResult>({
 
         const signalsComputed = computed(() => {
           return !filter
-            ? evaluateSignals(store)
+            ? evaluateSignals(store, undefined, true)
             : typeof filter === 'function'
               ? evaluateSignals(
                   filter(
@@ -88,7 +88,6 @@ export function withLogger<Input extends SignalStoreFeatureResult>({
         effect(() => {
           const state = signalsComputed();
           console.log(`${name} store changed: `, state);
-
           if (showDiff && lastState)
             deepDiff(`${name} store changes diff :`, lastState, state);
           lastState = state;


### PR DESCRIPTION
feat(signals): allow withLogger to sort the state props alphabeticaly if no filter is defined

fix #214