### PR TITLE
fix(signals): extract child route params in withRouteParams

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-route-params/with-route-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-route-params/with-route-params.spec.ts
@@ -1,5 +1,6 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { ActivatedRoute, provideRouter, Router } from '@angular/router';
 import { signalStore } from '@ngrx/signals';
 import { of } from 'rxjs';
 
@@ -43,5 +44,128 @@ describe('withRouteParams', () => {
     expect(store.foo()).toBe('foo2');
     expect(store.bar()).toBe(true);
     expect(store.data()).toEqual({ x: 1 });
+  });
+
+  describe('child route params', () => {
+    @Component({ template: '', standalone: true })
+    class ParentComponent {}
+
+    @Component({ template: '', standalone: true })
+    class ChildComponent {}
+
+    it('should extract params from child routes when store is provided at parent level', async () => {
+      const Store = signalStore(
+        withRouteParams((params) => ({
+          parentParam: params['parentParam'],
+          childParam: params['childParam'],
+        })),
+      );
+
+      TestBed.configureTestingModule({
+        providers: [
+          Store,
+          provideRouter([
+            {
+              path: ':parentParam',
+              component: ParentComponent,
+              children: [
+                {
+                  path: ':childParam',
+                  component: ChildComponent,
+                },
+              ],
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const store = TestBed.inject(Store);
+
+      await router.navigate(['/parent123', 'child456']);
+
+      expect(store.parentParam()).toBe('parent123');
+      expect(store.childParam()).toBe('child456');
+    });
+
+    it('should give precedence to deeper child route params over parent params with same name', async () => {
+      const Store = signalStore(
+        withRouteParams((params) => ({
+          id: params['id'],
+        })),
+      );
+
+      TestBed.configureTestingModule({
+        providers: [
+          Store,
+          provideRouter([
+            {
+              path: ':id',
+              component: ParentComponent,
+              children: [
+                {
+                  path: ':id',
+                  component: ChildComponent,
+                },
+              ],
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const store = TestBed.inject(Store);
+
+      await router.navigate(['/parent-id', 'child-id']);
+
+      // Child route param should take precedence
+      expect(store.id()).toBe('child-id');
+    });
+
+    it('should extract params from multiple nested child routes', async () => {
+      @Component({ template: '', standalone: true })
+      class GrandChildComponent {}
+
+      const Store = signalStore(
+        withRouteParams((params) => ({
+          level1: params['level1'],
+          level2: params['level2'],
+          level3: params['level3'],
+        })),
+      );
+
+      TestBed.configureTestingModule({
+        providers: [
+          Store,
+          provideRouter([
+            {
+              path: ':level1',
+              component: ParentComponent,
+              children: [
+                {
+                  path: ':level2',
+                  component: ChildComponent,
+                  children: [
+                    {
+                      path: ':level3',
+                      component: GrandChildComponent,
+                    },
+                  ],
+                },
+              ],
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const store = TestBed.inject(Store);
+
+      await router.navigate(['/first', 'second', 'third']);
+
+      expect(store.level1()).toBe('first');
+      expect(store.level2()).toBe('second');
+      expect(store.level3()).toBe('third');
+    });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-route-params/with-route-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-route-params/with-route-params.ts
@@ -1,7 +1,8 @@
 import { computed, inject, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Params } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot, NavigationEnd, Params, Router } from '@angular/router';
 import { signalStoreFeature, withComputed } from '@ngrx/signals';
+import { filter, map, startWith } from 'rxjs/operators';
 
 /**
  * This store feature provides access to the route params. The mapParams receives the route params object, use it to transform it
@@ -24,18 +25,54 @@ import { signalStoreFeature, withComputed } from '@ngrx/signals';
  *   })),
  * );
  */
+/**
+ * Recursively extracts route parameters from the current route and all its children.
+ * Parameters from deeper child routes take precedence over parent route parameters.
+ */
+function extractRouteParams(route: ActivatedRouteSnapshot): Params {
+  return route.children.reduce(
+    (params, childRoute) => ({ ...params, ...extractRouteParams(childRoute) }),
+    { ...route.params }
+  );
+}
+
 export function withRouteParams<T extends Record<string, any>>(
   mapParams: (params: Params, data?: any) => T,
 ) {
   return signalStoreFeature(
     withComputed(() => {
       const activatedRoute = inject(ActivatedRoute);
-      const paramsSignal = toSignal(activatedRoute.params);
+      const router = inject(Router);
+
+      // Fallback to direct params observable if router events don't provide snapshot
+      const directParamsSignal = toSignal(activatedRoute.params);
+
+      // Listen to router events and extract params from the entire route tree
+      const paramsSignal = toSignal(
+        router.events.pipe(
+          filter((event) => event instanceof NavigationEnd),
+          startWith(null),
+          map(() => {
+            // If snapshot is not available, return null to use fallback
+            if (!activatedRoute.snapshot) {
+              return null;
+            }
+            let route = activatedRoute.snapshot;
+            // Navigate to the root of the route tree
+            while (route.parent) {
+              route = route.parent;
+            }
+            // Extract params from all child routes
+            return extractRouteParams(route);
+          })
+        )
+      );
+
       const dataSignal = activatedRoute.data
         ? toSignal(activatedRoute.data)
         : undefined;
       const params = computed(() =>
-        mapParams(paramsSignal() ?? {}, dataSignal?.()),
+        mapParams(paramsSignal() ?? directParamsSignal() ?? {}, dataSignal?.()),
       );
       const computedParams = {} as any;
       Object.keys(params()).forEach((key) => {


### PR DESCRIPTION
  Previously, withRouteParams only captured params from the current ActivatedRoute,
  missing child route parameters when the store was provided at parent level.

  Now recursively extracts params from entire route tree using router events,
  with deeper child params taking precedence over parent params.

  Fixes #154