### PR TITLE
fix(signals): reorder filter overloads for correct signal param resolution

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
@@ -325,6 +325,26 @@ describe('withEntitiesHybridFilter', () => {
       });
     }));
 
+    it('should merge new filter with previous if patch true is set, using signal parameters', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.setLoaded();
+        tick(400);
+        store.filterEntities(() => ({
+          filter: { search: 'zero' },
+          patch: true,
+        }));
+        expect(store.entities().length).toEqual(mockProducts.length);
+        tick(400);
+        expect(store.entities().length).toEqual(2);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'snes',
+        });
+      });
+    }));
+
     it(' should reset page to and selection when filter is executed', fakeAsync(() => {
       TestBed.runInInjectionContext(() => {
         const Store = signalStore(
@@ -1103,9 +1123,7 @@ describe('withEntitiesHybridFilter', () => {
               previous.categoryId !== current.categoryId,
             filterFn: (entity, filter) =>
               !filter?.search ||
-              entity?.name
-                .toLowerCase()
-                .includes(filter?.search.toLowerCase()),
+              entity?.name.toLowerCase().includes(filter?.search.toLowerCase()),
           }),
           withEntitiesLoadingCall({
             fetchEntities: () => {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -31,16 +31,16 @@ export type FilterOptions<Filter> =
 export type EntitiesFilterMethods<Filter, Entity> = {
   filterEntities: {
     (
+      options?:
+        | (() => FilterOptions<Filter>)
+        | Observable<FilterOptions<Filter>>,
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter>,
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | (() => FilterOptions<Filter>)
-        | Observable<FilterOptions<Filter>>,
-    ): RxMethodRef;
   };
   resetEntitiesFilter: () => void;
 };
@@ -51,16 +51,16 @@ export type NamedEntitiesFilterMethods<
 > = {
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
     (
+      options?:
+        | (() => FilterOptions<Filter>)
+        | Observable<FilterOptions<Filter>>,
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter>,
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | (() => FilterOptions<Filter>)
-        | Observable<FilterOptions<Filter>>,
-    ): RxMethodRef;
   };
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: () => void;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
@@ -282,6 +282,21 @@ describe('withEntitiesLocalFilter', () => {
     });
   }));
 
+  it('should merge new filter with previous if patch true is set, and using signal parameters', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.filterEntities(() => ({
+        filter: { search: 'zero' },
+        patch: true,
+      }));
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
+    });
+  }));
+
   it(' should reset page to and selection when filter is executed', fakeAsync(() => {
     TestBed.runInInjectionContext(() => {
       const Store = signalStore(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -7,16 +7,16 @@ import { FilterOptions } from './with-entities-local-filter.model';
 export type EntitiesRemoteFilterMethods<Filter, Entity> = {
   filterEntities: {
     (
+      options?:
+        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+        | (() => FilterOptions<Filter>),
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-        | (() => FilterOptions<Filter>),
-    ): RxMethodRef;
   };
   resetEntitiesFilter: (options?: {
     debounce?: number;
@@ -31,16 +31,16 @@ export type NamedEntitiesRemoteFilterMethods<
 > = {
   [K in Collection as `filter${Capitalize<string & K>}Entities`]: {
     (
+      options?:
+        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
+        | (() => FilterOptions<Filter>),
+    ): RxMethodRef;
+    (
       options?: FilterOptions<Filter> & { skipLoadingCall?: boolean },
     ): Promise<
       | { value: Signal<Entity[]>; ok: true }
       | { error: Signal<unknown>; ok: false }
     >;
-    (
-      options?:
-        | Observable<FilterOptions<Filter> & { skipLoadingCall?: boolean }>
-        | (() => FilterOptions<Filter>),
-    ): RxMethodRef;
   };
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: (options?: {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
@@ -273,6 +273,21 @@ describe('withEntitiesRemoteFilter', () => {
     });
   }));
 
+  it('should merge new filter with previous if patch true is set using signals', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      TestBed.tick();
+      store.filterEntities(() => ({
+        filter: { search: 'zero' },
+        patch: true,
+      }));
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
+    });
+  }));
+
   it(' should resetPage to and selection when filter is executed', fakeAsync(() => {
     TestBed.runInInjectionContext(() => {
       const Store = signalStore(


### PR DESCRIPTION
Reorder filterEntities overload signatures in local and remote filter models, signal/observable overload first so TypeScript resolves signal params correctly
Add tests for signal parameter usage in local, remote, and hybrid filter