### PR TITLE
feat(signals): add skipLoadingCall parameter to withEntitiesSyncToRouteQueryParams

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
+++ b/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
@@ -71,14 +71,15 @@ export const ProductsRemoteStore = signalStore(
 ## API Reference
 
 
-| Property            | Description                                                                        | Value                                        |
-|---------------------|------------------------------------------------------------------------------------|----------------------------------------------|
-| entity              | The entity type                                                                    | `type<T>()`                                  |
-| collection          | The name of the collection. Optional                                               | string                                       |
-| prefix              | Prefix for the url query params to avoid conflicts with query param                | string. Default to the collection value      |
-| filterMapper        | Configure how the entities filter is serialize to and from the query params        | FilterQueryMapper<Filter>                    |
-| onQueryParamsLoaded | Callback to execute something else when the query params are loaded from the store | `(store) => void`                            |
-| defaultDebounce     | Debounce time for each call to the filter                                          | `(entity: T, filter: FilterType )=> boolean` |
+| Property            | Description                                                                                                                                       | Value                                        |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
+| entity              | The entity type                                                                                                                                   | `type<T>()`                                  |
+| collection          | The name of the collection. Optional                                                                                                              | string                                       |
+| prefix              | Prefix for the url query params to avoid conflicts with query param                                                                               | string. Default to the collection value      |
+| filterMapper        | Configure how the entities filter is serialize to and from the query params                                                                       | FilterQueryMapper<Filter>                    |
+| onQueryParamsLoaded | Callback to execute something else when the query params are loaded from the store                                                                | `(store) => void`                            |
+| defaultDebounce     | Debounce time for syncing store changes back to the route query params                                                                            | number (milliseconds)                        |
+| skipLoadingCall     | When true, restoring state from query params will update the store state but will not trigger a backend call to fetch entities. Default: false | boolean                                      |
 
 ## State
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -88,6 +88,7 @@ export type FilterQueryMapper<Filter, T extends Params = Params> = {
 export function getQueryMapperForEntitiesFilter<Filter>(config?: {
   collection?: string;
   filterMapper?: FilterQueryMapper<Filter>;
+  skipLoadingCall?: boolean;
 }): QueryMapper<
   typeof config extends { filterMapper: FilterQueryMapper<infer T> }
     ? T
@@ -109,6 +110,7 @@ export function getQueryMapperForEntitiesFilter<Filter>(config?: {
         filterEntities({
           filter,
           forceLoad: true,
+          skipLoadingCall: config?.skipLoadingCall,
         });
       }
     },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
@@ -9,10 +9,8 @@ import {
   props,
 } from '../with-event-handler/with-event-handler.util';
 import { QueryMapper } from '../with-sync-to-route-query-params/with-sync-to-route-query-params.util';
-import {
-  EntitiesPaginationLocalMethods,
-  EntitiesPaginationLocalState,
-} from './with-entities-local-pagination.model';
+import { EntitiesPaginationLocalState } from './with-entities-local-pagination.model';
+import { EntitiesPaginationRemoteMethods } from './with-entities-remote-pagination.model';
 
 export function getWithEntitiesLocalPaginationKeys(config?: {
   collection?: string;
@@ -46,6 +44,7 @@ export function getWithEntitiesLocalPaginationEvents(config?: {
 
 export function getQueryMapperForEntitiesPagination(config?: {
   collection?: string;
+  skipLoadingCall?: boolean;
 }): QueryMapper<{
   page: string;
 }> {
@@ -61,7 +60,7 @@ export function getQueryMapperForEntitiesPagination(config?: {
       if (page) {
         const loadEntitiesPage = store[
           loadEntitiesPageKey
-        ] as EntitiesPaginationLocalMethods['loadEntitiesPage'];
+        ] as EntitiesPaginationRemoteMethods<unknown>['loadEntitiesPage'];
         const loading = store[loadingKey] as Signal<boolean>;
         const loaded = store[loadedKey] as Signal<boolean>;
         const loaded$ = toObservable(loaded);
@@ -75,6 +74,7 @@ export function getQueryMapperForEntitiesPagination(config?: {
           .subscribe(() => {
             loadEntitiesPage({
               pageIndex: +page - 1,
+              skipLoadingCall: config?.skipLoadingCall,
             });
           });
       }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-remote-pagination.model.ts
@@ -1,12 +1,9 @@
-import { Signal } from '@angular/core';
+import { DeepSignal } from '@ngrx/signals';
 
 import {
-  EntitiesPaginationLocalMethods,
-  NamedEntitiesPaginationLocalMethods,
   NamedSetEntitiesResult,
   SetEntitiesResult,
 } from './with-entities-local-pagination.model';
-import { DeepSignal } from '@ngrx/signals';
 
 export type PaginationState = {
   currentPage: number;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.util.ts
@@ -93,6 +93,7 @@ export function getWithEntitiesLocalSortEvents(config?: {
 }
 export function getQueryMapperForEntitiesSort(config?: {
   collection?: string;
+  skipLoadingCall?: boolean;
 }): QueryMapper<{
   sortBy: string;
   sortDirection: string;
@@ -109,6 +110,7 @@ export function getQueryMapperForEntitiesSort(config?: {
         ] as EntitiesRemoteSortMethods<unknown>['sortEntities'];
         sortEntities({
           sort: { field: sortBy, direction: sortDirection as 'asc' | 'desc' },
+          skipLoadingCall: config?.skipLoadingCall,
         });
       }
     },

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
@@ -48,6 +48,7 @@ import { QueryMapper } from './with-sync-to-route-query-params.util';
  * @param config.prefix The prefix to use for the query params. If set to false, the prefix will be disabled.
  * @param config.onQueryParamsLoaded A function to be called when the query params are loaded into the store, (only gets called once).
  * @param config.defaultDebounce The default debounce time to use sync the store changes back to the route query params.
+ * @param config.skipLoadingCall When true, restoring state from query params will update the store state but will not trigger a backend call to fetch entities. Default is false.
  *
  * @example
  * export const ProductsRemoteStore = signalStore(
@@ -108,6 +109,7 @@ export function withEntitiesSyncToRouteQueryParams<
   onQueryParamsLoaded?: (store: StoreSource<Input>) => void;
   defaultDebounce?: number;
   restoreOnInit?: boolean;
+  skipLoadingCall?: boolean;
 }): SignalStoreFeature<
   Input &
     (Collection extends ''
@@ -132,9 +134,19 @@ export function withEntitiesSyncToRouteQueryParams<
   }
 > {
   const mappers = [
-    getQueryMapperForEntitiesPagination(config),
-    getQueryMapperForEntitiesSort(config),
-    getQueryMapperForEntitiesFilter(config),
+    getQueryMapperForEntitiesPagination({
+      collection: config?.collection,
+      skipLoadingCall: config?.skipLoadingCall ?? false,
+    }),
+    getQueryMapperForEntitiesSort({
+      collection: config?.collection,
+      skipLoadingCall: config?.skipLoadingCall ?? false,
+    }),
+    getQueryMapperForEntitiesFilter({
+      collection: config?.collection,
+      filterMapper: config?.filterMapper,
+      skipLoadingCall: config?.skipLoadingCall ?? false,
+    }),
     getQueryMapperForSingleSelection(config),
   ];
   const prefixString =


### PR DESCRIPTION


Add optional skipLoadingCall parameter that allows restoring state from query params without triggering backend calls. When set to true, filter, sort, and pagination state will be updated in the store without calling fetchEntities.

This is useful when entities are already loaded, or when you want to defer
  API calls until after initialization logic completes.

Fix #216