### PR TITLE
chore: disable dependabot config to control by ui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,12 @@ updates:
    directory: "/"
    schedule:
      interval: weekly
- - package-ecosystem: "npm"
-   directory: "/"
-   schedule:
-     interval: weekly
- - package-ecosystem: "github-actions"
-   directory: "/"
-   schedule:
-     interval: weekly
+ # # disabled settings here so it can be controlled by github ui    
+ # - package-ecosystem: "npm"
+ #   directory: "/"
+ #   schedule:
+ #     interval: weekly
+ # - package-ecosystem: "github-actions"
+ #   directory: "/"
+ #   schedule:
+ #     interval: weekly


### PR DESCRIPTION
chore: disable dependabot config to control by ui