### PR TITLE
fix(signals): improvemnts for ExtractStoreFeatureOutput

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-feature-factory/with-feature-factory.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-feature-factory/with-feature-factory.model.ts
@@ -24,7 +24,9 @@ export function getFeatureConfig<
 >(config: FeatureConfigFactory<Input, Config>, store: StoreSource<Input>) {
   return typeof config === 'function' ? config(store) : config;
 }
-export type ExtractStoreFeatureOutput<Result extends () => SignalStoreFeature> =
-  ReturnType<Result> extends SignalStoreFeature<any, infer Output>
-    ? Output
+export type ExtractStoreFeatureOutput<
+  Result extends (...args: any[]) => SignalStoreFeature<any, any>,
+> =
+  ReturnType<Result> extends SignalStoreFeature<infer In, infer Out>
+    ? In & Out
     : never;


### PR DESCRIPTION
Allow features with params, and merge input and output type, to support features that depend on other featues

Fix #264