### PR TITLE
Feat/ extract store feature output type

### DIFF
--- a/apps/docs/src/app/components/side-navigation/side-navigation.component.ts
+++ b/apps/docs/src/app/components/side-navigation/side-navigation.component.ts
@@ -319,6 +319,10 @@ export class SideNavigationComponent {
       title: 'Utils',
       links: [
         {
+          link: './utils/extract-store-feature-output',
+          name: 'ExtractStoreFeatureOutput',
+        },
+        {
           link: './utils/rename-collection',
           name: 'Rename Collection Schematic',
         },

--- a/apps/docs/src/app/pages/docs/utils/extract-store-feature-output.md
+++ b/apps/docs/src/app/pages/docs/utils/extract-store-feature-output.md
@@ -1,0 +1,190 @@
+---
+name: ExtractStoreFeatureOutput
+order: 1
+---
+
+# ExtractStoreFeatureOutput
+
+A TypeScript utility type that extracts the output type from a custom `signalStoreFeature` function. Essential when splitting large signal stores into multiple features.
+
+## The Problem
+There are going to be cases where you will want to split your NgRx `signalStore` into multiple [custom store features](https://ngrx.io/guide/signals/signal-store/custom-store-features) for better organization and reusability or simply you hit the maximum limit of 10 parameters the signalStore function has.
+ One tricky part of splitting a store into multiple features is when you need to create a store feature that depends on the output of previous features, because you need to create an input interface that represents all the state props or methods your feature depends on, and this can be cumbersome to find all the right types which sometimes are created on the fly by TS or belong to third party libs like ngrx-traits or ngrx-toolkit.
+ `ExtractStoreFeatureOutput` is a type utility that solves this problem by extracting the output type of store features so it can easily be reused as input for other store features.
+
+## Example of the problem
+
+The following is not complex enough that it needs to be split into multiple features, but we are going to intentionally split it a complex way to demonstrate how much the `ExtractStoreFeatureOutput` helps.
+
+The store bellow represent a simple product store that loads a list of products from server with filtering, pagination, sorting and selection capabilities, and also load product detail by id.
+```typescript
+const productEntityConfig = entityConfig({
+  entity: type<Product>(),
+  collection: 'product',
+});
+
+export const ProductStore = signalStore(
+  withEntities(productEntityConfig),
+  withCallStatus({
+    ...productEntityConfig,
+    initialValue: 'loading',
+    errorType: type<string>(),
+  }),
+  withEntitiesRemoteFilter({
+    ...productEntityConfig,
+    defaultFilter: { search: '' },
+  }),
+  withEntitiesRemotePagination({
+    ...productEntityConfig,
+    pageSize: 10,
+  }),
+  withEntitiesRemoteSort({
+    ...productEntityConfig,
+    defaultSort: { field: 'name', direction: 'asc' },
+  }),
+  withEntitiesSingleSelection(productEntityConfig),
+  // load list of products from server
+  withEntitiesLoadingCall(
+    (
+      {
+        productEntitiesPagedRequest,
+        productEntitiesFilter,
+        productEntitiesSort,
+      },
+      service = inject(ProductService),
+    ) => ({
+      ...productEntityConfig,
+      fetchEntities: async () => {
+        const query = {
+          search: productEntitiesFilter().search,
+          skip: productEntitiesPagedRequest().startIndex,
+          take: productEntitiesPagedRequest().size,
+          sortAscending: productEntitiesSort().direction === 'asc',
+          sortColumn: productEntitiesSort().field,
+        };
+        const source = cacheRxCall({
+          key: ['products', query],
+          call: service.getProducts(query),
+          maxCacheSize: 5,
+        });
+        const res = await lastValueFrom(source);
+        return { entities: res.resultList, total: res.total };
+      },
+      mapError: (error) => (error as Error).message,
+    }),
+  ),
+  // load product detail by id
+  withCalls((store, service = inject(ProductService)) => ({
+    loadProductDetail: ({ id }: { id: string }) =>
+      cacheRxCall({
+        key: ['products', id],
+        call: service.getProductDetail(id),
+        maxCacheSize: 3,
+      }),
+  })),
+);
+```
+
+Now let's split the above store into multiple features, in this case the first part will be withProductEntities, which will have all the store features related to the state of the product entities and the second part withProductsCalls which will have all the store features that make calls to the backend.
+
+First withProductEntities.ts :
+```typescript
+export const productEntityConfig = entityConfig({
+  entity: type<Product>(),
+  collection: 'product',
+});
+
+export function withProductEntities() {
+  return signalStoreFeature(
+    withEntities(productEntityConfig),
+    withCallStatus({
+      ...productEntityConfig,
+      initialValue: 'loading',
+      errorType: type<string>(),
+    }),
+    withEntitiesRemoteFilter({
+      ...productEntityConfig,
+      defaultFilter: { search: '' },
+    }),
+    withEntitiesRemotePagination({
+      ...productEntityConfig,
+      pageSize: 10,
+    }),
+    withEntitiesRemoteSort({
+      ...productEntityConfig,
+      defaultSort: { field: 'name', direction: 'asc' },
+    }),
+    withEntitiesSingleSelection(productEntityConfig),
+  );
+}
+// Now we can extract the output type of withProductEntities feature
+export type ProductEntitiesStoreFeature = ExtractStoreFeatureOutput<
+  typeof withProductEntities
+>;
+```
+Notice above how we extracted the output type  of the withProductEntities feature.
+
+Now we can create withProductsCalls.ts feature.
+```typescript
+export function withProductCalls() {
+  return signalStoreFeature(
+    /// notice here we use the ProductEntitiesStoreFeature, as input type
+    type<ProductEntitiesStoreFeature>(),
+    withEntitiesLoadingCall(
+      (
+        {
+          productEntitiesPagedRequest,
+          productEntitiesFilter,
+          productEntitiesSort,
+        },
+        service = inject(ProductService),
+      ) => ({
+        ...productEntityConfig,
+        fetchEntities: async () => {
+          const query = {
+            search: productEntitiesFilter().search,
+            skip: productEntitiesPagedRequest().startIndex,
+            take: productEntitiesPagedRequest().size,
+            sortAscending: productEntitiesSort().direction === 'asc',
+            sortColumn: productEntitiesSort().field,
+          };
+          const source = cacheRxCall({
+            key: ['products', query],
+            call: service.getProducts(query),
+            maxCacheSize: 5,
+          });
+          const res = await lastValueFrom(source);
+          return { entities: res.resultList, total: res.total };
+        },
+        mapError: (error) => (error as Error).message,
+      }),
+    ),
+    withCalls((store, service = inject(ProductService)) => ({
+      loadProductDetail: ({ id }: { id: string }) =>
+        cacheRxCall({
+          key: ['products', id],
+          call: service.getProductDetail(id),
+          maxCacheSize: 3,
+        }),
+    })),
+  );
+}
+```
+
+And finally we can compose the final ProductStore:
+```typescript
+export const ProductStore = signalStore(
+  withProductEntities(),
+  withProductCalls(),
+);
+```
+
+## More complex example
+You can find a more complex example in the github repo [here](
+https://github.com/gabrielguerrero/ngrx-traits/tree/main/apps/example-app/src/app/examples/signals/product-shop-page)
+## Key Points
+
+- Wrap your `signalStoreFeature` in a function to use with `typeof`
+- The extracted type includes all state, props, and methods from combined features
+- Use `type<ExtractedType>()` as first argument to dependent `signalStoreFeature`
+- Enables full type inference and autocompletion in factory functions

--- a/apps/example-app/src/app/examples/signals/product-shop-page/products-shop.store.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/products-shop.store.ts
@@ -1,203 +1,26 @@
-import { inject } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { Product, ProductOrder } from '@example-api/shared/models';
-import {
-  cacheRxCall,
-  callConfig,
-  withCalls,
-  withCallStatus,
-  withEntitiesLoadingCall,
-  withEntitiesLocalPagination,
-  withEntitiesLocalSort,
-  withEntitiesMultiSelection,
-  withEntitiesRemoteFilter,
-  withEntitiesRemotePagination,
-  withEntitiesRemoteSort,
-  withEntitiesSingleSelection,
-  withLogger,
-  withSyncToWebStorage,
-} from '@ngrx-traits/signals';
-import {
-  patchState,
-  signalStore,
-  signalStoreFeature,
-  type,
-  withMethods,
-} from '@ngrx/signals';
-import {
-  addEntities,
-  entityConfig,
-  removeEntities,
-  updateEntity,
-  withEntities,
-} from '@ngrx/signals/entities';
-import { lastValueFrom, of } from 'rxjs';
+import { signalStore } from '@ngrx/signals';
 
-import { OrderService } from '../../services/order.service';
-import { ProductService } from '../../services/product.service';
+import { withBasketOperations } from './with-basket-operations';
+import { withOrderEntities } from './with-order-entities';
+import { withProductEntities } from './with-product-entities';
 
 /**
  * The store for the products shop page
  * This store is used to manage the products and the order items,
  * it has two collections, one for the products and one for the order items.
- * I implemented all in one store mainly for simplicity, but you can split it
- * into two stores if you prefer. I also wanted to show how you can use multiple
+ * Here you can see how to split a store into multiple features for better
+ * organization and reusability. We also wanted to show how you can use multiple
  * collections in one store, at the moment of writing this comment, signalStore
- * method can only have 9 parameters, and you can easily reach this limit if you
- * have multiple collections in one store, the way to solve this group the store
- * features using signalStoreFeature, for this case we did two groups,
- * productsStoreFeature and orderItemsStoreFeature.
+ * method can only have 10 parameters, and you can easily reach this limit if you
+ * have multiple collections in one store, the way to solve this, is to group the store
+ * features into custom store features as seen bellow. Also notice the output types of
+ * withProductEntities and withOrderEntities are extracted using ExtractStoreFeatureOutput
+ * and then used as input of withBasketOperations.
  */
-const productEntityConfig = entityConfig({
-  entity: type<Product>(),
-  collection: 'product',
-});
-const productsStoreFeature = signalStoreFeature(
-  withEntities(productEntityConfig),
-  withCallStatus({
-    ...productEntityConfig,
-    initialValue: 'loading',
-    errorType: type<string>(),
-  }),
-  withEntitiesRemoteFilter({
-    ...productEntityConfig,
-    defaultFilter: { search: '' },
-  }),
-  withEntitiesRemotePagination({
-    ...productEntityConfig,
-    pageSize: 10,
-  }),
-  withEntitiesRemoteSort({
-    ...productEntityConfig,
-    defaultSort: { field: 'name', direction: 'asc' },
-  }),
-  withEntitiesSingleSelection(productEntityConfig),
-);
-
-const orderItemEntityConfig = entityConfig({
-  entity: type<ProductOrder>(),
-  collection: 'orderItem',
-});
-const orderItemsStoreFeature = signalStoreFeature(
-  withEntities(orderItemEntityConfig),
-  withEntitiesLocalSort({
-    ...orderItemEntityConfig,
-    defaultSort: { field: 'name', direction: 'asc' },
-  }),
-  withEntitiesMultiSelection(orderItemEntityConfig),
-  withEntitiesLocalPagination({
-    ...orderItemEntityConfig,
-    pageSize: 10,
-  }),
-  withLogger({
-    name: 'orderItemStore',
-    showDiff: true,
-    // filter: ({ orderItemEntityMap, orderItemIds }) => ({
-    //   orderItemEntityMap,
-    //   orderItemIds,
-    // }),
-    filter: ['orderItemIdsSelected'],
-  }),
-  withSyncToWebStorage({
-    key: 'orderItems',
-    type: 'session',
-    filterState: ({ orderItemEntityMap, orderItemIds }) => ({
-      orderItemEntityMap,
-      orderItemIds,
-    }),
-  }),
-);
 
 export const ProductsShopStore = signalStore(
   { providedIn: 'root' },
-  productsStoreFeature,
-  orderItemsStoreFeature,
-  withEntitiesLoadingCall(
-    (
-      { productEntitiesPagedRequest, productEntitiesFilter, productEntitiesSort },
-      service = inject(ProductService),
-    ) => ({
-      ...productEntityConfig,
-      fetchEntities: async () => {
-        const query = {
-          search: productEntitiesFilter().search,
-          skip: productEntitiesPagedRequest().startIndex,
-          take: productEntitiesPagedRequest().size,
-          sortAscending: productEntitiesSort().direction === 'asc',
-          sortColumn: productEntitiesSort().field,
-        };
-        const source = cacheRxCall({
-          key: ['products', query],
-          call: service.getProducts(query),
-          maxCacheSize: 5,
-        });
-        const res = await lastValueFrom(source);
-        return { entities: res.resultList, total: res.total };
-      },
-      mapError: (error) => (error as Error).message,
-    }),
-  ),
-  withCalls(
-    (
-      { orderItemEntities },
-      snackBar = inject(MatSnackBar),
-      service = inject(ProductService),
-    ) => ({
-      loadProductDetail: ({ id }: { id: string }) =>
-        cacheRxCall({
-          key: ['products', id],
-          call: service.getProductDetail(id),
-          maxCacheSize: 3,
-        }),
-      checkout: callConfig({
-        call: () =>
-          inject(OrderService).checkout(
-            ...orderItemEntities().map((p) => ({
-              productId: p.id,
-              quantity: p.quantity!,
-            })),
-          ),
-        resultProp: 'orderNumber',
-        onSuccess: (orderId) => {
-          snackBar.open(`Order number: ${orderId}`, 'Close', {
-            duration: 5000,
-          });
-        },
-        mapError: (error) => (error as Error).message,
-        onError: (error) => {
-          snackBar.open(error, 'Close', {
-            duration: 5000,
-          });
-        },
-      }),
-    }),
-  ),
-  withMethods(({ productEntitySelected, orderItemIdsSelected, ...state }) => ({
-    addProductToBasket: () => {
-      const product = productEntitySelected();
-      if (product) {
-        patchState(
-          state,
-          addEntities(
-            [{ ...product, quantity: 1 } as ProductOrder],
-            orderItemEntityConfig,
-          ),
-        );
-      }
-    },
-    updateProductInBasket: ({ id, quantity }: ProductOrder) => {
-      patchState(
-        state,
-        updateEntity({ id, changes: { quantity } }, orderItemEntityConfig),
-      );
-    },
-    removeProductsFromBasket: () => {
-      if (orderItemIdsSelected().length) {
-        patchState(
-          state,
-          removeEntities(orderItemIdsSelected(), orderItemEntityConfig),
-        );
-      }
-    },
-  })),
+  withProductEntities(),
+  withOrderEntities(),
+  withBasketOperations(),
 );

--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-basket-operations.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-basket-operations.ts
@@ -1,0 +1,94 @@
+import { inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ProductOrder } from '@example-api/shared/models';
+import { cacheRxCall, callConfig, withCalls } from '@ngrx-traits/signals';
+import {
+  patchState,
+  signalStoreFeature,
+  type,
+  withMethods,
+} from '@ngrx/signals';
+import {
+  addEntities,
+  removeEntities,
+  updateEntity,
+} from '@ngrx/signals/entities';
+
+import { OrderService } from '../../services/order.service';
+import { ProductService } from '../../services/product.service';
+import {
+  OrderEntitiesStoreFeature,
+  orderItemEntityConfig,
+} from './with-order-entities';
+import { ProductEntitiesStoreFeature } from './with-product-entities';
+
+export function withBasketOperations() {
+  return signalStoreFeature(
+    type<ProductEntitiesStoreFeature & OrderEntitiesStoreFeature>(),
+    withCalls(
+      (
+        { orderItemEntities },
+        snackBar = inject(MatSnackBar),
+        service = inject(ProductService),
+      ) => ({
+        loadProductDetail: ({ id }: { id: string }) =>
+          cacheRxCall({
+            key: ['products', id],
+            call: service.getProductDetail(id),
+            maxCacheSize: 3,
+          }),
+        checkout: callConfig({
+          call: () =>
+            inject(OrderService).checkout(
+              ...orderItemEntities().map((p) => ({
+                productId: p.id,
+                quantity: p.quantity!,
+              })),
+            ),
+          resultProp: 'orderNumber',
+          onSuccess: (orderId) => {
+            snackBar.open(`Order number: ${orderId}`, 'Close', {
+              duration: 5000,
+            });
+          },
+          mapError: (error) => (error as Error).message,
+          onError: (error) => {
+            snackBar.open(error, 'Close', {
+              duration: 5000,
+            });
+          },
+        }),
+      }),
+    ),
+    withMethods(
+      ({ productEntitySelected, orderItemIdsSelected, ...state }) => ({
+        addProductToBasket: () => {
+          const product = productEntitySelected();
+          if (product) {
+            patchState(
+              state,
+              addEntities(
+                [{ ...product, quantity: 1 } as ProductOrder],
+                orderItemEntityConfig,
+              ),
+            );
+          }
+        },
+        updateProductInBasket: ({ id, quantity }: ProductOrder) => {
+          patchState(
+            state,
+            updateEntity({ id, changes: { quantity } }, orderItemEntityConfig),
+          );
+        },
+        removeProductsFromBasket: () => {
+          if (orderItemIdsSelected().length) {
+            patchState(
+              state,
+              removeEntities(orderItemIdsSelected(), orderItemEntityConfig),
+            );
+          }
+        },
+      }),
+    ),
+  );
+}

--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
@@ -1,0 +1,51 @@
+import { ProductOrder } from '@example-api/shared/models';
+import {
+  ExtractStoreFeatureOutput,
+  withEntitiesLocalPagination,
+  withEntitiesLocalSort,
+  withEntitiesMultiSelection,
+  withLogger,
+  withSyncToWebStorage,
+} from '@ngrx-traits/signals';
+import { signalStoreFeature, type } from '@ngrx/signals';
+import { entityConfig, withEntities } from '@ngrx/signals/entities';
+
+export const orderItemEntityConfig = entityConfig({
+  entity: type<ProductOrder>(),
+  collection: 'orderItem',
+});
+
+export function withOrderEntities() {
+  return signalStoreFeature(
+    withEntities(orderItemEntityConfig),
+    withEntitiesLocalSort({
+      ...orderItemEntityConfig,
+      defaultSort: { field: 'name', direction: 'asc' },
+    }),
+    withEntitiesMultiSelection(orderItemEntityConfig),
+    withEntitiesLocalPagination({
+      ...orderItemEntityConfig,
+      pageSize: 10,
+    }),
+    withLogger({
+      name: 'orderItemStore',
+      showDiff: true,
+      // filter: ({ orderItemEntityMap, orderItemIds }) => ({
+      //   orderItemEntityMap,
+      //   orderItemIds,
+      // }),
+      filter: ['orderItemIdsSelected'],
+    }),
+    withSyncToWebStorage({
+      key: 'orderItems',
+      type: 'session',
+      filterState: ({ orderItemEntityMap, orderItemIds }) => ({
+        orderItemEntityMap,
+        orderItemIds,
+      }),
+    }),
+  );
+}
+export type OrderEntitiesStoreFeature = ExtractStoreFeatureOutput<
+  typeof withOrderEntities
+>;

--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-product-entities.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-product-entities.ts
@@ -1,0 +1,79 @@
+import { inject } from '@angular/core';
+import { Product } from '@example-api/shared/models';
+import {
+  cacheRxCall,
+  ExtractStoreFeatureOutput,
+  withCallStatus,
+  withEntitiesLoadingCall,
+  withEntitiesRemoteFilter,
+  withEntitiesRemotePagination,
+  withEntitiesRemoteSort,
+  withEntitiesSingleSelection,
+} from '@ngrx-traits/signals';
+import { signalStoreFeature, type } from '@ngrx/signals';
+import { entityConfig, withEntities } from '@ngrx/signals/entities';
+import { lastValueFrom } from 'rxjs';
+
+import { ProductService } from '../../services/product.service';
+
+export const productEntityConfig = entityConfig({
+  entity: type<Product>(),
+  collection: 'product',
+});
+
+export function withProductEntities() {
+  return signalStoreFeature(
+    withEntities(productEntityConfig),
+    withCallStatus({
+      ...productEntityConfig,
+      initialValue: 'loading',
+      errorType: type<string>(),
+    }),
+    withEntitiesRemoteFilter({
+      ...productEntityConfig,
+      defaultFilter: { search: '' },
+    }),
+    withEntitiesRemotePagination({
+      ...productEntityConfig,
+      pageSize: 10,
+    }),
+    withEntitiesRemoteSort({
+      ...productEntityConfig,
+      defaultSort: { field: 'name', direction: 'asc' },
+    }),
+    withEntitiesSingleSelection(productEntityConfig),
+    withEntitiesLoadingCall(
+      (
+        {
+          productEntitiesPagedRequest,
+          productEntitiesFilter,
+          productEntitiesSort,
+        },
+        service = inject(ProductService),
+      ) => ({
+        ...productEntityConfig,
+        fetchEntities: async () => {
+          const query = {
+            search: productEntitiesFilter().search,
+            skip: productEntitiesPagedRequest().startIndex,
+            take: productEntitiesPagedRequest().size,
+            sortAscending: productEntitiesSort().direction === 'asc',
+            sortColumn: productEntitiesSort().field,
+          };
+          const source = cacheRxCall({
+            key: ['products', query],
+            call: service.getProducts(query),
+            maxCacheSize: 5,
+          });
+          const res = await lastValueFrom(source);
+          return { entities: res.resultList, total: res.total };
+        },
+        mapError: (error) => (error as Error).message,
+      }),
+    ),
+  );
+}
+
+export type ProductEntitiesStoreFeature = ExtractStoreFeatureOutput<
+  typeof withProductEntities
+>;

--- a/libs/ngrx-traits/signals/src/lib/index.ts
+++ b/libs/ngrx-traits/signals/src/lib/index.ts
@@ -34,6 +34,7 @@ export * from './with-sync-to-route-query-params/with-sync-to-route-query-params
 export * from './with-route-params/with-route-params';
 export * from './with-input-bindings/with-input-bindings';
 export * from './with-feature-factory/with-feature-factory';
+export * from './with-feature-factory/with-feature-factory.model';
 export * from './with-all-call-status/with-all-call-status';
 export * from './with-all-call-status/with-all-call-status.util';
 export * from './with-entities-calls/with-entities-calls';

--- a/libs/ngrx-traits/signals/src/lib/with-feature-factory/with-feature-factory.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-feature-factory/with-feature-factory.model.ts
@@ -1,5 +1,6 @@
 import {
   Prettify,
+  SignalStoreFeature,
   SignalStoreFeatureResult,
   StateSignals,
   WritableStateSource,
@@ -23,3 +24,7 @@ export function getFeatureConfig<
 >(config: FeatureConfigFactory<Input, Config>, store: StoreSource<Input>) {
   return typeof config === 'function' ? config(store) : config;
 }
+export type ExtractStoreFeatureOutput<Result extends () => SignalStoreFeature> =
+  ReturnType<Result> extends SignalStoreFeature<any, infer Output>
+    ? Output
+    : never;


### PR DESCRIPTION

  Extracts output type from signalStoreFeature functions for use as input in dependent features. Simplifies splitting stores into multiple features by eliminating need to manually define input interfaces.
