### PR TITLE
feat(signals): add multi selection sync to route query params and per feature sync toggles

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
+++ b/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
@@ -5,7 +5,7 @@ order: 17
 
 # withEntitiesSyncToRouteQueryParams
 
-Syncs entities filter, pagination, sort and single selection to route query params for local or remote entities store features. If a collection is provided, it will be used as a prefix (if non is provided) for the query params.
+Syncs entities filter, pagination, sort, single selection and multi selection to route query params for local or remote entities store features. If a collection is provided, it will be used as a prefix (if non is provided) for the query params.
 The prefix can be disabled by setting it to false, or changed by providing a string. The filterMapper can be used to customize how the filter object is map to a query params object,
 when is not provided the filter will use JSON.stringify to serialize the filter object.
 
@@ -68,6 +68,25 @@ export const ProductsRemoteStore = signalStore(
 );
 ```
 
+### Syncing with multi selection
+
+Use `syncMultiSelection: true`  when using `withEntitiesMultiSelection`. Selected ids are serialized as a comma-separated `selectedIds` query param.
+
+```typescript
+export const ProductsLocalStore = signalStore(
+  { providedIn: 'root' },
+  withEntities({ entity, collection }),
+  withCallStatus({ prop: collection, initialValue: 'loading' }),
+  withEntitiesMultiSelection({ entity, collection }),
+  withEntitiesLoadingCall({ ... }),
+  withEntitiesSyncToRouteQueryParams({
+    entity,
+    collection,
+    syncMultiSelection: true,
+  }),
+);
+```
+
 ## API Reference
 
 
@@ -79,7 +98,12 @@ export const ProductsRemoteStore = signalStore(
 | filterMapper        | Configure how the entities filter is serialize to and from the query params                                                                       | FilterQueryMapper<Filter>                    |
 | onQueryParamsLoaded | Callback to execute something else when the query params are loaded from the store                                                                | `(store) => void`                            |
 | defaultDebounce     | Debounce time for syncing store changes back to the route query params                                                                            | number (milliseconds)                        |
-| skipLoadingCall     | When true, restoring state from query params will update the store state but will not trigger a backend call to fetch entities. Default: false | boolean                                      |
+| skipLoadingCall     | When true, restoring state from query params will update the store state but will not trigger a backend call to fetch entities. Default: false    | boolean                                      |
+| syncFilter          | Sync entities filter to route query params. Default: true                                                                                         | boolean                                      |
+| syncPagination      | Sync entities pagination to route query params. Default: true                                                                                     | boolean                                      |
+| syncSort            | Sync entities sort to route query params. Default: true                                                                                           | boolean                                      |
+| syncSingleSelection | Sync single selected entity id to route query params as `selectedId`. Default: true                                                               | boolean                                      |
+| syncMultiSelection  | Sync multi selected entity ids to route query params as `selectedIds` (comma-separated). Default: false                                           | boolean                                      |
 
 ## State
 

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -122,7 +122,8 @@ export type ExtractCallResultType<T extends Call | CallConfig> =
 export type ExtractErrorType<T extends Call | CallConfig> =
   T extends CallConfig<any, any, any, infer E>
     ? E
-    : unknown;      
+    : unknown;
+
 
 export type NamedCallsStatusComputed<
   Calls extends Record<string, Call | CallConfig>,

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -356,8 +356,8 @@ export function withCalls<
                     take(1),
                     map((v) =>
                       v === 'loaded'
-                        ? { value: resultSignal, ok: true }
-                        : { error: errorSignal, ok: false },
+                        ? { value: resultSignal, ok: true as const }
+                        : { error: errorSignal, ok: false as const },
                     ),
                   ),
                 );

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
@@ -19,6 +19,7 @@ describe('withEntitiesMultiSelection', () => {
       withEntities({ entity }),
       withEntitiesMultiSelection({ entity }),
     );
+
     it('selectEntities should select the entity', () => {
       TestBed.runInInjectionContext(() => {
         const store = new Store();
@@ -120,6 +121,56 @@ describe('withEntitiesMultiSelection', () => {
         expect(store.isAllEntitiesSelected()).toEqual('all');
         store.toggleSelectEntities({ id: mockProducts[4].id });
         expect(store.isAllEntitiesSelected()).toEqual('some');
+      });
+    });
+
+    it('selectEntities should not change state when ids are already selected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        const mapBefore = store.idsSelectedMap();
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        expect(store.idsSelectedMap()).toBe(mapBefore);
+      });
+    });
+
+    it('selectEntities should not change state when a single id is already selected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ id: mockProducts[4].id });
+        const mapBefore = store.idsSelectedMap();
+        store.selectEntities({ id: mockProducts[4].id });
+        expect(store.idsSelectedMap()).toBe(mapBefore);
+      });
+    });
+
+    it('deselectEntities should not change state when ids are already deselected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        store.deselectEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        const mapBefore = store.idsSelectedMap();
+        store.deselectEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        expect(store.idsSelectedMap()).toEqual(mapBefore);
+      });
+    });
+
+    it('deselectEntities should not change state when a single id is already deselected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ id: mockProducts[4].id });
+        store.deselectEntities({ id: mockProducts[4].id });
+        const mapBefore = store.idsSelectedMap();
+        store.deselectEntities({ id: mockProducts[4].id });
+        expect(store.idsSelectedMap()).toEqual(mapBefore);
       });
     });
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
@@ -211,9 +211,27 @@ export function withEntitiesMultiSelection<
         const isAllEntitiesSelected = state[isAllEntitiesSelectedKey] as Signal<
           'all' | 'none' | 'some'
         >;
-
+        const selectedIds = state[selectedEntitiesIdsKey] as Signal<
+          (string | number)[]
+        >;
         const idsArray = state[idsKey] as Signal<EntityId[]>;
 
+        function areAllIds({
+          ids,
+          selected,
+        }: {
+          ids: (string | number)[];
+          selected: boolean;
+        }) {
+          const previoslySelectedIds = selectedIds();
+          return (
+            previoslySelectedIds === ids ||
+            (previoslySelectedIds.length === ids.length &&
+              ids.every((id) =>
+                selected ? !!selectedIdsMap()[id] : !selectedIdsMap()[id],
+              ))
+          );
+        }
         return {
           [selectEntitiesKey]: rxMethod<
             { clearSelectionBeforeSelect?: boolean } & (
@@ -223,10 +241,13 @@ export function withEntitiesMultiSelection<
           >(
             pipe(
               tap((options) => {
+                const ids = 'id' in options ? [options.id] : options.ids;
+                // protect againts cyclic resetting
+                if (areAllIds({ ids, selected: true })) return;
+
                 if (options.clearSelectionBeforeSelect) {
                   clearEntitiesSelection(state, selectedIdsMapKey);
                 }
-                const ids = 'id' in options ? [options.id] : options.ids;
                 const idsMap = ids.reduce(
                   (acc, id) => {
                     acc[id] = true;
@@ -245,6 +266,9 @@ export function withEntitiesMultiSelection<
             options: { id: string | number } | { ids: (string | number)[] },
           ) => {
             const ids = 'id' in options ? [options.id] : options.ids;
+            // protect againts cyclic resetting
+            if (areAllIds({ ids, selected: false })) return;
+            
             const idsMap = ids.reduce(
               (acc, id) => {
                 acc[id] = false;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.util.ts
@@ -1,4 +1,12 @@
+import { computed, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { concatMap, take } from 'rxjs';
+import { filter, startWith } from 'rxjs/operators';
+
 import { capitalize } from '../util';
+import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
+import { QueryMapper } from '../with-sync-to-route-query-params/with-sync-to-route-query-params.util';
+import { EntitiesMultiSelectionMethods } from './with-entities-multi-selection.model';
 
 export function getEntitiesMultiSelectionKeys(config?: {
   collection?: string;
@@ -33,5 +41,71 @@ export function getEntitiesMultiSelectionKeys(config?: {
     isAllEntitiesSelectedKey: collection
       ? `isAll${capitalizedProp}EntitiesSelected`
       : 'isAllEntitiesSelected',
+  };
+}
+
+export function getQueryMapperForMultiSelection(config?: {
+  collection?: string;
+}): QueryMapper<{
+  selectedIds: string | undefined;
+}> {
+  const { selectedEntitiesIdsKey, selectEntitiesKey } =
+    getEntitiesMultiSelectionKeys(config);
+  const { loadingKey, loadedKey } = getWithCallStatusKeys({
+    collection: config?.collection,
+  });
+  return {
+    queryParamsToState: (query, store) => {
+      const selectedIds = query.selectedIds;
+      if (selectedIds) {
+        const selectEntities = store[
+          selectEntitiesKey
+        ] as EntitiesMultiSelectionMethods['selectEntities'];
+
+        const loading = store[loadingKey] as Signal<boolean>;
+
+        const ids = selectedIds
+          .split(',')
+          .map((id) => id.trim())
+          .filter(Boolean);
+
+        if (!loading) {
+          // if there is no loading signal, we can select the entities immediately
+          selectEntities({ ids });
+          return;
+        }
+
+        const loaded = store[loadedKey] as Signal<boolean>;
+        const loaded$ = toObservable(loaded);
+        toObservable(loading)
+          .pipe(
+            startWith(loading()),
+            filter((v) => v), // wait until loading becomes true
+            take(1),
+            concatMap(() =>
+              loaded$.pipe(
+                startWith(loaded()),
+                filter((v) => v), // wait until loaded becomes true
+                take(1),
+              ),
+            ),
+            takeUntilDestroyed(),
+          )
+          .subscribe(() => {
+            selectEntities({ ids });
+          });
+      }
+    },
+    stateToQueryParams: (store) => {
+      const selectedIds = store[selectedEntitiesIdsKey] as
+        | Signal<(string | number)[]>
+        | undefined;
+      return selectedIds
+        ? computed(() => ({
+            selectedIds:
+              selectedIds().length > 0 ? selectedIds().join(',') : undefined,
+          }))
+        : undefined;
+    },
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.util.ts
@@ -52,9 +52,17 @@ export function getQueryMapperForSingleSelection(config?: {
         ] as EntitiesSingleSelectionMethods['selectEntity'];
 
         const loading = store[loadingKey] as Signal<boolean>;
+
+        if (!loading) {
+          // if there is no loading signal, we can select the entity immediately
+          selectEntity({
+            id: selectedId,
+          });
+          return;
+        }
+
         const loaded = store[loadedKey] as Signal<boolean>;
         const loaded$ = toObservable(loaded);
-
         toObservable(loading)
           .pipe(
             startWith(loading()),

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -7,6 +7,7 @@ import {
   withEntitiesLocalFilter,
   withEntitiesLocalPagination,
   withEntitiesLocalSort,
+  withEntitiesMultiSelection,
   withEntitiesRemoteFilter,
   withEntitiesRemotePagination,
   withEntitiesRemoteSort,
@@ -493,6 +494,93 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
         relativeTo: expect.anything(),
         queryParams: expect.objectContaining({
           selectedId: '3',
+        }),
+        queryParamsHandling: 'merge',
+      });
+    }));
+  });
+
+  describe('entities multi selection', () => {
+    const multiSelectionStoreFeature = ({
+      load,
+    }: { load?: Subject<boolean> } = {}) => {
+      return signalStoreFeature(
+        signalStoreFeature(
+          withEntities({ entity }),
+          withCallStatus({ initialValue: 'loading' }),
+          withEntitiesLocalPagination({ entity, pageSize: 10 }),
+          withEntitiesLocalSort({
+            entity,
+            defaultSort: { field: 'name', direction: 'asc' },
+          }),
+          withEntitiesLocalFilter({
+            entity,
+            defaultFilter: { search: '', foo: 'bar' },
+            filterFn: (entity, filter) =>
+              !filter?.search ||
+              entity?.name.toLowerCase().includes(filter?.search.toLowerCase()),
+          }),
+        ),
+        withEntitiesMultiSelection({ entity }),
+        withEntitiesLoadingCall({
+          fetchEntities: ({}) => {
+            const result = [...mockProducts.slice(0, 40)];
+            const total = result.length;
+            const response = { entities: result, total };
+            return load
+              ? load.pipe(
+                  filter(Boolean),
+                  map(() => response),
+                )
+              : of(response);
+          },
+        }),
+      );
+    };
+
+    it('url query params selectedIds should update store', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        multiSelectionStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          syncSingleSelection: false,
+          syncMultiSelection: true,
+        }),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { selectedIds: '2,3' },
+      });
+      TestBed.tick();
+      load.next(true);
+      tick(400);
+      expect(store.idsSelected()).toEqual(['2', '3']);
+    }));
+
+    it('changes on idsSelected should update url query params', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        multiSelectionStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          syncSingleSelection: false,
+          syncMultiSelection: true,
+        }),
+      );
+      const { store, router } = init({
+        Store,
+        queryParams: {},
+      });
+      TestBed.tick();
+      load.next(true);
+      tick(400);
+      store.selectEntities({ ids: ['3', '5'] });
+      tick(400);
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          selectedIds: '3,5',
         }),
         queryParamsHandling: 'merge',
       });

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
@@ -30,6 +30,7 @@ import {
   getQueryMapperForEntitiesFilter,
 } from '../with-entities-filter/with-entities-filter.util';
 import { getQueryMapperForEntitiesPagination } from '../with-entities-pagination/with-entities-local-pagination.util';
+import { getQueryMapperForMultiSelection } from '../with-entities-selection/with-entities-multi-selection.util';
 import { getQueryMapperForSingleSelection } from '../with-entities-selection/with-entities-single-selection.util';
 import { getQueryMapperForEntitiesSort } from '../with-entities-sort/with-entities-local-sort.util';
 import { StoreSource } from '../with-feature-factory/with-feature-factory.model';
@@ -110,6 +111,11 @@ export function withEntitiesSyncToRouteQueryParams<
   defaultDebounce?: number;
   restoreOnInit?: boolean;
   skipLoadingCall?: boolean;
+  syncFilter?: boolean;
+  syncPagination?: boolean;
+  syncSort?: boolean;
+  syncSingleSelection?: boolean;
+  syncMultiSelection?: boolean;
 }): SignalStoreFeature<
   Input &
     (Collection extends ''
@@ -134,20 +140,37 @@ export function withEntitiesSyncToRouteQueryParams<
   }
 > {
   const mappers = [
-    getQueryMapperForEntitiesPagination({
-      collection: config?.collection,
-      skipLoadingCall: config?.skipLoadingCall ?? false,
-    }),
-    getQueryMapperForEntitiesSort({
-      collection: config?.collection,
-      skipLoadingCall: config?.skipLoadingCall ?? false,
-    }),
-    getQueryMapperForEntitiesFilter({
-      collection: config?.collection,
-      filterMapper: config?.filterMapper,
-      skipLoadingCall: config?.skipLoadingCall ?? false,
-    }),
-    getQueryMapperForSingleSelection(config),
+    ...(config?.syncPagination !== false
+      ? [
+          getQueryMapperForEntitiesPagination({
+            collection: config?.collection,
+            skipLoadingCall: config?.skipLoadingCall ?? false,
+          }),
+        ]
+      : []),
+    ...(config?.syncSort !== false
+      ? [
+          getQueryMapperForEntitiesSort({
+            collection: config?.collection,
+            skipLoadingCall: config?.skipLoadingCall ?? false,
+          }),
+        ]
+      : []),
+    ...(config?.syncFilter !== false
+      ? [
+          getQueryMapperForEntitiesFilter({
+            collection: config?.collection,
+            filterMapper: config?.filterMapper,
+            skipLoadingCall: config?.skipLoadingCall ?? false,
+          }),
+        ]
+      : []),
+    ...(config?.syncSingleSelection !== false
+      ? [getQueryMapperForSingleSelection(config)]
+      : []),
+    ...(config?.syncMultiSelection === true
+      ? [getQueryMapperForMultiSelection(config)]
+      : []),
   ];
   const prefixString =
     config?.prefix === false ? undefined : config?.prefix ?? config?.collection;


### PR DESCRIPTION
feat(signals): add multi selection sync to route query params and per feature sync toggles

  - withEntitiesSyncToRouteQueryParams now supports syncMultiSelection, syncFilter, syncPagination, syncSort, syncSingleSelection flags
  - withEntitiesMultiSelection select/deselect guards against no-op state changes to prevent cyclic resets

Fix #268