### PR TITLE
feat(signals): add valueMapper support to withSyncToWebStorage

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.util.ts
@@ -1,0 +1,7 @@
+export type StorageValueMapper<
+  T,
+  Store extends Record<string, any> = Record<string, any>,
+> = {
+  storageValueToState: (query: T, store: Store) => void;
+  stateToStorageValue: (store: Store) => T | undefined | null;
+};


### PR DESCRIPTION
  Add a new valueMapper option that enables custom bidirectional transformation
  between store state and storage values. This provides more flexibility than
  filterState by allowing users to transform data format before saving and
  reconstruct state when loading.