### PR TITLE
fix(signals): reorder filter overloads for correct signal param resolution

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
+++ b/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
@@ -5,7 +5,7 @@ order: 17
 
 # withEntitiesSyncToRouteQueryParams
 
-Syncs entities filter, pagination, sort and single selection to route query params for local or remote entities store features. If a collection is provided, it will be used as a prefix (if non is provided) for the query params.
+Syncs entities filter, pagination, sort, single selection and multi selection to route query params for local or remote entities store features. If a collection is provided, it will be used as a prefix (if non is provided) for the query params.
 The prefix can be disabled by setting it to false, or changed by providing a string. The filterMapper can be used to customize how the filter object is map to a query params object,
 when is not provided the filter will use JSON.stringify to serialize the filter object.
 
@@ -68,6 +68,25 @@ export const ProductsRemoteStore = signalStore(
 );
 ```
 
+### Syncing with multi selection
+
+Use `syncMultiSelection: true`  when using `withEntitiesMultiSelection`. Selected ids are serialized as a comma-separated `selectedIds` query param.
+
+```typescript
+export const ProductsLocalStore = signalStore(
+  { providedIn: 'root' },
+  withEntities({ entity, collection }),
+  withCallStatus({ prop: collection, initialValue: 'loading' }),
+  withEntitiesMultiSelection({ entity, collection }),
+  withEntitiesLoadingCall({ ... }),
+  withEntitiesSyncToRouteQueryParams({
+    entity,
+    collection,
+    syncMultiSelection: true,
+  }),
+);
+```
+
 ## API Reference
 
 
@@ -79,7 +98,12 @@ export const ProductsRemoteStore = signalStore(
 | filterMapper        | Configure how the entities filter is serialize to and from the query params                                                                       | FilterQueryMapper<Filter>                    |
 | onQueryParamsLoaded | Callback to execute something else when the query params are loaded from the store                                                                | `(store) => void`                            |
 | defaultDebounce     | Debounce time for syncing store changes back to the route query params                                                                            | number (milliseconds)                        |
-| skipLoadingCall     | When true, restoring state from query params will update the store state but will not trigger a backend call to fetch entities. Default: false | boolean                                      |
+| skipLoadingCall     | When true, restoring state from query params will update the store state but will not trigger a backend call to fetch entities. Default: false    | boolean                                      |
+| syncFilter          | Sync entities filter to route query params. Default: true                                                                                         | boolean                                      |
+| syncPagination      | Sync entities pagination to route query params. Default: true                                                                                     | boolean                                      |
+| syncSort            | Sync entities sort to route query params. Default: true                                                                                           | boolean                                      |
+| syncSingleSelection | Sync single selected entity id to route query params as `selectedId`. Default: true                                                               | boolean                                      |
+| syncMultiSelection  | Sync multi selected entity ids to route query params as `selectedIds` (comma-separated). Default: false                                           | boolean                                      |
 
 ## State
 

--- a/libs/ngrx-traits/signals/src/lib/with-calls/call-config.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/call-config.ts
@@ -11,7 +11,7 @@ import { CallConfig } from './with-calls.model';
  * @param config.mapError - optional, a function that will be called to transform the error before storing it
  * @param config.onError - optional, a function that will be called when the call fails
  * @param config.skipWhen - optional, a function that will be called to determine if the call should be skipped
- * @param config.callWith - optional, reactively execute the call with the provided params return by a function or signal or observable
+ * @param config.callWith - optional, reactively execute the call with the provided params return by a function or observable
  * @param config.defaultResult - optional, A default value for the result before the call is executed
  */
 export function callConfig<
@@ -47,7 +47,7 @@ export function callConfig<
  * @param config.mapError - optional, a function that will be called to transform the error before storing it
  * @param config.onError - optional, a function that will be called when the call fails
  * @param config.skipWhen - optional, a function that will be called to determine if the call should be skipped
- * @param config.callWith - optional, reactively execute the call with the provided params return by a function or signal or observable
+ * @param config.callWith - optional, reactively execute the call with the provided params return by a function or observable
  * @param config.defaultResult - optional, A default value for the result before the call is executed
  */
 export function callConfig<
@@ -82,7 +82,7 @@ export function callConfig<
  * @param config.mapError - optional, a function that will be called to transform the error before storing it
  * @param config.onError - optional, a function that will be called when the call fails
  * @param config.skipWhen - optional, a function that will be called to determine if the call should be skipped
- * @param config.callWith - optional, reactively execute the call with the provided params return by a function or signal or observable
+ * @param config.callWith - optional, reactively execute the call with the provided params return by a function or observable
  * @param config.defaultResult - optional, A default value for the result before the call is executed
  */
 export function callConfig<
@@ -120,7 +120,7 @@ export function callConfig(config: any): any {
  * @param config.mapError - optional, a function that will be called to transform the error before storing it
  * @param config.onError - optional, a function that will be called when the call fails
  * @param config.skipWhen - optional, a function that will be called to determine if the call should be skipped
- * @param config.callWith - optional, reactively execute the call with the provided params return by a function or signal or observable
+ * @param config.callWith - optional, reactively execute the call with the provided params return by a function or observable
  * @param config.defaultResult - optional, A default value for the result before the call is executed
  */
 export function typedCallConfig<
@@ -157,7 +157,7 @@ export function typedCallConfig<
  * @param config.mapError - optional, a function that will be called to transform the error before storing it
  * @param config.onError - optional, a function that will be called when the call fails
  * @param config.skipWhen - optional, a function that will be called to determine if the call should be skipped
- * @param config.callWith - optional, reactively execute the call with the provided params return by a function or signal or observable
+ * @param config.callWith - optional, reactively execute the call with the provided params return by a function or observable
  * @param config.defaultResult - optional, A default value for the result before the call is executed
  */
 export function typedCallConfig<
@@ -193,7 +193,7 @@ export function typedCallConfig<
  * @param config.mapError - optional, a function that will be called to transform the error before storing it
  * @param config.onError - optional, a function that will be called when the call fails
  * @param config.skipWhen - optional, a function that will be called to determine if the call should be skipped
- * @param config.callWith - optional, reactively execute the call with the provided params return by a function or signal or observable
+ * @param config.callWith - optional, reactively execute the call with the provided params return by a function or observable
  * @param config.defaultResult - optional, A default value for the result before the call is executed
  */
 export function typedCallConfig<

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -122,7 +122,8 @@ export type ExtractCallResultType<T extends Call | CallConfig> =
 export type ExtractErrorType<T extends Call | CallConfig> =
   T extends CallConfig<any, any, any, infer E>
     ? E
-    : unknown;      
+    : unknown;
+
 
 export type NamedCallsStatusComputed<
   Calls extends Record<string, Call | CallConfig>,

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -71,7 +71,7 @@ export type CallConfig<
 
   /**
    * A function with condition that determines whether the call should be skipped.
-   * The function accepts the  call parameter and must return a boolean | Signal<boolean> | Observable<boolean>.
+   * The function accepts the  call parameter and must return a boolean | Observable<boolean>.
    */
   skipWhen?: (
     param: NoInfer<Param>,
@@ -82,7 +82,7 @@ export type CallConfig<
    * Reactively execute the call with the provided params.
    * Supports the following:
    * - A direct parameter value. Which execute the call once on init.
-   * - A `Signal` or `Observable` emitting the parameter of the call or undefined.
+   * - A function or `Observable` emitting the parameter of the call or undefined.
    * - A function returning the parameter or undefined.
    *
    * **Warning**: By default, when withCall is a function, signal
@@ -91,12 +91,11 @@ export type CallConfig<
    * to always execute on any value.
    */
   callWith?: Param extends undefined
-    ? Signal<boolean> | Observable<boolean> | (() => boolean) | boolean
+    ? Observable<boolean> | (() => boolean) | boolean
     :
         | NoInfer<Param>
         | null
         | undefined
-        | Signal<NoInfer<Param | null | undefined>>
         | Observable<NoInfer<Param | null | undefined>>
         | (() => NoInfer<Param> | null | undefined);
 };

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.model.ts
@@ -119,6 +119,10 @@ export type ExtractCallResultType<T extends Call | CallConfig> =
         ? R | undefined
         : D
       : never;
+export type ExtractErrorType<T extends Call | CallConfig> =
+  T extends CallConfig<any, any, any, infer E>
+    ? E
+    : unknown;      
 
 export type NamedCallsStatusComputed<
   Calls extends Record<string, Call | CallConfig>,
@@ -139,4 +143,8 @@ export type NamedCallsStatusComputed<
   >
     ? Signal<Error | undefined>
     : Signal<unknown | undefined>;
+};
+
+export type RxMethodRef = {
+    destroy: () => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
@@ -79,6 +79,7 @@ describe('withCalls', () => {
     });
   });
 
+
   it('Fail on a call should set status return error ', async () => {
     TestBed.runInInjectionContext(() => {
       const store = new Store();
@@ -86,6 +87,33 @@ describe('withCalls', () => {
       store.testCall({ ok: false });
       expect(store.testCallError()).toEqual(new Error('fail'));
       expect(store.testCallResult()).toBe(undefined);
+    });
+  });
+
+  it('should return promise with value on success', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const store = new Store();
+      const resultPromise = store.testCall({ ok: true });
+      apiResponse.next('test');
+      TestBed.tick();
+      const result = await resultPromise;
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value()).toBe('test');
+      }
+    });
+  });
+
+  it('should return promise with error on failure', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const store = new Store();
+      const resultPromise = store.testCall({ ok: false });
+      TestBed.tick();
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error()).toEqual(new Error('fail'));
+      }
     });
   });
 
@@ -175,6 +203,55 @@ describe('withCalls', () => {
         expect(store.testCall2Error()).toEqual(new Error('fail'));
         expect(store.result()).toBe(undefined);
         expect(onError).toHaveBeenCalledWith(new Error('fail'), { ok: false });
+      });
+    });
+    it('should return promise with value on success', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const store = new Store();
+        const resultPromise = store.testCall2({ ok: true });
+        apiResponse.next('test');
+        TestBed.tick();
+        const result = await resultPromise;
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value()).toBe('test');
+        }
+      });
+    });
+    it('should return promise with error on failure', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const store = new Store();
+        const resultPromise = store.testCall2({ ok: false });
+        TestBed.tick();
+        const result = await resultPromise;
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error()).toEqual(new Error('fail'));
+        }
+      });
+    });
+    it('should return promise with mapped error when mapError is used', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const Store = signalStore(
+          withState({ foo: 'bar' }),
+          withCalls(() => ({
+            testCall2: callConfig({
+              call: ({ ok }: { ok: boolean }) => {
+                return ok ? apiResponse : throwError(() => new Error('fail'));
+              },
+              mapError: (error, { ok }) => (error as Error).message + ' ' + ok,
+              resultProp: 'result',
+            }),
+          })),
+        );
+        const store = new Store();
+        const resultPromise = store.testCall2({ ok: false });
+        TestBed.tick();
+        const result = await resultPromise;
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error()).toEqual('fail false');
+        }
       });
     });
     it('Fail on a call should set status return error with correct type if mapError is used ', async () => {

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -147,7 +147,7 @@ export function withCalls<
           ? () => void
           : {
               (param: P[0]): void;
-              (param: Observable<P[0]> | Signal<P[0]>): void;
+              (param: Observable<P[0]> | (() => P[0])): void;
             }
         : Calls[K] extends CallConfig
           ? Parameters<Calls[K]['call']> extends undefined[]
@@ -157,7 +157,7 @@ export function withCalls<
                 (
                   param:
                     | Observable<Parameters<Calls[K]['call']>[0]>
-                    | Signal<Parameters<Calls[K]['call']>[0]>,
+                    | (() => Parameters<Calls[K]['call']>[0]),
                 ): void;
               }
           : never;

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -356,8 +356,8 @@ export function withCalls<
                     take(1),
                     map((v) =>
                       v === 'loaded'
-                        ? { value: resultSignal, ok: true }
-                        : { error: errorSignal, ok: false },
+                        ? { value: resultSignal, ok: true as const }
+                        : { error: errorSignal, ok: false as const },
                     ),
                   ),
                 );

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -7,7 +7,7 @@ import {
   runInInjectionContext,
   Signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import {
   patchState,
   signalStoreFeature,
@@ -29,6 +29,7 @@ import {
   from,
   ignoreElements,
   isObservable,
+  lastValueFrom,
   map,
   merge,
   Observable,
@@ -58,8 +59,10 @@ import {
   CallConfig,
   ExtractCallResultPropName,
   ExtractCallResultType,
+  ExtractErrorType,
   NamedCallsStatusComputed,
   ObservableCall,
+  RxMethodRef,
 } from './with-calls.model';
 import { getWithCallKeys } from './with-calls.util';
 
@@ -146,19 +149,29 @@ export function withCalls<
         ? P extends []
           ? () => void
           : {
-              (param: P[0]): void;
-              (param: Observable<P[0]> | (() => P[0])): void;
+              (
+                param: P[0],
+              ): Promise<
+                | { value: Signal<ExtractCallResultType<Calls[K]>>; ok: true }
+                | { error: Signal<ExtractErrorType<Calls[K]>>; ok: false }
+              >;
+              (param: Observable<P[0]> | (() => P[0])): RxMethodRef;
             }
         : Calls[K] extends CallConfig
           ? Parameters<Calls[K]['call']> extends undefined[]
             ? () => void
             : {
-                (param: Parameters<Calls[K]['call']>[0]): void;
+                (
+                  param: Parameters<Calls[K]['call']>[0],
+                ): Promise<
+                  | { value: Signal<ExtractCallResultType<Calls[K]>>; ok: true }
+                  | { error: Signal<ExtractErrorType<Calls[K]>>; ok: false }
+                >;
                 (
                   param:
                     | Observable<Parameters<Calls[K]['call']>[0]>
                     | (() => Parameters<Calls[K]['call']>[0]),
-                ): void;
+                ): RxMethodRef;
               }
           : never;
     };
@@ -218,7 +231,7 @@ export function withCalls<
         (state, environmentInjector = inject(EnvironmentInjector)) => {
           const methods = Object.entries(calls).reduce(
             (acc, [callName, call]) => {
-              const { callStatusKey } = getWithCallStatusKeys({
+              const { callStatusKey, errorKey } = getWithCallStatusKeys({
                 prop: callName,
               });
               const { resultPropKey, callNameKey } = getWithCallKeys({
@@ -255,7 +268,7 @@ export function withCalls<
                     : undefined)
                 : undefined;
 
-              acc[callNameKey] = rxMethod<unknown[]>(
+              let reactiveMethod = rxMethod<unknown>(
                 pipe(
                   mapPipe((params) => {
                     const previousResult = isCallConfig(call)
@@ -322,6 +335,34 @@ export function withCalls<
                   }),
                 ),
               );
+              acc[callNameKey] = function (param?: unknown) {
+                if (
+                  typeof param === 'function' ||
+                  param instanceof Observable ||
+                  isSignal(param)
+                ) {
+                  return reactiveMethod(param as any);
+                }
+
+                reactiveMethod(param as any);
+                const callState = state[callStatusKey] as Signal<CallStatus>;
+                const resultSignal = state[resultPropKey] as Signal<unknown>;
+                const errorSignal = state[errorKey] as Signal<unknown>;
+                let resultPromise = lastValueFrom(
+                  toObservable(callState, {
+                    injector: environmentInjector,
+                  }).pipe(
+                    filter((v) => v === 'loaded' || typeof v === 'object'),
+                    take(1),
+                    map((v) =>
+                      v === 'loaded'
+                        ? { value: resultSignal, ok: true }
+                        : { error: errorSignal, ok: false },
+                    ),
+                  ),
+                );
+                return resultPromise;
+              };
               return acc;
             },
             {} as Record<string, any>,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/entity-call-config.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/entity-call-config.ts
@@ -10,7 +10,7 @@ import { EntityCallConfig } from './with-entities-calls.model';
  * @param config.mapError - optional, a function that will be called to transform the error before storing it
  * @param config.onError - optional, a function that will be called when the call fails
  * @param config.skipWhen - optional, a function that will be called to determine if the call should be skipped
- * @param config.callWith - optional, reactively execute the call with the provided params return by a function or signal or observable
+ * @param config.callWith - optional, reactively execute the call with the provided params return by a function or observable
  * @param config.defaultResult - optional, A default value for the result before the call is executed
  */
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.model.ts
@@ -74,7 +74,7 @@ export type EntityCallConfig<
 
   /**
    * A function with condition that determines whether the call should be skipped.
-   * The function accepts the  call parameter and must return a boolean | Signal<boolean> | Observable<boolean>.
+   * The function accepts the  call parameter and must return a boolean | Observable<boolean>.
    */
   skipWhen?:
     | Call<NoInfer<Param>, boolean>
@@ -88,7 +88,7 @@ export type EntityCallConfig<
    * Reactively execute the call with the provided params.
    * Supports the following:
    * - A direct parameter value. Which execute the call once on init.
-   * - A `Signal` or `Observable` emitting the parameter of the call or undefined.
+   * - A function or `Observable` emitting the parameter of the call or undefined.
    * - A function returning the parameter or undefined.
    *
    * **Warning**: By default, when withCall is a function, signal
@@ -97,12 +97,11 @@ export type EntityCallConfig<
    * to always execute on any value.
    */
   callWith?: Param extends undefined
-    ? Signal<boolean> | Observable<boolean> | (() => boolean) | boolean
+    ? Observable<boolean> | (() => boolean) | boolean
     :
         | NoInfer<Param>
         | null
         | undefined
-        | Signal<NoInfer<Param | null | undefined>>
         | Observable<NoInfer<Param | null | undefined>>
         | (() => NoInfer<Param> | null | undefined);
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.model.ts
@@ -106,6 +106,10 @@ export type EntityCallConfig<
         | (() => NoInfer<Param> | null | undefined);
 };
 
+export type ExtractEntityCallErrorType<
+  T extends EntityCall<any> | EntityCallConfig,
+> = T extends EntityCallConfig<any, any, any, infer E> ? E : unknown;
+
 export type NamedEntitiesCallsStatusComputed<
   Calls extends Record<string, EntityCall<any> | EntityCallConfig>,
 > = {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.spec.ts
@@ -233,6 +233,107 @@ describe('withEntitiesCalls', () => {
     });
   });
 
+  it('should return promise with value on success', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const apiResponse = new Subject<Partial<ProductDetail>>();
+      const Store = signalStore(
+        { protectedState: false },
+        withState({ foo: 'bar' }),
+        withEntities({ entity }),
+        withEntitiesCalls({
+          entity,
+          calls: () => ({
+            loadProductDetail: entityCallConfig({
+              call: ({ id }: { id: string }) => {
+                return apiResponse;
+              },
+              paramsSelectId: ({ id }) => id,
+            }),
+          }),
+        }),
+      );
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      const product = mockProducts[0];
+      const resultPromise = store.loadProductDetail({ id: product.id });
+      apiResponse.next({ detail: productDetail });
+      TestBed.tick();
+      const result = await resultPromise;
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value()?.detail).toEqual(productDetail);
+      }
+    });
+  });
+
+  it('should return promise with error on failure', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const apiResponse = new Subject<Partial<ProductDetail>>();
+      const Store = signalStore(
+        { protectedState: false },
+        withState({ foo: 'bar' }),
+        withEntities({ entity }),
+        withEntitiesCalls({
+          entity,
+          calls: () => ({
+            loadProductDetail: entityCallConfig({
+              call: ({ id }: { id: string }) => {
+                return apiResponse;
+              },
+              paramsSelectId: ({ id }) => id,
+            }),
+          }),
+        }),
+      );
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      const product = mockProducts[0];
+      const resultPromise = store.loadProductDetail({ id: product.id });
+      apiResponse.error(new Error('fail'));
+      TestBed.tick();
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error()).toEqual(new Error('fail'));
+      }
+    });
+  });
+
+  it('should return promise with mapped error when mapError is used', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const apiResponse = new Subject<Partial<ProductDetail>>();
+      const Store = signalStore(
+        { protectedState: false },
+        withState({ foo: 'bar' }),
+        withEntities({ entity }),
+        withEntitiesCalls({
+          entity,
+          calls: () => ({
+            loadProductDetail: entityCallConfig({
+              call: ({ id }: { id: string }) => {
+                return apiResponse;
+              },
+              paramsSelectId: ({ id }) => id,
+              mapError: (error, { id }) =>
+                (error as Error).message + ' ' + id,
+            }),
+          }),
+        }),
+      );
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      const product = mockProducts[0];
+      const resultPromise = store.loadProductDetail({ id: product.id });
+      apiResponse.error(new Error('fail'));
+      TestBed.tick();
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error()).toEqual('fail ' + product.id);
+      }
+    });
+  });
+
   it('Successful call using collection, should set status to loading and loaded ', async () => {
     TestBed.runInInjectionContext(() => {
       const apiResponse = new Subject<Partial<ProductDetail>>();

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
@@ -161,7 +161,7 @@ export function withEntitiesCalls<
       [K in keyof Calls]: Calls[K] extends (...args: infer P) => any
         ? {
             (param: P[0]): void;
-            (param: Observable<P[0]> | Signal<P[0]>): void;
+            (param: Observable<P[0]> | (() => P[0])): void;
           }
         : Calls[K] extends EntityCallConfig
           ? Parameters<Calls[K]['call']> extends undefined[]
@@ -171,7 +171,7 @@ export function withEntitiesCalls<
                 (
                   param:
                     | Observable<Parameters<Calls[K]['call']>[0]>
-                    | Signal<Parameters<Calls[K]['call']>[0]>,
+                    | (() => Parameters<Calls[K]['call']>[0]),
                 ): void;
               }
           : never;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
@@ -7,7 +7,7 @@ import {
   runInInjectionContext,
   Signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import {
   patchState,
   signalStoreFeature,
@@ -32,9 +32,9 @@ import {
   catchError,
   concatMap,
   finalize,
-  first,
   from,
   isObservable,
+  lastValueFrom,
   map,
   mergeMap,
   Observable,
@@ -53,12 +53,13 @@ import {
   CallStatus,
   NamedCallStatusState,
 } from '../with-call-status/with-call-status.model';
-import { ObservableCall } from '../with-calls/with-calls.model';
+import { ObservableCall, RxMethodRef } from '../with-calls/with-calls.model';
 import { withFeatureFactory } from '../with-feature-factory/with-feature-factory';
 import { StoreSource } from '../with-feature-factory/with-feature-factory.model';
 import {
   EntityCall,
   EntityCallConfig,
+  ExtractEntityCallErrorType,
   NamedEntitiesCallsStatusComputed,
   NamedEntitiesCallsStatusMethods,
 } from './with-entities-calls.model';
@@ -160,19 +161,29 @@ export function withEntitiesCalls<
     methods: NamedEntitiesCallsStatusMethods<Entity, Calls> & {
       [K in keyof Calls]: Calls[K] extends (...args: infer P) => any
         ? {
-            (param: P[0]): void;
-            (param: Observable<P[0]> | (() => P[0])): void;
+            (
+              param: P[0],
+            ): Promise<
+              | { value: Signal<Entity>; ok: true }
+              | { error: Signal<ExtractEntityCallErrorType<Calls[K]>>; ok: false }
+            >;
+            (param: Observable<P[0]> | (() => P[0])): RxMethodRef;
           }
         : Calls[K] extends EntityCallConfig
           ? Parameters<Calls[K]['call']> extends undefined[]
             ? () => void
             : {
-                (...param: Parameters<Calls[K]['call']>): void;
+                (
+                  ...param: Parameters<Calls[K]['call']>
+                ): Promise<
+                  | { value: Signal<Entity>; ok: true }
+                  | { error: Signal<ExtractEntityCallErrorType<Calls[K]>>; ok: false }
+                >;
                 (
                   param:
                     | Observable<Parameters<Calls[K]['call']>[0]>
                     | (() => Parameters<Calls[K]['call']>[0]),
-                ): void;
+                ): RxMethodRef;
               }
           : never;
     };
@@ -304,7 +315,7 @@ export function withEntitiesCalls<
                     : undefined)
                 : undefined;
               const inFlight = new Set<number | string>();
-              acc[callNameKey] = rxMethod<unknown[]>(
+              const reactiveMethod = rxMethod<unknown>(
                 pipe(
                   mergeMap((params: any) => {
                     const id =
@@ -436,6 +447,42 @@ export function withEntitiesCalls<
                   }),
                 ),
               );
+              acc[callNameKey] = function (param?: unknown) {
+                if (
+                  typeof param === 'function' ||
+                  param instanceof Observable ||
+                  isSignal(param)
+                ) {
+                  return reactiveMethod(param as any);
+                }
+
+                reactiveMethod(param as any);
+                const id =
+                  isCallConfig(call) && call.paramsSelectId
+                    ? call.paramsSelectId(param)
+                    : typeof param === 'object' &&
+                        param !== null &&
+                        'entity' in param
+                      ? selectId((param as any).entity)
+                      : selectId(param as any);
+                const entityStatus = computed(() => callState()[id]);
+                return lastValueFrom(
+                  toObservable(entityStatus, {
+                    injector: environmentInjector,
+                  }).pipe(
+                    filter((v) => v === 'loaded' || typeof v === 'object'),
+                    take(1),
+                    map((v) =>
+                      v === 'loaded'
+                        ? { value: computed(() => entityMap()[id]), ok: true as const }
+                        : {
+                            error: computed(() => typeof v === 'object' ? v.error : undefined),
+                            ok: false as const,
+                          },
+                    ),
+                  ),
+                );
+              };
               return acc;
             },
             {} as Record<string, any>,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.spec.ts
@@ -1,7 +1,128 @@
 import { Signal, signal } from '@angular/core';
 import { TestScheduler } from 'rxjs/testing';
 
-import { debounceFilterPipe } from './with-entities-filter.util';
+import { debounceFilterPipe, toFilterOptions } from './with-entities-filter.util';
+
+describe('toFilterOptions', () => {
+  it('should wrap raw Filter when no filter key exists', () => {
+    const defaultFilter = { search: '' };
+    const result = toFilterOptions({ search: 'hello' }, defaultFilter);
+    expect(result).toEqual({ filter: { search: 'hello' } });
+  });
+
+  it('should pass through FilterOptions with filter key', () => {
+    const defaultFilter = { search: '' };
+    const result = toFilterOptions(
+      { filter: { search: 'hello' } },
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: { search: 'hello' } });
+  });
+
+  it('should pass through FilterOptions with debounce', () => {
+    const defaultFilter = { search: '' };
+    const result = toFilterOptions(
+      { filter: { search: 'hello' }, debounce: 300 },
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: { search: 'hello' }, debounce: 300 });
+  });
+
+  it('should pass through FilterOptions with patch', () => {
+    const defaultFilter = { search: '', name: '' };
+    const result = toFilterOptions(
+      { filter: { search: 'hello' }, patch: true },
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: { search: 'hello' }, patch: true });
+  });
+
+  it('should pass through FilterOptions with empty filter in patch mode', () => {
+    const defaultFilter = { search: '', name: '' };
+    const result = toFilterOptions(
+      { filter: {}, patch: true },
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: {}, patch: true });
+  });
+
+  it('should pass through FilterOptions with forceLoad', () => {
+    const defaultFilter = { search: '' };
+    const result = toFilterOptions(
+      { filter: { search: 'hello' }, forceLoad: true },
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: { search: 'hello' }, forceLoad: true });
+  });
+
+  it('should pass through FilterOptions with skipLoadingCall', () => {
+    const defaultFilter = { search: '' };
+    const result = toFilterOptions(
+      { filter: { search: 'hello' }, skipLoadingCall: true },
+      defaultFilter,
+    );
+    expect(result).toEqual({
+      filter: { search: 'hello' },
+      skipLoadingCall: true,
+    });
+  });
+
+  it('should wrap raw Filter when filter key has null value', () => {
+    const defaultFilter = { filter: '' };
+    const result = toFilterOptions({ filter: null } as any, defaultFilter);
+    expect(result).toEqual({ filter: { filter: null } });
+  });
+
+  it('should wrap raw Filter when filter key has undefined value', () => {
+    const defaultFilter = { filter: '' };
+    const result = toFilterOptions(
+      { filter: undefined } as any,
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: { filter: undefined } });
+  });
+
+  it('should wrap raw Filter when Filter = {filter: string} and value is primitive', () => {
+    const defaultFilter = { filter: '' };
+    const result = toFilterOptions({ filter: 'hello' } as any, defaultFilter);
+    expect(result).toEqual({ filter: { filter: 'hello' } });
+  });
+
+  it('should wrap raw Filter when Filter = {filter: number} and value is primitive', () => {
+    const defaultFilter = { filter: 0 };
+    const result = toFilterOptions({ filter: 42 } as any, defaultFilter);
+    expect(result).toEqual({ filter: { filter: 42 } });
+  });
+
+  it('should wrap raw Filter when Filter = {filter: {name: string}} and value keys dont match defaultFilter', () => {
+    const defaultFilter = { filter: { name: '' } };
+    const result = toFilterOptions(
+      { filter: { name: 'hello' } },
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: { filter: { name: 'hello' } } });
+  });
+
+  it('should pass through FilterOptions when Filter = {filter: {name: string}} and value keys match defaultFilter', () => {
+    const defaultFilter = { filter: { name: '' } };
+    const result = toFilterOptions(
+      { filter: { filter: { name: 'hello' } } },
+      defaultFilter,
+    );
+    expect(result).toEqual({ filter: { filter: { name: 'hello' } } });
+  });
+
+  it('should wrap raw Filter with multiple keys', () => {
+    const defaultFilter = { search: '', category: '' };
+    const result = toFilterOptions(
+      { search: 'text', category: 'books' },
+      defaultFilter,
+    );
+    expect(result).toEqual({
+      filter: { search: 'text', category: 'books' },
+    });
+  });
+});
 
 describe('debounceFilterPipe', () => {
   let testScheduler: TestScheduler;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -108,7 +108,7 @@ export function getQueryMapperForEntitiesFilter<Filter>(config?: {
       if (filter) {
         const filterEntities = store[
           filterEntitiesKey
-        ] as EntitiesRemoteFilterMethods<unknown>['filterEntities'];
+        ] as EntitiesRemoteFilterMethods<unknown, unknown>['filterEntities'];
         filterEntities({
           filter,
           forceLoad: true,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -21,7 +21,9 @@ export function getWithEntitiesFilterKeys(config?: { collection?: string }) {
   const collection = config?.collection;
   const capitalizedProp = collection && capitalize(collection);
   return {
-    filterKey: collection ? `_${config.collection}EntitiesFilter` : '_entitiesFilter',
+    filterKey: collection
+      ? `_${config.collection}EntitiesFilter`
+      : '_entitiesFilter',
     computedFilterKey: collection
       ? `${config.collection}EntitiesFilter`
       : 'entitiesFilter',
@@ -157,7 +159,7 @@ export function getQueryMapperForEntitiesFilter<Filter>(config?: {
       if (filter) {
         const filterEntities = store[
           filterEntitiesKey
-        ] as EntitiesRemoteFilterMethods<unknown, unknown>['filterEntities'];
+        ] as EntitiesRemoteFilterMethods<any, any>['filterEntities'];
         filterEntities({
           filter,
           forceLoad: true,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -87,6 +87,55 @@ export type FilterQueryMapper<Filter, T extends Params = Params> = {
   filterToQueryParams: (filter: Filter) => T | undefined | null;
 };
 
+/**
+ * Normalizes FilterOptions to always return the {filter, debounce?, ...} format.
+ * Handles the case where a raw Filter object is passed directly.
+ */
+export function toFilterOptions<Filter extends Record<string, unknown>>(
+  options: Record<string, unknown>,
+  defaultFilter: Filter,
+): {
+  filter: Filter;
+  debounce?: number;
+  patch?: boolean;
+  forceLoad?: boolean;
+  skipLoadingCall?: boolean;
+} {
+  // FilterOptions requires 'filter' key - if missing, it's raw Filter
+  if (!('filter' in options)) {
+    return { filter: options } as any;
+  }
+
+  // filter value can't be null/undefined/primitive in FilterOptions
+  // (Filter extends Record<string, unknown>)
+  const filterValue = options['filter'];
+  if (
+    filterValue === null ||
+    filterValue === undefined ||
+    typeof filterValue !== 'object'
+  ) {
+    return { filter: options } as any;
+  }
+
+  // Check for FilterOptions-specific keys not present in defaultFilter
+  const defaultFilterKeys = new Set(Object.keys(defaultFilter));
+  const specificKeys = ['debounce', 'patch', 'forceLoad', 'skipLoadingCall'];
+  if (specificKeys.some((k) => k in options && !defaultFilterKeys.has(k))) {
+    return options as any; // has debounce/patch/etc → FilterOptions
+  }
+
+  // Check if filter value's keys overlap with defaultFilter keys
+  const filterValueKeys = new Set(
+    Object.keys(filterValue as Record<string, unknown>),
+  );
+  if ([...defaultFilterKeys].some((k) => filterValueKeys.has(k))) {
+    return options as any; // FilterOptions
+  }
+
+  // Default: raw Filter
+  return { filter: options } as any;
+}
+
 export function getQueryMapperForEntitiesFilter<Filter>(config?: {
   collection?: string;
   filterMapper?: FilterQueryMapper<Filter>;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
@@ -5,7 +5,7 @@ import {
   setAllEntities,
   withEntities,
 } from '@ngrx/signals/entities';
-import { of, Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import {
   withCallStatus,
@@ -596,6 +596,22 @@ describe('withEntitiesHybridFilter', () => {
         });
       }));
     });
+
+    it('should return promise with value on success for local filter', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.setLoaded();
+        const result = await store.filterEntities({
+          filter: { search: 'zero', categoryId: 'snes' },
+          forceLoad: true,
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value().length).toEqual(2);
+        }
+      });
+    });
   });
 
   describe('remote filter', () => {
@@ -1059,5 +1075,55 @@ describe('withEntitiesHybridFilter', () => {
         expect(store.productEntities().length).toEqual(11);
       });
     }));
+
+    it('should return promise with value on success', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const store = new Store();
+        TestBed.tick();
+        const result = await store.filterEntities({
+          filter: { search: 'zero', categoryId: 'gamecube' },
+          forceLoad: true,
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value().length).toEqual(1);
+        }
+      });
+    });
+
+    it('should return promise with error on failure', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const FailStore = signalStore(
+          withEntities({ entity }),
+          withCallStatus({ initialValue: 'loading' }),
+          withEntitiesHybridFilter({
+            entity,
+            defaultFilter: { search: '', categoryId: 'snes' } as Filter,
+            isRemoteFilter: (previous, current) =>
+              previous.categoryId !== current.categoryId,
+            filterFn: (entity, filter) =>
+              !filter?.search ||
+              entity?.name
+                .toLowerCase()
+                .includes(filter?.search.toLowerCase()),
+          }),
+          withEntitiesLoadingCall({
+            fetchEntities: () => {
+              return throwError(() => new Error('fail'));
+            },
+          }),
+        );
+        const store = new FailStore();
+        TestBed.tick();
+        const result = await store.filterEntities({
+          filter: { search: 'zero', categoryId: 'gamecube' },
+          forceLoad: true,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error()).toEqual(new Error('fail'));
+        }
+      });
+    });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
@@ -325,6 +325,26 @@ describe('withEntitiesHybridFilter', () => {
       });
     }));
 
+    it('should merge new filter with previous if patch true is set, using signal parameters ', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.setLoaded();
+        tick(400);
+        store.filterEntities(() => ({
+          filter: { search: 'zero' },
+          patch: true,
+        }));
+        expect(store.entities().length).toEqual(mockProducts.length);
+        tick(400);
+        expect(store.entities().length).toEqual(2);
+        store.filterEntities({
+          filter: { search: 'zero', categoryId: 'snes' },
+          forceLoad: true,
+        });
+      });
+    }));
+
     it(' should reset page to and selection when filter is executed', fakeAsync(() => {
       TestBed.runInInjectionContext(() => {
         const Store = signalStore(
@@ -1103,9 +1123,7 @@ describe('withEntitiesHybridFilter', () => {
               previous.categoryId !== current.categoryId,
             filterFn: (entity, filter) =>
               !filter?.search ||
-              entity?.name
-                .toLowerCase()
-                .includes(filter?.search.toLowerCase()),
+              entity?.name.toLowerCase().includes(filter?.search.toLowerCase()),
           }),
           withEntitiesLoadingCall({
             fetchEntities: () => {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
@@ -59,6 +59,7 @@ import {
   debounceFilterPipe,
   getWithEntitiesFilterEvents,
   getWithEntitiesFilterKeys,
+  toFilterOptions,
 } from './with-entities-filter.util';
 import {
   EntitiesFilterComputed,
@@ -311,7 +312,7 @@ export function withEntitiesHybridFilter<
               ) {
                 return filterEntities(options);
               }
-              filterEntities(options);
+              filterEntities(options ? toFilterOptions(options, defaultFilter) : undefined);
 
               return lastValueFrom(
                 toObservable(callState, { injector: environmentInjector }).pipe(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
@@ -1,4 +1,12 @@
-import { computed, effect, Signal, untracked } from '@angular/core';
+import {
+  computed,
+  effect,
+  EnvironmentInjector,
+  inject,
+  Signal,
+  untracked,
+} from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import {
   deepComputed,
   patchState,
@@ -20,10 +28,19 @@ import {
   SelectEntityId,
 } from '@ngrx/signals/entities';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { map, pipe, tap } from 'rxjs';
+import {
+  filter as filterPipe,
+  lastValueFrom,
+  map,
+  Observable,
+  pipe,
+  take,
+  tap,
+} from 'rxjs';
 
 import { getWithEntitiesKeys, insertIf } from '../util';
 import {
+  CallStatus,
   CallStatusMethods,
   NamedCallStatusMethods,
 } from '../with-call-status/with-call-status.model';
@@ -176,21 +193,22 @@ export function withEntitiesHybridFilter<
     ? {
         state: {};
         props: EntitiesFilterComputed<Filter>;
-        methods: EntitiesRemoteFilterMethods<Filter>;
+        methods: EntitiesRemoteFilterMethods<Filter, Entity>;
       }
     : {
         state: {};
         props: NamedEntitiesFilterComputed<Collection, Filter>;
-        methods: NamedEntitiesRemoteFilterMethods<Collection, Filter>;
+        methods: NamedEntitiesRemoteFilterMethods<Collection, Filter, Entity>;
       }
 > {
   return withFeatureFactory((store: StoreSource<Input>) => {
     const { defaultFilter, ...config } = getFeatureConfig(configFactory, store);
     const filterFn = config.filterFn;
-    const { entityMapKey, idsKey } = getWithEntitiesKeys(config);
-    const { setLoadingKey, loadedKey } = getWithCallStatusKeys({
-      collection: config.collection,
-    });
+    const { entityMapKey, idsKey, entitiesKey } = getWithEntitiesKeys(config);
+    const { setLoadingKey, loadedKey, callStatusKey, errorKey } =
+      getWithCallStatusKeys({
+        collection: config.collection,
+      });
     const {
       filterKey,
       filterEntitiesKey,
@@ -212,69 +230,107 @@ export function withEntitiesHybridFilter<
         };
       }),
       withEventHandler(),
-      withMethods((state: Record<string, Signal<unknown>>) => {
-        const setLoading = state[setLoadingKey] as () => void;
-        const isLoaded = state[loadedKey] as Signal<boolean>;
-        const filter = state[filterKey] as Signal<Filter>;
-        const entitiesMap = state[entityMapKey] as Signal<EntityMap<Entity>>;
-        // we create a computed entities that relies on the entitiesMap instead of
-        // using the computed state.entities from the withEntities , because this local filter is going to replace
-        // the ids array of the state with the filtered ids array, and the state.entities depends on it,
-        // so hour filter function needs the full list of entities always which will be always so we get them from entityMap
-        const entities = computed(() => Object.values(entitiesMap()));
-        const filterEntities = rxMethod<
-          | {
-              filter: Filter;
-              debounce?: number;
-              patch?: boolean;
-              forceLoad?: boolean;
-              skipLoadingCall?: boolean;
-            }
-          | undefined
-        >(
-          pipe(
-            map(
-              (options) =>
-                // if no options are provided, we use the default filter
-                // and forceLoad
-                options ?? {
-                  filter: filter(),
-                  debounce: config.defaultDebounce,
-                  forceLoad: true,
-                },
-            ),
-            debounceFilterPipe(filter, config.defaultDebounce),
-            tap((value) => {
-              const isRemote =
-                config.isRemoteFilter(value.filter, filter()) || !isLoaded();
-
-              patchState(state as WritableStateSource<any>, {
-                [filterKey]: value.filter,
-              });
-              if (!isRemote || value?.forceLoad) {
-                const newEntities = entities().filter((entity) => {
-                  return filterFn(entity, value.filter);
-                });
-                patchState(state as WritableStateSource<any>, {
-                  [idsKey]: newEntities.map((entity) =>
-                    config.selectId
-                      ? config.selectId(entity)
-                      : (entity as any)['id'],
-                  ),
-                });
+      withMethods(
+        (
+          state: Record<string, Signal<unknown>>,
+          environmentInjector = inject(EnvironmentInjector),
+        ) => {
+          const setLoading = state[setLoadingKey] as () => void;
+          const isLoaded = state[loadedKey] as Signal<boolean>;
+          const filter = state[filterKey] as Signal<Filter>;
+          const entitiesMap = state[entityMapKey] as Signal<EntityMap<Entity>>;
+          const filteredEntities = state[entitiesKey] as Signal<Entity[]>;
+          const callState = state[callStatusKey] as Signal<CallStatus>;
+          const error = state[errorKey] as Signal<unknown>;
+          // we create a computed entities that relies on the entitiesMap instead of
+          // using the computed state.entities from the withEntities , because this local filter is going to replace
+          // the ids array of the state with the filtered ids array, and the state.entities depends on it,
+          // so hour filter function needs the full list of entities always which will be always so we get them from entityMap
+          const entities = computed(() => Object.values(entitiesMap()));
+          const filterEntities = rxMethod<
+            | {
+                filter: Filter;
+                debounce?: number;
+                patch?: boolean;
+                forceLoad?: boolean;
+                skipLoadingCall?: boolean;
               }
-              broadcast(state, entitiesFilterChanged(value));
-              if (isRemote && !value?.skipLoadingCall) setLoading?.();
-            }),
-          ),
-        );
-        return {
-          [filterEntitiesKey]: filterEntities,
-          [resetEntitiesFilterKey]: () => {
-            filterEntities({ filter: defaultFilter });
-          },
-        };
-      }),
+            | undefined
+          >(
+            pipe(
+              map(
+                (options) =>
+                  // if no options are provided, we use the default filter
+                  // and forceLoad
+                  options ?? {
+                    filter: filter(),
+                    debounce: config.defaultDebounce,
+                    forceLoad: true,
+                  },
+              ),
+              debounceFilterPipe(filter, config.defaultDebounce),
+              tap((value) => {
+                const isRemote =
+                  config.isRemoteFilter(value.filter, filter()) || !isLoaded();
+
+                patchState(state as WritableStateSource<any>, {
+                  [filterKey]: value.filter,
+                });
+                if (!isRemote || value?.forceLoad) {
+                  const newEntities = entities().filter((entity) => {
+                    return filterFn(entity, value.filter);
+                  });
+                  patchState(state as WritableStateSource<any>, {
+                    [idsKey]: newEntities.map((entity) =>
+                      config.selectId
+                        ? config.selectId(entity)
+                        : (entity as any)['id'],
+                    ),
+                  });
+                }
+                broadcast(state, entitiesFilterChanged(value));
+                if (isRemote && !value?.skipLoadingCall) setLoading?.();
+              }),
+            ),
+          );
+          return {
+            [filterEntitiesKey]: (
+              options:
+                | {
+                    filter: Filter;
+                    debounce?: number;
+                    patch?: boolean;
+                    forceLoad?: boolean;
+                    skipLoadingCall?: boolean;
+                  }
+                | undefined,
+            ) => {
+              if (
+                options instanceof Observable ||
+                typeof options === 'function'
+              ) {
+                return filterEntities(options);
+              }
+              filterEntities(options);
+
+              return lastValueFrom(
+                toObservable(callState, { injector: environmentInjector }).pipe(
+                  filterPipe((v) => v === 'loaded' || typeof v === 'object'),
+                  take(1),
+                  map((v) =>
+                    v === 'loaded'
+                      ? { value: filteredEntities, ok: true }
+                      : { error: error, ok: false },
+                  ),
+                ),
+              );
+            },
+            [resetEntitiesFilterKey]: () => {
+              filterEntities({ filter: defaultFilter });
+            },
+          };
+        },
+      ),
       withHooks((state: Record<string, unknown>) => {
         const { loadedKey } = getWithCallStatusKeys({
           collection: config?.collection,

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -28,8 +28,8 @@ export type EntitiesFilterMethods<Filter> = {
   filterEntities: (
     options?:
       | FilterOptions<Filter>
+      | (() => FilterOptions<Filter>)
       | Observable<FilterOptions<Filter>>
-      | Signal<FilterOptions<Filter>>,
   ) => void;
   resetEntitiesFilter: () => void;
 };
@@ -37,8 +37,8 @@ export type NamedEntitiesFilterMethods<Collection extends string, Filter> = {
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: (
     options?:
       | FilterOptions<Filter>
+      | (() => FilterOptions<Filter>)
       | Observable<FilterOptions<Filter>>
-      | Signal<FilterOptions<Filter>>,
   ) => void;
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: () => void;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -15,6 +15,7 @@ export type NamedEntitiesFilterComputed<Collection extends string, Filter> = {
 } & { [K in Collection as `${K}EntitiesFilter`]: DeepSignal<Filter> };
 
 export type FilterOptions<Filter> =
+  | Filter
   | {
       filter: Filter;
       debounce?: number;
@@ -31,7 +32,10 @@ export type EntitiesFilterMethods<Filter, Entity> = {
   filterEntities: {
     (
       options?: FilterOptions<Filter>,
-    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    ): Promise<
+      | { value: Signal<Entity[]>; ok: true }
+      | { error: Signal<unknown>; ok: false }
+    >;
     (
       options?:
         | (() => FilterOptions<Filter>)
@@ -48,7 +52,10 @@ export type NamedEntitiesFilterMethods<
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
     (
       options?: FilterOptions<Filter>,
-    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    ): Promise<
+      | { value: Signal<Entity[]>; ok: true }
+      | { error: Signal<unknown>; ok: false }
+    >;
     (
       options?:
         | (() => FilterOptions<Filter>)

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -31,16 +31,16 @@ export type FilterOptions<Filter> =
 export type EntitiesFilterMethods<Filter, Entity> = {
   filterEntities: {
     (
+      options?:
+        | (() => FilterOptions<Filter>)
+        | Observable<FilterOptions<Filter>>,
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter>,
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | (() => FilterOptions<Filter>)
-        | Observable<FilterOptions<Filter>>,
-    ): RxMethodRef;
   };
   resetEntitiesFilter: () => void;
 };
@@ -51,16 +51,16 @@ export type NamedEntitiesFilterMethods<
 > = {
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
     (
+      options?:
+        | (() => FilterOptions<Filter>)
+        | Observable<FilterOptions<Filter>>,
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter>,
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | (() => FilterOptions<Filter>)
-        | Observable<FilterOptions<Filter>>,
-    ): RxMethodRef;
   };
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: () => void;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -1,6 +1,9 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from '@ngrx/signals';
+import { RxMethod } from '@ngrx/signals/rxjs-interop';
 import { Observable } from 'rxjs';
+
+import { RxMethodRef } from '../with-calls/with-calls.model';
 
 export type EntitiesFilterComputed<Filter> = {
   entitiesFilter: DeepSignal<Filter>;
@@ -24,22 +27,34 @@ export type FilterOptions<Filter> =
       patch: true;
       forceLoad?: boolean;
     };
-export type EntitiesFilterMethods<Filter> = {
-  filterEntities: (
-    options?:
-      | FilterOptions<Filter>
-      | (() => FilterOptions<Filter>)
-      | Observable<FilterOptions<Filter>>
-  ) => void;
+export type EntitiesFilterMethods<Filter, Entity> = {
+  filterEntities: {
+    (
+      options?: FilterOptions<Filter>,
+    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    (
+      options?:
+        | (() => FilterOptions<Filter>)
+        | Observable<FilterOptions<Filter>>,
+    ): RxMethodRef;
+  };
   resetEntitiesFilter: () => void;
 };
-export type NamedEntitiesFilterMethods<Collection extends string, Filter> = {
-  [K in Collection as `filter${Capitalize<string & K>}Entities`]: (
-    options?:
-      | FilterOptions<Filter>
-      | (() => FilterOptions<Filter>)
-      | Observable<FilterOptions<Filter>>
-  ) => void;
+export type NamedEntitiesFilterMethods<
+  Collection extends string,
+  Filter,
+  Entity,
+> = {
+  [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
+    (
+      options?: FilterOptions<Filter>,
+    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    (
+      options?:
+        | (() => FilterOptions<Filter>)
+        | Observable<FilterOptions<Filter>>,
+    ): RxMethodRef;
+  };
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: () => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
@@ -528,4 +528,19 @@ describe('withEntitiesLocalFilter', () => {
       });
     }));
   });
+
+  it('should return promise with value on success', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      const result = await store.filterEntities({
+        filter: { search: 'zero', foo: 'bar' },
+        forceLoad: true,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value().length).toEqual(2);
+      }
+    });
+  });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
@@ -282,6 +282,24 @@ describe('withEntitiesLocalFilter', () => {
     });
   }));
 
+  it('should merge new filter with previous if patch true is set, and using signal parameters ', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.filterEntities(() => ({
+        filter: { search: 'zero' },
+        patch: true,
+      }));
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      store.filterEntities({
+        filter: { search: 'zero', foo: 'bar' },
+        forceLoad: true,
+      });
+    });
+  }));
+
   it(' should reset page to and selection when filter is executed', fakeAsync(() => {
     TestBed.runInInjectionContext(() => {
       const Store = signalStore(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -20,7 +20,7 @@ import {
   SelectEntityId,
 } from '@ngrx/signals/entities';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { map, pipe, tap } from 'rxjs';
+import { map, Observable, pipe, tap } from 'rxjs';
 
 import { getWithEntitiesKeys } from '../util';
 import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
@@ -119,12 +119,12 @@ export function withEntitiesLocalFilter<
     ? {
         state: {};
         props: EntitiesFilterComputed<Filter>;
-        methods: EntitiesFilterMethods<Filter>;
+        methods: EntitiesFilterMethods<Filter, Entity>;
       }
     : {
         state: {};
         props: NamedEntitiesFilterComputed<Collection, Filter>;
-        methods: NamedEntitiesFilterMethods<Collection, Filter>;
+        methods: NamedEntitiesFilterMethods<Collection, Filter, Entity>;
       }
 > {
   return withFeatureFactory((store: StoreSource<Input>) => {
@@ -132,7 +132,7 @@ export function withEntitiesLocalFilter<
       configFactory,
       store,
     );
-    const { entityMapKey, idsKey } = getWithEntitiesKeys(config);
+    const { entityMapKey, idsKey, entitiesKey } = getWithEntitiesKeys(config);
     const { entitiesFilterChanged } = getWithEntitiesFilterEvents(config);
     const {
       filterEntitiesKey,
@@ -156,6 +156,7 @@ export function withEntitiesLocalFilter<
       withMethods((state: Record<string, Signal<unknown>>) => {
         const filter = state[filterKey] as Signal<Filter>;
         const entitiesMap = state[entityMapKey] as Signal<EntityMap<Entity>>;
+        const filteredEntities = state[entitiesKey] as Signal<Entity[]>;
         // we create a computed entities that relies on the entitiesMap instead of
         // using the computed state.entities from the withEntities , because this local filter is going to replace
         // the ids array of the state with the filtered ids array, and the state.entities depends on it,
@@ -204,7 +205,18 @@ export function withEntitiesLocalFilter<
           ),
         );
         return {
-          [filterEntitiesKey]: filterEntities,
+          [filterEntitiesKey]: (options: {
+              filter: Filter;
+              debounce?: number;
+              patch?: boolean;
+              forceLoad?: boolean;
+            }
+          | undefined) => {
+            if (options instanceof Observable || typeof options === 'function') 
+              return filterEntities(options);
+            filterEntities(options);
+            return Promise.resolve({ ok: true, value: filteredEntities });
+          },
           [resetEntitiesFilterKey]: () => {
             filterEntities({ filter: defaultFilter });
           },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -38,6 +38,7 @@ import {
   debounceFilterPipe,
   getWithEntitiesFilterEvents,
   getWithEntitiesFilterKeys,
+  toFilterOptions,
 } from './with-entities-filter.util';
 import {
   EntitiesFilterComputed,
@@ -212,9 +213,9 @@ export function withEntitiesLocalFilter<
               forceLoad?: boolean;
             }
           | undefined) => {
-            if (options instanceof Observable || typeof options === 'function') 
+            if (options instanceof Observable || typeof options === 'function')
               return filterEntities(options);
-            filterEntities(options);
+            filterEntities(options ? toFilterOptions(options, defaultFilter) : undefined);
             return Promise.resolve({ ok: true, value: filteredEntities });
           },
           [resetEntitiesFilterKey]: () => {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -7,16 +7,16 @@ import { FilterOptions } from './with-entities-local-filter.model';
 export type EntitiesRemoteFilterMethods<Filter, Entity> = {
   filterEntities: {
     (
+      options?:
+        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+        | (() => FilterOptions<Filter>),
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-        | (() => FilterOptions<Filter>),
-    ): RxMethodRef;
   };
   resetEntitiesFilter: (options?: {
     debounce?: number;
@@ -31,16 +31,16 @@ export type NamedEntitiesRemoteFilterMethods<
 > = {
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
     (
+      options?:
+        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+        | (() => FilterOptions<Filter>),
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-        | (() => FilterOptions<Filter>),
-    ): RxMethodRef;
   };
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: (options?: {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -1,15 +1,20 @@
 import { Signal } from '@angular/core';
 import { Observable } from 'rxjs';
 
+import { RxMethodRef } from '../with-calls/with-calls.model';
 import { FilterOptions } from './with-entities-local-filter.model';
 
-export type EntitiesRemoteFilterMethods<Filter> = {
-  filterEntities: (
-    options?:
-      | (FilterOptions<Filter> & { skipLoadingCall?: boolean })
-      | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-      | (() => FilterOptions<Filter>),
-  ) => void;
+export type EntitiesRemoteFilterMethods<Filter, Entity> = {
+  filterEntities: {
+    (
+      options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
+    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    (
+      options?:
+        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+        | (() => FilterOptions<Filter>),
+    ): RxMethodRef;
+  };
   resetEntitiesFilter: (options?: {
     debounce?: number;
     forceLoad?: boolean;
@@ -19,13 +24,18 @@ export type EntitiesRemoteFilterMethods<Filter> = {
 export type NamedEntitiesRemoteFilterMethods<
   Collection extends string,
   Filter,
+  Entity,
 > = {
-  [K in Collection as `filter${Capitalize<string & K>}Entities`]: (
-    options?:
-      | (FilterOptions<Filter> & { skipLoadingCall?: boolean })
-      | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-      | (() => FilterOptions<Filter>),
-  ) => void;
+  [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
+    (
+      options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
+    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    (
+      options?:
+        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+        | (() => FilterOptions<Filter>),
+    ): RxMethodRef;
+  };
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: (options?: {
     debounce?: number;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -8,7 +8,10 @@ export type EntitiesRemoteFilterMethods<Filter, Entity> = {
   filterEntities: {
     (
       options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
-    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    ): Promise<
+      | { value: Signal<Entity[]>; ok: true }
+      | { error: Signal<unknown>; ok: false }
+    >;
     (
       options?:
         | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
@@ -29,7 +32,10 @@ export type NamedEntitiesRemoteFilterMethods<
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
     (
       options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
-    ): Promise<{ value: Signal<Entity[]>; ok: true } | { error: Signal<unknown>; ok: false }>;
+    ): Promise<
+      | { value: Signal<Entity[]>; ok: true }
+      | { error: Signal<unknown>; ok: false }
+    >;
     (
       options?:
         | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -8,7 +8,7 @@ export type EntitiesRemoteFilterMethods<Filter> = {
     options?:
       | (FilterOptions<Filter> & { skipLoadingCall?: boolean })
       | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-      | Signal<FilterOptions<Filter> & { skipLoadingCall?: boolean }>,
+      | (() => FilterOptions<Filter>),
   ) => void;
   resetEntitiesFilter: (options?: {
     debounce?: number;
@@ -24,7 +24,7 @@ export type NamedEntitiesRemoteFilterMethods<
     options?:
       | (FilterOptions<Filter> & { skipLoadingCall?: boolean })
       | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-      | Signal<FilterOptions<Filter> & { skipLoadingCall?: boolean }>,
+      | (() => FilterOptions<Filter>),
   ) => void;
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: (options?: {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core/testing';
 import { patchState, signalStore, type, withState } from '@ngrx/signals';
 import { setAllEntities, withEntities } from '@ngrx/signals/entities';
-import { of, Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import {
   withCallStatus,
@@ -476,4 +476,70 @@ describe('withEntitiesRemoteFilter', () => {
       expect(store.entities().length).toEqual(23);
     });
   }));
+
+  it('should return promise with value on success', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const Store = signalStore(
+        { protectedState: false },
+        withEntities({ entity }),
+        withCallStatus({ initialValue: 'loading' }),
+        withEntitiesRemoteFilter({
+          entity,
+          defaultFilter: { search: '', foo: 'bar' },
+        }),
+        withEntitiesLoadingCall({
+          fetchEntities: ({ entitiesFilter }) => {
+            let result = [...mockProducts];
+            if (entitiesFilter()?.search) {
+              result = mockProducts.filter((e) =>
+                e.name
+                  .toLowerCase()
+                  .includes(entitiesFilter()!.search.toLowerCase()),
+              );
+            }
+            return of(result);
+          },
+        }),
+      );
+      const store = new Store();
+      TestBed.tick();
+      const result = await store.filterEntities({
+        filter: { search: 'zero', foo: 'bar' },
+        forceLoad: true,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value().length).toEqual(2);
+      }
+    });
+  });
+
+  it('should return promise with error on failure', async () => {
+    await TestBed.runInInjectionContext(async () => {
+      const Store = signalStore(
+        { protectedState: false },
+        withEntities({ entity }),
+        withCallStatus({ initialValue: 'loading' }),
+        withEntitiesRemoteFilter({
+          entity,
+          defaultFilter: { search: '', foo: 'bar' },
+        }),
+        withEntitiesLoadingCall({
+          fetchEntities: () => {
+            return throwError(() => new Error('fail'));
+          },
+        }),
+      );
+      const store = new Store();
+      TestBed.tick();
+      const result = await store.filterEntities({
+        filter: { search: 'zero', foo: 'bar' },
+        forceLoad: true,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error()).toEqual(new Error('fail'));
+      }
+    });
+  });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
@@ -273,6 +273,21 @@ describe('withEntitiesRemoteFilter', () => {
     });
   }));
 
+  it('should merge new filter with previous if patch true is set using signals', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      TestBed.tick();
+      store.filterEntities(() => ({
+        filter: { search: 'zero' },
+        patch: true,
+      }));
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
+    });
+  }));
+
   it(' should resetPage to and selection when filter is executed', fakeAsync(() => {
     TestBed.runInInjectionContext(() => {
       const Store = signalStore(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -50,6 +50,7 @@ import {
   debounceFilterPipe,
   getWithEntitiesFilterEvents,
   getWithEntitiesFilterKeys,
+  toFilterOptions,
 } from './with-entities-filter.util';
 import {
   EntitiesFilterComputed,
@@ -261,7 +262,7 @@ export function withEntitiesRemoteFilter<
               ) {
                 return filterEntities(options);
               }
-              filterEntities(options);
+              filterEntities(options ? toFilterOptions(options, defaultFilter) : undefined);
 
               return lastValueFrom(
                 toObservable(callState, { injector: environmentInjector }).pipe(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -1,4 +1,5 @@
-import { computed, Signal } from '@angular/core';
+import { computed, EnvironmentInjector, inject, Signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import {
   deepComputed,
   patchState,
@@ -17,13 +18,24 @@ import type {
   NamedEntityState,
 } from '@ngrx/signals/entities';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { map, pipe, tap } from 'rxjs';
-
 import {
+  filter as filterPipe,
+  lastValueFrom,
+  map,
+  Observable,
+  pipe,
+  take,
+  tap,
+} from 'rxjs';
+
+import { getWithEntitiesKeys } from '../util';
+import {
+  CallStatus,
   CallStatusMethods,
   NamedCallStatusMethods,
 } from '../with-call-status/with-call-status.model';
 import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
+import { Call } from '../with-calls/with-calls.model';
 import {
   broadcast,
   withEventHandler,
@@ -154,19 +166,20 @@ export function withEntitiesRemoteFilter<
     ? {
         state: {};
         props: EntitiesFilterComputed<Filter>;
-        methods: EntitiesRemoteFilterMethods<Filter>;
+        methods: EntitiesRemoteFilterMethods<Filter, Entity>;
       }
     : {
         state: {};
         props: NamedEntitiesFilterComputed<Collection, Filter>;
-        methods: NamedEntitiesRemoteFilterMethods<Collection, Filter>;
+        methods: NamedEntitiesRemoteFilterMethods<Collection, Filter, Entity>;
       }
 > {
   return withFeatureFactory((store: StoreSource<Input>) => {
     const { defaultFilter, ...config } = getFeatureConfig(configFactory, store);
-    const { setLoadingKey } = getWithCallStatusKeys({
+    const { setLoadingKey, callStatusKey, errorKey } = getWithCallStatusKeys({
       collection: config.collection,
     });
+    const { entitiesKey } = getWithEntitiesKeys(config);
     const {
       filterKey,
       filterEntitiesKey,
@@ -188,48 +201,86 @@ export function withEntitiesRemoteFilter<
         };
       }),
       withEventHandler(),
-      withMethods((state: Record<string, Signal<unknown>>) => {
-        const setLoading = state[setLoadingKey] as () => void;
-        const filter = state[filterKey] as Signal<Filter>;
+      withMethods(
+        (
+          state: Record<string, Signal<unknown>>,
+          environmentInjector = inject(EnvironmentInjector),
+        ) => {
+          const setLoading = state[setLoadingKey] as () => void;
+          const filter = state[filterKey] as Signal<Filter>;
+          const entities = state[entitiesKey] as Signal<Entity[]>;
+          const callState = state[callStatusKey] as Signal<CallStatus>;
+          const error = state[errorKey] as Signal<unknown>;
 
-        const filterEntities = rxMethod<
-          | {
-              filter: Filter;
-              debounce?: number;
-              patch?: boolean;
-              forceLoad?: boolean;
-              skipLoadingCall?: boolean;
-            }
-          | undefined
-        >(
-          pipe(
-            map(
-              (options) =>
-                // if no options are provided, we use the default filter
-                // and forceLoad
-                options ?? {
-                  filter: filter(),
-                  debounce: config.defaultDebounce,
-                  forceLoad: true,
-                },
+          const filterEntities = rxMethod<
+            | {
+                filter: Filter;
+                debounce?: number;
+                patch?: boolean;
+                forceLoad?: boolean;
+                skipLoadingCall?: boolean;
+              }
+            | undefined
+          >(
+            pipe(
+              map(
+                (options) =>
+                  // if no options are provided, we use the default filter
+                  // and forceLoad
+                  options ?? {
+                    filter: filter(),
+                    debounce: config.defaultDebounce,
+                    forceLoad: true,
+                  },
+              ),
+              debounceFilterPipe(filter, config.defaultDebounce),
+              tap((value) => {
+                patchState(state as WritableStateSource<any>, {
+                  [filterKey]: value.filter,
+                });
+                broadcast(state, entitiesFilterChanged(value));
+                if (!value?.skipLoadingCall) setLoading();
+              }),
             ),
-            debounceFilterPipe(filter, config.defaultDebounce),
-            tap((value) => {
-              patchState(state as WritableStateSource<any>, {
-                [filterKey]: value.filter,
-              });
-              broadcast(state, entitiesFilterChanged(value));
-              if (!value?.skipLoadingCall) setLoading();
-            }),
-          ),
-        );
-        return {
-          [filterEntitiesKey]: filterEntities,
-          [resetEntitiesFilterKey]: () => {
-            filterEntities({ filter: defaultFilter });
-          },
-        };
-      }),
+          );
+          return {
+            [filterEntitiesKey]: (
+              options:
+                | {
+                    filter: Filter;
+                    debounce?: number;
+                    patch?: boolean;
+                    forceLoad?: boolean;
+                    skipLoadingCall?: boolean;
+                  }
+                | undefined,
+            ) => {
+              if (
+                options instanceof Observable ||
+                typeof options === 'function'
+              ) {
+                return filterEntities(options);
+              }
+              filterEntities(options);
+
+              return lastValueFrom(
+                toObservable(callState, { injector: environmentInjector }).pipe(
+                  filterPipe((v) => v === 'loaded' || typeof v === 'object'),
+                  take(1),
+                  map((v) =>
+                    v === 'loaded'
+                      ? { value: entities, ok: true }
+                      : { error: error, ok: false },
+                  ),
+                ),
+              );
+            },
+            [resetEntitiesFilterKey]: () => {
+              filterEntities({ filter: defaultFilter });
+            },
+          };
+        },
+      ),
     );
   }) as any;
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
@@ -1,5 +1,6 @@
 import { computed, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { DeepSignal } from '@ngrx/signals';
 import { concatMap, take } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 
@@ -48,6 +49,7 @@ export function getQueryMapperForEntitiesPagination(config?: {
   skipLoadingCall?: boolean;
 }): QueryMapper<{
   page: string;
+  pageSize: string;
 }> {
   const { loadEntitiesPageKey, paginationKey } =
     getWithEntitiesLocalPaginationKeys(config);
@@ -57,6 +59,7 @@ export function getQueryMapperForEntitiesPagination(config?: {
   return {
     queryParamsToState: (query, store) => {
       const page = query.page;
+      const pageSize = query.pageSize;
 
       if (page) {
         const loadEntitiesPage = store[
@@ -83,18 +86,20 @@ export function getQueryMapperForEntitiesPagination(config?: {
           .subscribe(() => {
             loadEntitiesPage({
               pageIndex: +page - 1,
+              pageSize: pageSize ? +pageSize : undefined,
               skipLoadingCall: config?.skipLoadingCall,
             });
           });
       }
     },
     stateToQueryParams: (store) => {
-      const pagination = store[paginationKey] as Signal<
+      const pagination = store[paginationKey] as DeepSignal<
         EntitiesPaginationLocalState['entitiesPagination']
       >;
       return pagination
         ? computed(() => ({
-            page: (pagination().currentPage + 1).toString(),
+            page: (pagination.currentPage() + 1).toString(),
+            pageSize: pagination.pageSize().toString(),
           }))
         : null;
     },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.model.ts
@@ -34,7 +34,7 @@ export type EntitiesMultiSelectionMethods = {
       | Observable<
           EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }
         >
-      | Signal<EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }>,
+      | (() => EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }),
   ) => void;
   deselectEntities: (options: EntitySelectOptions) => void;
   toggleSelectEntities: (options: EntitySelectOptions) => void;
@@ -48,7 +48,7 @@ export type NamedEntitiesMultiSelectionMethods<Collection extends string> = {
       | Observable<
           EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }
         >
-      | Signal<EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }>,
+      | (() => EntitySelectOptions & { clearSelectionBeforeSelect?: boolean }),
   ) => void;
 } & {
   [K in Collection as `deselect${Capitalize<string & K>}Entities`]: (

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.spec.ts
@@ -19,6 +19,7 @@ describe('withEntitiesMultiSelection', () => {
       withEntities({ entity }),
       withEntitiesMultiSelection({ entity }),
     );
+
     it('selectEntities should select the entity', () => {
       TestBed.runInInjectionContext(() => {
         const store = new Store();
@@ -120,6 +121,56 @@ describe('withEntitiesMultiSelection', () => {
         expect(store.isAllEntitiesSelected()).toEqual('all');
         store.toggleSelectEntities({ id: mockProducts[4].id });
         expect(store.isAllEntitiesSelected()).toEqual('some');
+      });
+    });
+
+    it('selectEntities should not change state when ids are already selected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        const mapBefore = store.idsSelectedMap();
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        expect(store.idsSelectedMap()).toBe(mapBefore);
+      });
+    });
+
+    it('selectEntities should not change state when a single id is already selected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ id: mockProducts[4].id });
+        const mapBefore = store.idsSelectedMap();
+        store.selectEntities({ id: mockProducts[4].id });
+        expect(store.idsSelectedMap()).toBe(mapBefore);
+      });
+    });
+
+    it('deselectEntities should not change state when ids are already deselected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ ids: [mockProducts[4].id, mockProducts[8].id] });
+        store.deselectEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        const mapBefore = store.idsSelectedMap();
+        store.deselectEntities({
+          ids: [mockProducts[4].id, mockProducts[8].id],
+        });
+        expect(store.idsSelectedMap()).toEqual(mapBefore);
+      });
+    });
+
+    it('deselectEntities should not change state when a single id is already deselected', () => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.selectEntities({ id: mockProducts[4].id });
+        store.deselectEntities({ id: mockProducts[4].id });
+        const mapBefore = store.idsSelectedMap();
+        store.deselectEntities({ id: mockProducts[4].id });
+        expect(store.idsSelectedMap()).toEqual(mapBefore);
       });
     });
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.ts
@@ -211,9 +211,27 @@ export function withEntitiesMultiSelection<
         const isAllEntitiesSelected = state[isAllEntitiesSelectedKey] as Signal<
           'all' | 'none' | 'some'
         >;
-
+        const selectedIds = state[selectedEntitiesIdsKey] as Signal<
+          (string | number)[]
+        >;
         const idsArray = state[idsKey] as Signal<EntityId[]>;
 
+        function areAllIds({
+          ids,
+          selected,
+        }: {
+          ids: (string | number)[];
+          selected: boolean;
+        }) {
+          const previoslySelectedIds = selectedIds();
+          return (
+            previoslySelectedIds === ids ||
+            (previoslySelectedIds.length === ids.length &&
+              ids.every((id) =>
+                selected ? !!selectedIdsMap()[id] : !selectedIdsMap()[id],
+              ))
+          );
+        }
         return {
           [selectEntitiesKey]: rxMethod<
             { clearSelectionBeforeSelect?: boolean } & (
@@ -223,10 +241,13 @@ export function withEntitiesMultiSelection<
           >(
             pipe(
               tap((options) => {
+                const ids = 'id' in options ? [options.id] : options.ids;
+                // protect againts cyclic resetting
+                if (areAllIds({ ids, selected: true })) return;
+
                 if (options.clearSelectionBeforeSelect) {
                   clearEntitiesSelection(state, selectedIdsMapKey);
                 }
-                const ids = 'id' in options ? [options.id] : options.ids;
                 const idsMap = ids.reduce(
                   (acc, id) => {
                     acc[id] = true;
@@ -245,6 +266,9 @@ export function withEntitiesMultiSelection<
             options: { id: string | number } | { ids: (string | number)[] },
           ) => {
             const ids = 'id' in options ? [options.id] : options.ids;
+            // protect againts cyclic resetting
+            if (areAllIds({ ids, selected: false })) return;
+            
             const idsMap = ids.reduce(
               (acc, id) => {
                 acc[id] = false;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-multi-selection.util.ts
@@ -1,4 +1,12 @@
+import { computed, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { concatMap, take } from 'rxjs';
+import { filter, startWith } from 'rxjs/operators';
+
 import { capitalize } from '../util';
+import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
+import { QueryMapper } from '../with-sync-to-route-query-params/with-sync-to-route-query-params.util';
+import { EntitiesMultiSelectionMethods } from './with-entities-multi-selection.model';
 
 export function getEntitiesMultiSelectionKeys(config?: {
   collection?: string;
@@ -33,5 +41,71 @@ export function getEntitiesMultiSelectionKeys(config?: {
     isAllEntitiesSelectedKey: collection
       ? `isAll${capitalizedProp}EntitiesSelected`
       : 'isAllEntitiesSelected',
+  };
+}
+
+export function getQueryMapperForMultiSelection(config?: {
+  collection?: string;
+}): QueryMapper<{
+  selectedIds: string | undefined;
+}> {
+  const { selectedEntitiesIdsKey, selectEntitiesKey } =
+    getEntitiesMultiSelectionKeys(config);
+  const { loadingKey, loadedKey } = getWithCallStatusKeys({
+    collection: config?.collection,
+  });
+  return {
+    queryParamsToState: (query, store) => {
+      const selectedIds = query.selectedIds;
+      if (selectedIds) {
+        const selectEntities = store[
+          selectEntitiesKey
+        ] as EntitiesMultiSelectionMethods['selectEntities'];
+
+        const loading = store[loadingKey] as Signal<boolean>;
+
+        const ids = selectedIds
+          .split(',')
+          .map((id) => id.trim())
+          .filter(Boolean);
+
+        if (!loading) {
+          // if there is no loading signal, we can select the entities immediately
+          selectEntities({ ids });
+          return;
+        }
+
+        const loaded = store[loadedKey] as Signal<boolean>;
+        const loaded$ = toObservable(loaded);
+        toObservable(loading)
+          .pipe(
+            startWith(loading()),
+            filter((v) => v), // wait until loading becomes true
+            take(1),
+            concatMap(() =>
+              loaded$.pipe(
+                startWith(loaded()),
+                filter((v) => v), // wait until loaded becomes true
+                take(1),
+              ),
+            ),
+            takeUntilDestroyed(),
+          )
+          .subscribe(() => {
+            selectEntities({ ids });
+          });
+      }
+    },
+    stateToQueryParams: (store) => {
+      const selectedIds = store[selectedEntitiesIdsKey] as
+        | Signal<(string | number)[]>
+        | undefined;
+      return selectedIds
+        ? computed(() => ({
+            selectedIds:
+              selectedIds().length > 0 ? selectedIds().join(',') : undefined,
+          }))
+        : undefined;
+    },
   };
 }

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.model.ts
@@ -22,14 +22,14 @@ export type EntitiesSingleSelectionMethods = {
     options:
       | EntitySelectOptions
       | Observable<EntitySelectOptions>
-      | Signal<EntitySelectOptions>,
+      | (() => EntitySelectOptions),
   ) => void;
   deselectEntity: () => void;
   toggleSelectEntity: (
     options:
       | EntitySelectOptions
       | Observable<EntitySelectOptions>
-      | Signal<EntitySelectOptions>,
+      | (() => EntitySelectOptions),
   ) => void;
 };
 export type NamedEntitiesSingleSelectionMethods<Collection extends string> = {
@@ -37,7 +37,7 @@ export type NamedEntitiesSingleSelectionMethods<Collection extends string> = {
     options:
       | EntitySelectOptions
       | Observable<EntitySelectOptions>
-      | Signal<EntitySelectOptions>,
+      | (() => EntitySelectOptions),
   ) => void;
 } & {
   [K in Collection as `deselect${Capitalize<string & K>}Entity`]: () => void;
@@ -46,6 +46,6 @@ export type NamedEntitiesSingleSelectionMethods<Collection extends string> = {
     options:
       | EntitySelectOptions
       | Observable<EntitySelectOptions>
-      | Signal<EntitySelectOptions>,
+      | (() => EntitySelectOptions),
   ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-selection/with-entities-single-selection.util.ts
@@ -52,9 +52,17 @@ export function getQueryMapperForSingleSelection(config?: {
         ] as EntitiesSingleSelectionMethods['selectEntity'];
 
         const loading = store[loadingKey] as Signal<boolean>;
+
+        if (!loading) {
+          // if there is no loading signal, we can select the entity immediately
+          selectEntity({
+            id: selectedId,
+          });
+          return;
+        }
+
         const loaded = store[loadedKey] as Signal<boolean>;
         const loaded$ = toObservable(loaded);
-
         toObservable(loading)
           .pipe(
             startWith(loading()),

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
@@ -23,16 +23,34 @@ export type NamedEntitiesSortState<Entity, Collection extends string> = {
 export type EntitiesSortMethods<Entity> = {
   sortEntities: (
     options?:
+      | Sort<Entity>
+      | CdkSort<Entity>
       | { sort: Sort<Entity> | CdkSort<Entity> }
-      | Observable<{ sort: Sort<Entity> | CdkSort<Entity> }>
-      | (() => { sort: Sort<Entity> | CdkSort<Entity> }),
+      | Observable<
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | { sort: Sort<Entity> | CdkSort<Entity> }
+        >
+      | (() =>
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | { sort: Sort<Entity> | CdkSort<Entity> }),
   ) => void;
 };
 export type NamedEntitiesSortMethods<Entity, Collection extends string> = {
   [K in Collection as `sort${Capitalize<string & K>}Entities`]: (
     options?:
+      | Sort<Entity>
+      | CdkSort<Entity>
       | { sort: Sort<Entity> | CdkSort<Entity> }
-      | Observable<{ sort: Sort<Entity> | CdkSort<Entity> }>
-      | (() => { sort: Sort<Entity> | CdkSort<Entity> }),
+      | Observable<
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | { sort: Sort<Entity> | CdkSort<Entity> }
+        >
+      | (() =>
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | { sort: Sort<Entity> | CdkSort<Entity> }),
   ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.model.ts
@@ -1,4 +1,3 @@
-import { Signal } from '@angular/core';
 import { Observable } from 'rxjs';
 
 export type SortDirection = 'asc' | 'desc' | '';
@@ -26,7 +25,7 @@ export type EntitiesSortMethods<Entity> = {
     options?:
       | { sort: Sort<Entity> | CdkSort<Entity> }
       | Observable<{ sort: Sort<Entity> | CdkSort<Entity> }>
-      | Signal<{ sort: Sort<Entity> | CdkSort<Entity> }>,
+      | (() => { sort: Sort<Entity> | CdkSort<Entity> }),
   ) => void;
 };
 export type NamedEntitiesSortMethods<Entity, Collection extends string> = {
@@ -34,6 +33,6 @@ export type NamedEntitiesSortMethods<Entity, Collection extends string> = {
     options?:
       | { sort: Sort<Entity> | CdkSort<Entity> }
       | Observable<{ sort: Sort<Entity> | CdkSort<Entity> }>
-      | Signal<{ sort: Sort<Entity> | CdkSort<Entity> }>,
+      | (() => { sort: Sort<Entity> | CdkSort<Entity> }),
   ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.spec.ts
@@ -585,6 +585,116 @@ describe('withEntitiesLocalSort', () => {
     });
   }));
 
+  it('should sort entities when passing raw Sort directly', () => {
+    TestBed.runInInjectionContext(() => {
+      const Store = signalStore(
+        { protectedState: false, providedIn: 'root' },
+        withEntities({ entity }),
+        withEntitiesLocalSort({
+          entity,
+          defaultSort: { field: 'name', direction: 'asc' },
+        }),
+      );
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.sortEntities();
+
+      // pass raw Sort directly (no { sort: ... } wrapper)
+      store.sortEntities({ field: 'price', direction: 'desc' });
+      expect(
+        store
+          .entities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.entitiesSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
+    });
+  });
+
+  it('should sort entities when passing raw CdkSort directly', () => {
+    TestBed.runInInjectionContext(() => {
+      const Store = signalStore(
+        { protectedState: false, providedIn: 'root' },
+        withEntities({ entity }),
+        withEntitiesLocalSort({
+          entity,
+          defaultSort: { field: 'name', direction: 'asc' },
+        }),
+      );
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.sortEntities();
+
+      // pass raw CdkSort directly (no { sort: ... } wrapper)
+      store.sortEntities({ active: 'name', direction: 'asc' });
+      expect(
+        store
+          .entities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+      expect(store.entitiesSort()).toEqual({
+        field: 'name',
+        direction: 'asc',
+      });
+    });
+  });
+
+  it('with collection should sort entities when passing raw Sort directly', () => {
+    const collection = 'product';
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities({ entity, collection }),
+      withEntitiesLocalSort({
+        entity,
+        collection,
+        defaultSort: { field: 'name', direction: 'asc' },
+      }),
+    );
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts, { collection }));
+      store.sortProductEntities();
+
+      // pass raw Sort directly
+      store.sortProductEntities({ field: 'price', direction: 'desc' });
+      expect(
+        store
+          .productEntities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.productEntitiesSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
+
+      // pass raw CdkSort directly
+      store.sortProductEntities({ active: 'name', direction: 'asc' });
+      expect(
+        store
+          .productEntities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+    });
+  });
+
   it('should sort entities by release date', () => {
     const Store = signalStore(
       { protectedState: false },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.ts
@@ -17,7 +17,7 @@ import {
   SelectEntityId,
 } from '@ngrx/signals/entities';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { pipe, tap } from 'rxjs';
+import { isObservable, map, Observable, pipe, tap } from 'rxjs';
 
 import { getWithEntitiesKeys } from '../util';
 import { getWithCallStatusKeys } from '../with-call-status/with-call-status.util';
@@ -127,37 +127,64 @@ export function withEntitiesLocalSort<
       withState({ [sortKey]: defaultSort }),
       withEventHandler(),
       withMethods((state: Record<string, Signal<unknown>>) => {
-        return {
-          [sortEntitiesKey]: rxMethod<{
-            sort?: Sort<Entity> | CdkSort<Entity>;
-          }>(
-            pipe(
-              tap((options) => {
-                let newSort = options?.sort;
-                if (newSort && 'active' in newSort)
-                  newSort = {
-                    field: newSort.active,
-                    direction: newSort.direction,
-                  };
-                const sort = newSort ?? (state[sortKey]() as Sort<Entity>);
-                patchState(state as WritableStateSource<object>, {
-                  [sortKey]: sort,
-                  [idsKey]: (config?.sortFunction
-                    ? config.sortFunction(
-                        state[entitiesKey]() as Entity[],
-                        sort,
-                      )
-                    : sortData(state[entitiesKey]() as Entity[], sort)
-                  ).map((entity) =>
-                    config.selectId
-                      ? config.selectId(entity)
-                      : (entity as any).id,
-                  ),
-                });
-                broadcast(state, entitiesLocalSortChanged({ sort }));
-              }),
-            ),
+        const _sortEntities = rxMethod<{
+          sort?: Sort<Entity> | CdkSort<Entity>;
+        }>(
+          pipe(
+            tap((options) => {
+              let newSort = options?.sort;
+              if (newSort && 'active' in newSort)
+                newSort = {
+                  field: newSort.active,
+                  direction: newSort.direction,
+                };
+              const sort = newSort ?? (state[sortKey]() as Sort<Entity>);
+              patchState(state as WritableStateSource<object>, {
+                [sortKey]: sort,
+                [idsKey]: (config?.sortFunction
+                  ? config.sortFunction(
+                      state[entitiesKey]() as Entity[],
+                      sort,
+                    )
+                  : sortData(state[entitiesKey]() as Entity[], sort)
+                ).map((entity) =>
+                  config.selectId
+                    ? config.selectId(entity)
+                    : (entity as any).id,
+                ),
+              });
+              broadcast(state, entitiesLocalSortChanged({ sort }));
+            }),
           ),
+        );
+        function normalizeToWrapped(
+          options: unknown,
+        ): { sort: Sort<Entity> | CdkSort<Entity> } {
+          if (
+            options &&
+            typeof options === 'object' &&
+            ('field' in options || 'active' in options)
+          ) {
+            return { sort: options as Sort<Entity> | CdkSort<Entity> };
+          }
+          return options as { sort: Sort<Entity> | CdkSort<Entity> };
+        }
+        return {
+          [sortEntitiesKey]: (options?: unknown) => {
+            if (isObservable(options)) {
+              return _sortEntities(
+                (options as Observable<unknown>).pipe(
+                  map((v) => normalizeToWrapped(v)),
+                ),
+              );
+            }
+            if (typeof options === 'function') {
+              return _sortEntities(() =>
+                normalizeToWrapped((options as () => unknown)()),
+              );
+            }
+            return _sortEntities(normalizeToWrapped(options));
+          },
         };
       }),
       withEventHandler((state: Record<string, unknown>) => {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.model.ts
@@ -1,4 +1,3 @@
-import { Signal } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { CdkSort, Sort } from './with-entities-local-sort.model';
@@ -14,10 +13,10 @@ export type EntitiesRemoteSortMethods<Entity> = {
           sort: Sort<Entity> | CdkSort<Entity>;
           skipLoadingCall?: boolean;
         }>
-      | Signal<{
+      | (() => {
           sort: Sort<Entity> | CdkSort<Entity>;
           skipLoadingCall?: boolean;
-        }>,
+        }),
   ) => void;
 };
 export type NamedEntitiesRemoteSortMethods<
@@ -34,9 +33,9 @@ export type NamedEntitiesRemoteSortMethods<
           sort: Sort<Entity> | CdkSort<Entity>;
           skipLoadingCall?: boolean;
         }>
-      | Signal<{
+      | (() => {
           sort: Sort<Entity> | CdkSort<Entity>;
           skipLoadingCall?: boolean;
-        }>,
+        }),
   ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.model.ts
@@ -5,18 +5,27 @@ import { CdkSort, Sort } from './with-entities-local-sort.model';
 export type EntitiesRemoteSortMethods<Entity> = {
   sortEntities: (
     options?:
+      | Sort<Entity>
+      | CdkSort<Entity>
       | {
           sort: Sort<Entity> | CdkSort<Entity>;
           skipLoadingCall?: boolean;
         }
-      | Observable<{
-          sort: Sort<Entity> | CdkSort<Entity>;
-          skipLoadingCall?: boolean;
-        }>
-      | (() => {
-          sort: Sort<Entity> | CdkSort<Entity>;
-          skipLoadingCall?: boolean;
-        }),
+      | Observable<
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | {
+              sort: Sort<Entity> | CdkSort<Entity>;
+              skipLoadingCall?: boolean;
+            }
+        >
+      | (() =>
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | {
+              sort: Sort<Entity> | CdkSort<Entity>;
+              skipLoadingCall?: boolean;
+            }),
   ) => void;
 };
 export type NamedEntitiesRemoteSortMethods<
@@ -25,17 +34,26 @@ export type NamedEntitiesRemoteSortMethods<
 > = {
   [K in Collection as `sort${Capitalize<string & K>}Entities`]: (
     options?:
+      | Sort<Entity>
+      | CdkSort<Entity>
       | {
           sort: Sort<Entity> | CdkSort<Entity>;
           skipLoadingCall?: boolean;
         }
-      | Observable<{
-          sort: Sort<Entity> | CdkSort<Entity>;
-          skipLoadingCall?: boolean;
-        }>
-      | (() => {
-          sort: Sort<Entity> | CdkSort<Entity>;
-          skipLoadingCall?: boolean;
-        }),
+      | Observable<
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | {
+              sort: Sort<Entity> | CdkSort<Entity>;
+              skipLoadingCall?: boolean;
+            }
+        >
+      | (() =>
+          | Sort<Entity>
+          | CdkSort<Entity>
+          | {
+              sort: Sort<Entity> | CdkSort<Entity>;
+              skipLoadingCall?: boolean;
+            }),
   ) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.spec.ts
@@ -94,6 +94,157 @@ describe('withEntitiesRemoteSort', () => {
     });
   }));
 
+  it('should sort entities when passing raw Sort directly', fakeAsync(() => {
+    const Store = signalStore(
+      withEntities({ entity }),
+      withCallStatus({ initialValue: 'loading' }),
+      withEntitiesRemoteSort({
+        entity,
+        defaultSort: { field: 'name', direction: 'asc' },
+      }),
+      withEntitiesLoadingCall({
+        fetchEntities: ({ entitiesSort }) => {
+          let result = [...mockProducts];
+          if (entitiesSort()?.field) {
+            result = sortData(result, {
+              field: entitiesSort()?.field as any,
+              direction: entitiesSort().direction,
+            });
+          }
+          return Promise.resolve({ entities: result, total: result.length });
+        },
+      }),
+    );
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      TestBed.tick();
+      tick();
+
+      // pass raw Sort directly (no { sort: ... } wrapper)
+      store.sortEntities({ field: 'price', direction: 'desc' });
+      tick();
+      expect(
+        store
+          .entities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.entitiesSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
+    });
+  }));
+
+  it('should sort entities when passing raw CdkSort directly', fakeAsync(() => {
+    const Store = signalStore(
+      withEntities({ entity }),
+      withCallStatus({ initialValue: 'loading' }),
+      withEntitiesRemoteSort({
+        entity,
+        defaultSort: { field: 'name', direction: 'asc' },
+      }),
+      withEntitiesLoadingCall({
+        fetchEntities: ({ entitiesSort }) => {
+          let result = [...mockProducts];
+          if (entitiesSort()?.field) {
+            result = sortData(result, {
+              field: entitiesSort()?.field as any,
+              direction: entitiesSort().direction,
+            });
+          }
+          return Promise.resolve({ entities: result, total: result.length });
+        },
+      }),
+    );
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      TestBed.tick();
+      tick();
+
+      // pass raw CdkSort directly (no { sort: ... } wrapper)
+      store.sortEntities({ active: 'name', direction: 'asc' });
+      tick();
+      expect(
+        store
+          .entities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+      expect(store.entitiesSort()).toEqual({
+        field: 'name',
+        direction: 'asc',
+      });
+    });
+  }));
+
+  it('with collection should sort entities when passing raw Sort and CdkSort directly', fakeAsync(() => {
+    const collection = 'product';
+    const Store = signalStore(
+      withEntities({ entity, collection }),
+      withCallStatus({ initialValue: 'loading', collection }),
+      withEntitiesRemoteSort({
+        entity,
+        collection,
+        defaultSort: { field: 'name', direction: 'asc' },
+      }),
+      withEntitiesLoadingCall({
+        collection,
+        fetchEntities: ({ productEntitiesSort }) => {
+          let result = [...mockProducts];
+          if (productEntitiesSort()?.field) {
+            result = sortData(result, {
+              field: productEntitiesSort()?.field as any,
+              direction: productEntitiesSort().direction,
+            });
+          }
+          return Promise.resolve({ entities: result, total: result.length });
+        },
+      }),
+    );
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      TestBed.tick();
+      tick();
+
+      // pass raw Sort directly
+      store.sortProductEntities({ field: 'price', direction: 'desc' });
+      tick();
+      expect(
+        store
+          .productEntities()
+          .map((e) => e.price)
+          .slice(0, 5),
+      ).toEqual([178, 175, 172, 169, 166]);
+      expect(store.productEntitiesSort()).toEqual({
+        field: 'price',
+        direction: 'desc',
+      });
+
+      // pass raw CdkSort directly
+      store.sortProductEntities({ active: 'name', direction: 'asc' });
+      tick();
+      expect(
+        store
+          .productEntities()
+          .map((e) => e.name)
+          .slice(0, 5),
+      ).toEqual([
+        '1080° Avalanche',
+        'Animal Crossing',
+        'Arkanoid: Doh it Again',
+        'Battalion Wars',
+        'BattleClash',
+      ]);
+    });
+  }));
+
   it('should not sort entities if skipLoadingCall? is true but should store sort', fakeAsync(() => {
     const Store = signalStore(
       withEntities({

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-remote-sort.ts
@@ -11,7 +11,7 @@ import {
 import { EntityState, NamedEntityState } from '@ngrx/signals/entities';
 import { EntityProps, NamedEntityProps } from '@ngrx/signals/entities';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { pipe, tap } from 'rxjs';
+import { isObservable, map, Observable, pipe, tap } from 'rxjs';
 
 import {
   CallStatusMethods,
@@ -169,29 +169,62 @@ export function withEntitiesRemoteSort<
       withEventHandler(),
       withMethods((state: Record<string, Signal<unknown>>) => {
         const setLoading = state[setLoadingKey] as () => void;
-        return {
-          [sortEntitiesKey]: rxMethod<{
+        const _sortEntities = rxMethod<{
+          sort?: Sort<Entity> | CdkSort<Entity>;
+          skipLoadingCall?: boolean;
+        }>(
+          pipe(
+            tap((options) => {
+              let newSort = options?.sort;
+              if (newSort && 'active' in newSort)
+                newSort = {
+                  field: newSort.active,
+                  direction: newSort.direction,
+                };
+              const skipLoadingCall = options?.skipLoadingCall;
+              const sort = newSort ?? (state[sortKey]() as Sort<Entity>);
+              patchState(state as WritableStateSource<object>, {
+                [sortKey]: sort,
+              });
+              broadcast(state, entitiesRemoteSortChanged({ sort }));
+              if (!skipLoadingCall) setLoading();
+            }),
+          ),
+        );
+        function normalizeToWrapped(
+          options: unknown,
+        ): {
+          sort?: Sort<Entity> | CdkSort<Entity>;
+          skipLoadingCall?: boolean;
+        } {
+          if (
+            options &&
+            typeof options === 'object' &&
+            ('field' in options || 'active' in options)
+          ) {
+            return { sort: options as Sort<Entity> | CdkSort<Entity> };
+          }
+          return options as {
             sort?: Sort<Entity> | CdkSort<Entity>;
             skipLoadingCall?: boolean;
-          }>(
-            pipe(
-              tap((options) => {
-                let newSort = options?.sort;
-                if (newSort && 'active' in newSort)
-                  newSort = {
-                    field: newSort.active,
-                    direction: newSort.direction,
-                  };
-                const skipLoadingCall = options?.skipLoadingCall;
-                const sort = newSort ?? (state[sortKey]() as Sort<Entity>);
-                patchState(state as WritableStateSource<object>, {
-                  [sortKey]: sort,
-                });
-                broadcast(state, entitiesRemoteSortChanged({ sort }));
-                if (!skipLoadingCall) setLoading();
-              }),
-            ),
-          ),
+          };
+        }
+        return {
+          [sortEntitiesKey]: (options?: unknown) => {
+            if (isObservable(options)) {
+              return _sortEntities(
+                (options as Observable<unknown>).pipe(
+                  map((v) => normalizeToWrapped(v)),
+                ),
+              );
+            }
+            if (typeof options === 'function') {
+              return _sortEntities(() =>
+                normalizeToWrapped((options as () => unknown)()),
+              );
+            }
+            return _sortEntities(normalizeToWrapped(options));
+          },
         };
       }),
     );

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -7,6 +7,7 @@ import {
   withEntitiesLocalFilter,
   withEntitiesLocalPagination,
   withEntitiesLocalSort,
+  withEntitiesMultiSelection,
   withEntitiesRemoteFilter,
   withEntitiesRemotePagination,
   withEntitiesRemoteSort,
@@ -493,6 +494,93 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
         relativeTo: expect.anything(),
         queryParams: expect.objectContaining({
           selectedId: '3',
+        }),
+        queryParamsHandling: 'merge',
+      });
+    }));
+  });
+
+  describe('entities multi selection', () => {
+    const multiSelectionStoreFeature = ({
+      load,
+    }: { load?: Subject<boolean> } = {}) => {
+      return signalStoreFeature(
+        signalStoreFeature(
+          withEntities({ entity }),
+          withCallStatus({ initialValue: 'loading' }),
+          withEntitiesLocalPagination({ entity, pageSize: 10 }),
+          withEntitiesLocalSort({
+            entity,
+            defaultSort: { field: 'name', direction: 'asc' },
+          }),
+          withEntitiesLocalFilter({
+            entity,
+            defaultFilter: { search: '', foo: 'bar' },
+            filterFn: (entity, filter) =>
+              !filter?.search ||
+              entity?.name.toLowerCase().includes(filter?.search.toLowerCase()),
+          }),
+        ),
+        withEntitiesMultiSelection({ entity }),
+        withEntitiesLoadingCall({
+          fetchEntities: ({}) => {
+            const result = [...mockProducts.slice(0, 40)];
+            const total = result.length;
+            const response = { entities: result, total };
+            return load
+              ? load.pipe(
+                  filter(Boolean),
+                  map(() => response),
+                )
+              : of(response);
+          },
+        }),
+      );
+    };
+
+    it('url query params selectedIds should update store', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        multiSelectionStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          syncSingleSelection: false,
+          syncMultiSelection: true,
+        }),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { selectedIds: '2,3' },
+      });
+      TestBed.tick();
+      load.next(true);
+      tick(400);
+      expect(store.idsSelected()).toEqual(['2', '3']);
+    }));
+
+    it('changes on idsSelected should update url query params', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        multiSelectionStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          syncSingleSelection: false,
+          syncMultiSelection: true,
+        }),
+      );
+      const { store, router } = init({
+        Store,
+        queryParams: {},
+      });
+      TestBed.tick();
+      load.next(true);
+      tick(400);
+      store.selectEntities({ ids: ['3', '5'] });
+      tick(400);
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          selectedIds: '3,5',
         }),
         queryParamsHandling: 'merge',
       });

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -596,12 +596,29 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       );
       const { store } = init({
         Store,
-        queryParams: { page: '2' },
+        queryParams: { page: '2', pageSize: '5' },
       });
       TestBed.tick();
       load.next(true);
       tick(400);
       expect(store.entitiesPagination().currentPage).toEqual(1);
+      expect(store.entitiesPagination().pageSize).toEqual(5);
+    }));
+
+    it('url query params pageSize should update store pageSize', fakeAsync(() => {
+      const load = new Subject<boolean>();
+      const Store = signalStore(
+        localStoreFeature({ load }),
+        withEntitiesSyncToRouteQueryParams({ entity }),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { page: '1', pageSize: '20' },
+      });
+      TestBed.tick();
+      load.next(true);
+      tick(400);
+      expect(store.entitiesPagination().pageSize).toEqual(20);
     }));
 
     it('url query params with invalid page not updated store', fakeAsync(() => {
@@ -612,12 +629,13 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       );
       const { store } = init({
         Store,
-        queryParams: { page: '9999' },
+        queryParams: { page: '9999', pageSize: '5' },
       });
       TestBed.tick();
       load.next(true);
       tick(400);
       expect(store.entitiesPagination().currentPage).toEqual(0);
+      expect(store.entitiesPagination().pageSize).toEqual(5);
     }));
 
     it('changes on entities page should update url query params', fakeAsync(() => {
@@ -639,6 +657,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
         relativeTo: expect.anything(),
         queryParams: expect.objectContaining({
           page: '3',
+          pageSize: '10',
         }),
         queryParamsHandling: 'merge',
       });
@@ -680,6 +699,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
         relativeTo: expect.anything(),
         queryParams: expect.objectContaining({
           page: '3',
+          pageSize: '10',
         }),
         queryParamsHandling: 'merge',
       });
@@ -720,6 +740,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: expect.objectContaining({
         page: '3',
+        pageSize: '10',
         filter: JSON.stringify({ search: 'a', foo: 'bar2' }),
         sortBy: 'name',
         sortDirection: 'asc',
@@ -778,6 +799,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: expect.objectContaining({
         page: '3',
+        pageSize: '10',
         filter: JSON.stringify({ search: 'a', foo: 'bar2' }),
         sortBy: 'name',
         sortDirection: 'asc',
@@ -821,6 +843,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: expect.objectContaining({
         'p-page': '3',
+        'p-pageSize': '10',
         'p-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
         'p-sortBy': 'name',
         'p-sortDirection': 'asc',
@@ -871,6 +894,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: expect.objectContaining({
         'product-page': '3',
+        'product-pageSize': '10',
         'product-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
         'product-sortBy': 'name',
         'product-sortDirection': 'asc',
@@ -914,6 +938,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: expect.objectContaining({
         page: '3',
+        pageSize: '10',
         filter: JSON.stringify({ search: 'a', foo: 'bar2' }),
         sortBy: 'name',
         sortDirection: 'asc',
@@ -1021,6 +1046,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: expect.objectContaining({
         'product-page': '3',
+        'product-pageSize': '10',
         'product-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
         'product-sortBy': 'name',
         'product-sortDirection': 'asc',
@@ -1033,6 +1059,7 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: expect.objectContaining({
         'order-page': '3',
+        'order-pageSize': '10',
         'order-filter': JSON.stringify({ search: 'a', foo: 'bar2' }),
         'order-sortBy': 'name',
         'order-sortDirection': 'asc',

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
@@ -30,6 +30,7 @@ import {
   getQueryMapperForEntitiesFilter,
 } from '../with-entities-filter/with-entities-filter.util';
 import { getQueryMapperForEntitiesPagination } from '../with-entities-pagination/with-entities-local-pagination.util';
+import { getQueryMapperForMultiSelection } from '../with-entities-selection/with-entities-multi-selection.util';
 import { getQueryMapperForSingleSelection } from '../with-entities-selection/with-entities-single-selection.util';
 import { getQueryMapperForEntitiesSort } from '../with-entities-sort/with-entities-local-sort.util';
 import { StoreSource } from '../with-feature-factory/with-feature-factory.model';
@@ -110,6 +111,11 @@ export function withEntitiesSyncToRouteQueryParams<
   defaultDebounce?: number;
   restoreOnInit?: boolean;
   skipLoadingCall?: boolean;
+  syncFilter?: boolean;
+  syncPagination?: boolean;
+  syncSort?: boolean;
+  syncSingleSelection?: boolean;
+  syncMultiSelection?: boolean;
 }): SignalStoreFeature<
   Input &
     (Collection extends ''
@@ -134,20 +140,37 @@ export function withEntitiesSyncToRouteQueryParams<
   }
 > {
   const mappers = [
-    getQueryMapperForEntitiesPagination({
-      collection: config?.collection,
-      skipLoadingCall: config?.skipLoadingCall ?? false,
-    }),
-    getQueryMapperForEntitiesSort({
-      collection: config?.collection,
-      skipLoadingCall: config?.skipLoadingCall ?? false,
-    }),
-    getQueryMapperForEntitiesFilter({
-      collection: config?.collection,
-      filterMapper: config?.filterMapper,
-      skipLoadingCall: config?.skipLoadingCall ?? false,
-    }),
-    getQueryMapperForSingleSelection(config),
+    ...(config?.syncPagination !== false
+      ? [
+          getQueryMapperForEntitiesPagination({
+            collection: config?.collection,
+            skipLoadingCall: config?.skipLoadingCall ?? false,
+          }),
+        ]
+      : []),
+    ...(config?.syncSort !== false
+      ? [
+          getQueryMapperForEntitiesSort({
+            collection: config?.collection,
+            skipLoadingCall: config?.skipLoadingCall ?? false,
+          }),
+        ]
+      : []),
+    ...(config?.syncFilter !== false
+      ? [
+          getQueryMapperForEntitiesFilter({
+            collection: config?.collection,
+            filterMapper: config?.filterMapper,
+            skipLoadingCall: config?.skipLoadingCall ?? false,
+          }),
+        ]
+      : []),
+    ...(config?.syncSingleSelection !== false
+      ? [getQueryMapperForSingleSelection(config)]
+      : []),
+    ...(config?.syncMultiSelection === true
+      ? [getQueryMapperForMultiSelection(config)]
+      : []),
   ];
   const prefixString =
     config?.prefix === false ? undefined : config?.prefix ?? config?.collection;


### PR DESCRIPTION
## Summary
- Reorder filterEntities overload signatures in local and remote filter models, signal/observable overload first so TypeScript resolves signal params correctly
- Add tests for signal parameter usage in local, remote, and hybrid filter
