### PR TITLE
fix(signals): fix type withEntitiesSyncToRouteQueryParams 

### DIFF
--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-product-entities.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-product-entities.ts
@@ -9,6 +9,7 @@ import {
   withEntitiesRemotePagination,
   withEntitiesRemoteSort,
   withEntitiesSingleSelection,
+  withEntitiesSyncToRouteQueryParams,
 } from '@ngrx-traits/signals';
 import { signalStoreFeature, type } from '@ngrx/signals';
 import { entityConfig, withEntities } from '@ngrx/signals/entities';
@@ -42,6 +43,7 @@ export function withProductEntities() {
       defaultSort: { field: 'name', direction: 'asc' },
     }),
     withEntitiesSingleSelection(productEntityConfig),
+    withEntitiesSyncToRouteQueryParams(productEntityConfig),
     withEntitiesLoadingCall(
       (
         {

--- a/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-call-status/with-call-status.model.ts
@@ -4,7 +4,7 @@ export type CallStatus = 'init' | 'loading' | 'loaded' | { error: unknown };
 export type CallStatusState = {
   callStatus: CallStatus;
 };
-export type CallStatusComputed<Error = unknown> = {
+export type CallStatusComputed<Error = any> = {
   isLoading: Signal<boolean>;
 } & {
   isLoaded: Signal<boolean>;

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
@@ -100,7 +100,6 @@ export function withEntitiesSyncToRouteQueryParams<
   Entity,
   Filter,
   const Collection extends string = '',
-  Error = unknown,
 >(config: {
   entity: Entity;
   collection?: Collection;
@@ -115,15 +114,15 @@ export function withEntitiesSyncToRouteQueryParams<
     (Collection extends ''
       ? {
           state: EntityState<Entity> & CallStatusState;
-          props: EntityProps<Entity> & CallStatusComputed<Error>;
-          methods: CallStatusMethods<Error>;
+          props: EntityProps<Entity> & CallStatusComputed;
+          methods: CallStatusMethods;
         }
       : {
           state: NamedEntityState<Entity, Collection> &
             NamedCallStatusState<`${Collection}Entities`>;
           props: NamedEntityProps<Entity, Collection> &
-            NamedCallStatusComputed<`${Collection}Entities`, Error>;
-          methods: NamedCallStatusMethods<`${Collection}Entities`, Error>;
+            NamedCallStatusComputed<`${Collection}Entities`>;
+          methods: NamedCallStatusMethods<`${Collection}Entities`>;
         }),
   {
     state: {};


### PR DESCRIPTION
fix(signals): fix type withEntitiesSyncToRouteQueryParams to not break when error type is defined