### PR TITLE
refactor(signals): convert valueMapper to factory function in withSyncToWebStorage

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-sync-to-web-storage.md
+++ b/apps/docs/src/app/pages/docs/traits/with-sync-to-web-storage.md
@@ -95,12 +95,12 @@ const store = signalStore(
     restoreOnInit: true,
     saveStateChangesAfterMs: 500,
     // Only save and restore userName and email from userProfile, not preferences or tempData
-    valueMapper: {
-      stateToStorageValue: (store) => ({
+    valueMapper: (store) => ({
+      stateToStorageValue: () => ({
         userName: store.userProfile().userName,
         email: store.userProfile().email,
       }),
-      storageValueToState: (savedData, store) => {
+      storageValueToState: (savedData) => {
         patchState(store, {
           userProfile: {
             ...store.userProfile(),
@@ -109,7 +109,7 @@ const store = signalStore(
           }
         });
       },
-    },
+    }),
   }),
 );
 ```
@@ -183,10 +183,19 @@ This trait receives an object to allow specific configurations:
 
 ### StorageValueMapper<T, Store>
 
+The `valueMapper` is a factory function that receives the store and returns an object with two methods:
+
+```typescript
+valueMapper: (store: Store) => {
+  stateToStorageValue: () => T | undefined | null;
+  storageValueToState: (value: T) => void;
+}
+```
+
 | Property              | Description                                           | Type                           |
 |-----------------------|-------------------------------------------------------|--------------------------------|
-| stateToStorageValue   | Function to transform store state to storage value   | (store: Store) => T \| undefined \| null |
-| storageValueToState   | Function to transform storage value back to state    | (value: T, store: Store) => void        |
+| stateToStorageValue   | Function to transform store state to storage value   | () => T \| undefined \| null |
+| storageValueToState   | Function to transform storage value back to state    | (value: T) => void        |
 
 ## State
 No extra state generated

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.spec.ts
@@ -384,12 +384,12 @@ describe('withSyncToWebStorage', () => {
             restoreOnInit: false,
             saveStateChangesAfterMs: 0,
             // Only save userName and email from userProfile
-            valueMapper: {
-              stateToStorageValue: (store) => ({
+            valueMapper: (store) => ({
+              stateToStorageValue: () => ({
                 userName: store.userProfile().userName,
                 email: store.userProfile().email,
               }),
-              storageValueToState: (savedData, store) => {
+              storageValueToState: (savedData) => {
                 patchState(store, {
                   userProfile: {
                     ...store.userProfile(),
@@ -398,7 +398,7 @@ describe('withSyncToWebStorage', () => {
                   },
                 });
               },
-            },
+            }),
           }),
         );
         const store = new Store();
@@ -467,12 +467,12 @@ describe('withSyncToWebStorage', () => {
             type: 'session',
             restoreOnInit: false,
             saveStateChangesAfterMs: 0,
-            valueMapper: {
-              stateToStorageValue: (store) => ({
+            valueMapper: (store) => ({
+              stateToStorageValue: () => ({
                 userName: store.userProfile().userName,
                 email: store.userProfile().email,
               }),
-              storageValueToState: (savedData, store) => {
+              storageValueToState: (savedData) => {
                 patchState(store, {
                   userProfile: {
                     ...store.userProfile(),
@@ -481,7 +481,7 @@ describe('withSyncToWebStorage', () => {
                   },
                 });
               },
-            },
+            }),
           }),
         );
         const store = new Store();
@@ -541,12 +541,12 @@ describe('withSyncToWebStorage', () => {
             restoreOnInit: false,
             saveStateChangesAfterMs: 0,
             onRestore,
-            valueMapper: {
-              stateToStorageValue: (store) => ({
+            valueMapper: (store) => ({
+              stateToStorageValue: () => ({
                 userName: store.userProfile().userName,
                 email: store.userProfile().email,
               }),
-              storageValueToState: (savedData, store) => {
+              storageValueToState: (savedData) => {
                 patchState(store, {
                   userProfile: {
                     ...store.userProfile(),
@@ -555,7 +555,7 @@ describe('withSyncToWebStorage', () => {
                   },
                 });
               },
-            },
+            }),
           }),
         );
         const store = new Store();
@@ -605,12 +605,12 @@ describe('withSyncToWebStorage', () => {
             type: 'local',
             restoreOnInit: false,
             saveStateChangesAfterMs: 1000,
-            valueMapper: {
-              stateToStorageValue: (store) => ({
+            valueMapper: (store) => ({
+              stateToStorageValue: () => ({
                 userName: store.userProfile().userName,
                 email: store.userProfile().email,
               }),
-              storageValueToState: (savedData, store) => {
+              storageValueToState: (savedData) => {
                 patchState(store, {
                   userProfile: {
                     ...store.userProfile(),
@@ -619,7 +619,7 @@ describe('withSyncToWebStorage', () => {
                   },
                 });
               },
-            },
+            }),
           }),
         );
         const store = new Store();

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.util.ts
@@ -1,7 +1,7 @@
 export type StorageValueMapper<
   T,
   Store extends Record<string, any> = Record<string, any>,
-> = {
-  storageValueToState: (query: T, store: Store) => void;
-  stateToStorageValue: (store: Store) => T | undefined | null;
+> = (store: Store) => {
+  storageValueToState: (value: T) => void;
+  stateToStorageValue: () => T | undefined | null;
 };


### PR DESCRIPTION

  Convert valueMapper from object to factory function pattern for better
  flexibility and cleaner API. The factory receives the store and returns
  the mapper object, allowing methods to access store through closure.

Fix #223