### PR TITLE
fix(signals): add takeUntilDestroyed to loadFromQueryParams subscription

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
@@ -1,9 +1,9 @@
-import { computed } from '@angular/core';
+import { computed, createEnvironmentInjector, EnvironmentInjector } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter, Router } from '@angular/router';
 import { withSyncToRouteQueryParams } from '@ngrx-traits/signals';
 import { patchState, signalStore, withState } from '@ngrx/signals';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 describe('withSyncToRouteQueryParams', () => {
   function init({ debounce }: { debounce?: number } = {}) {
@@ -134,6 +134,69 @@ describe('withSyncToRouteQueryParams', () => {
     expect(store.test()).toBe('test2');
     expect(store.foo()).toBe('foo2');
     expect(store.bar()).toBe(true);
+  });
+
+  it('should unsubscribe from queryParams when store is destroyed', () => {
+    const queryParams$ = new Subject<Record<string, string>>();
+    const queryParamsToStateSpy = vi.fn(
+      (query: Record<string, string>, store: any) => {
+        patchState(store, {
+          test: query['test'],
+          foo: query['foo'],
+          bar: query['bar'] === 'true',
+        });
+      },
+    );
+    const Store = signalStore(
+      { protectedState: false },
+      withState({
+        test: 'test',
+        foo: 'foo',
+        bar: false,
+      }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          {
+            queryParamsToState: queryParamsToStateSpy,
+            stateToQueryParams: (store: any) =>
+              computed(() => ({
+                test: store.test(),
+                foo: store.foo(),
+                bar: store.bar().toString(),
+              })),
+          },
+        ],
+        restoreOnInit: false,
+      }),
+    );
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            queryParams: queryParams$,
+          }),
+        },
+      ],
+    });
+
+    // Create a child EnvironmentInjector so we can destroy it without breaking TestBed
+    const parentInjector = TestBed.inject(EnvironmentInjector);
+    const childInjector = createEnvironmentInjector([Store], parentInjector);
+    const store = childInjector.get(Store);
+
+    // Call loadFromQueryParams — sets up subscription on the Subject (no emission yet)
+    store.loadFromQueryParams();
+
+    // Destroy the child injector (simulates navigating away from the route)
+    childInjector.destroy();
+
+    // Emit after destruction — should NOT call the mapper or throw NG0205
+    expect(() => {
+      queryParams$.next({ test: 'c', foo: 'd', bar: 'false' });
+    }).not.toThrow();
+    expect(queryParamsToStateSpy).not.toHaveBeenCalled();
   });
 
   it('store should be synced with url query params with custom debounce', fakeAsync(() => {

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
@@ -1,5 +1,6 @@
 import {
   computed,
+  DestroyRef,
   EnvironmentInjector,
   inject,
   Injector,
@@ -7,15 +8,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import {
-  SignalStoreFeature,
-  signalStoreFeature,
-  SignalStoreFeatureResult,
-  type,
-  withHooks,
-  withMethods,
-  withState,
-} from '@ngrx/signals';
+import { SignalStoreFeature, signalStoreFeature, SignalStoreFeatureResult, type, withHooks, withMethods, withState } from '@ngrx/signals';
 import { concatWith, debounce, defaultIfEmpty, NEVER, take, timer } from 'rxjs';
 
 import { combineFunctionsInObject } from '../util';
@@ -86,6 +79,7 @@ export function withSyncToRouteQueryParams<
     withMethods((store) => {
       const injector = inject(Injector);
       const environmentInjector = inject(EnvironmentInjector);
+      const destroyRef = inject(DestroyRef);
       return combineFunctionsInObject(
         {
           loadFromQueryParams: () => {
@@ -93,6 +87,7 @@ export function withSyncToRouteQueryParams<
             activatedRoute.queryParams
               .pipe(
                 defaultIfEmpty({}), // Provide default empty object if observable completes without emitting
+                takeUntilDestroyed(destroyRef)
               )
               .subscribe((queryParams) => {
                 if (shallowEqualParams(lastPushedQueryParams, queryParams)) {


### PR DESCRIPTION
Fixes #283

### Problem
withSyncToRouteQueryParams creates a subscription to activatedRoute.queryParams in loadFromQueryParams() that is never cleaned up. When the store's injector is destroyed (e.g. navigating away from a route that scopes the store via providers), the subscription persists and calls runInInjectionContext() on the destroyed EnvironmentInjector, throwing NG0205.
The error accumulates on each visit to the route because new subscriptions are added but old ones are never removed.

### Fix
Capture DestroyRef via inject(DestroyRef) inside withMethods (at store creation time, where injection context is available).
Pipe takeUntilDestroyed(destroyRef) into the activatedRoute.queryParams subscription in loadFromQueryParams().
This matches the cleanup pattern already used in the onInit hook for the state-to-query-params direction in the same file.
Testing
Added a test that verifies no NG0205 error is thrown when queryParams emits after the store's injector has been destroyed.