### PR TITLE
Filter improvements: runtime default, plain-state filter, signal args

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -22,9 +22,6 @@ export function getWithEntitiesFilterKeys(config?: { collection?: string }) {
   const capitalizedProp = collection && capitalize(collection);
   return {
     filterKey: collection
-      ? `_${config.collection}EntitiesFilter`
-      : '_entitiesFilter',
-    computedFilterKey: collection
       ? `${config.collection}EntitiesFilter`
       : 'entitiesFilter',
     filterEntitiesKey: collection

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -36,6 +36,9 @@ export function getWithEntitiesFilterKeys(config?: { collection?: string }) {
     resetEntitiesFilterKey: collection
       ? `reset${capitalizedProp}EntitiesFilter`
       : 'resetEntitiesFilter',
+    defaultFilterKey: collection
+      ? `_${config.collection}EntitiesDefaultFilter`
+      : '_entitiesDefaultFilter',
   };
 }
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
@@ -1,3 +1,4 @@
+import { computed } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { patchState, signalStore, type, withState } from '@ngrx/signals';
 import {
@@ -52,6 +53,115 @@ describe('withEntitiesHybridFilter', () => {
         store.filterEntities({
           filter: { search: 'zero', categoryId: 'snes' },
         });
+        tick(400);
+        expect(store.entities().length).toEqual(2);
+        expect(store.entities()).toEqual([
+          {
+            description: 'Super Nintendo Game',
+            id: '1',
+            name: 'F-Zero',
+            price: 12,
+            categoryId: 'snes',
+          },
+          {
+            description: 'GameCube Game',
+            id: '80',
+            name: 'F-Zero GX',
+            price: 55,
+            categoryId: 'gamecube',
+          },
+        ]);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'snes',
+        });
+        expect(store.entitiesFilter.search()).toEqual('zero');
+      });
+    }));
+
+    it('should filter entities and store filter using plain object as filter', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.setLoaded();
+
+        expect(store.entities().length).toEqual(mockProducts.length);
+        tick(400);
+        store.filterEntities({ search: 'zero', categoryId: 'snes' });
+        tick(400);
+        expect(store.entities().length).toEqual(2);
+        expect(store.entities()).toEqual([
+          {
+            description: 'Super Nintendo Game',
+            id: '1',
+            name: 'F-Zero',
+            price: 12,
+            categoryId: 'snes',
+          },
+          {
+            description: 'GameCube Game',
+            id: '80',
+            name: 'F-Zero GX',
+            price: 55,
+            categoryId: 'gamecube',
+          },
+        ]);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'snes',
+        });
+        expect(store.entitiesFilter.search()).toEqual('zero');
+      });
+    }));
+
+    it('should filter entities and store filter in a signal', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.setLoaded();
+
+        expect(store.entities().length).toEqual(mockProducts.length);
+        tick(400);
+        store.filterEntities(
+          computed(() => ({ filter: { search: 'zero', categoryId: 'snes' } })),
+        );
+        tick(400);
+        expect(store.entities().length).toEqual(2);
+        expect(store.entities()).toEqual([
+          {
+            description: 'Super Nintendo Game',
+            id: '1',
+            name: 'F-Zero',
+            price: 12,
+            categoryId: 'snes',
+          },
+          {
+            description: 'GameCube Game',
+            id: '80',
+            name: 'F-Zero GX',
+            price: 55,
+            categoryId: 'gamecube',
+          },
+        ]);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'snes',
+        });
+        expect(store.entitiesFilter.search()).toEqual('zero');
+      });
+    }));
+
+    it('should filter entities and store filter using plain object as filter of a signal', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.setLoaded();
+
+        expect(store.entities().length).toEqual(mockProducts.length);
+        tick(400);
+        store.filterEntities(
+          computed(() => ({ search: 'zero', categoryId: 'snes' })),
+        );
         tick(400);
         expect(store.entities().length).toEqual(2);
         expect(store.entities()).toEqual([
@@ -757,6 +867,85 @@ describe('withEntitiesHybridFilter', () => {
         });
       });
     }));
+
+    it('should filter entities and store filter using plain object as filter', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        tick();
+        store.filterEntities({ search: 'zero', categoryId: 'gamecube' });
+        expect(store.entities().length).toEqual(65);
+        tick(400);
+        expect(store.entities().length).toEqual(1);
+        expect(store.entities()).toEqual([
+          {
+            description: 'GameCube Game',
+            id: '80',
+            name: 'F-Zero GX',
+            price: 55,
+            categoryId: 'gamecube',
+          },
+        ]);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'gamecube',
+        });
+      });
+    }));
+
+    it('should filter entities and store filter in a signal', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        tick();
+        store.filterEntities(
+          computed(() => ({
+            filter: { search: 'zero', categoryId: 'gamecube' },
+          })),
+        );
+        expect(store.entities().length).toEqual(65);
+        tick(400);
+        expect(store.entities().length).toEqual(1);
+        expect(store.entities()).toEqual([
+          {
+            description: 'GameCube Game',
+            id: '80',
+            name: 'F-Zero GX',
+            price: 55,
+            categoryId: 'gamecube',
+          },
+        ]);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'gamecube',
+        });
+      });
+    }));
+
+    it('should filter entities and store filter using plain object as filter of a signal', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        tick();
+        store.filterEntities(
+          computed(() => ({ search: 'zero', categoryId: 'gamecube' })),
+        );
+        expect(store.entities().length).toEqual(65);
+        tick(400);
+        expect(store.entities().length).toEqual(1);
+        expect(store.entities()).toEqual([
+          {
+            description: 'GameCube Game',
+            id: '80',
+            name: 'F-Zero GX',
+            price: 55,
+            categoryId: 'gamecube',
+          },
+        ]);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'zero',
+          categoryId: 'gamecube',
+        });
+      });
+    }));
+
     it('should allow to set default filter from previous state', fakeAsync(() => {
       const Store = signalStore(
         withEntities({

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.spec.ts
@@ -630,6 +630,67 @@ describe('withEntitiesHybridFilter', () => {
         }
       });
     });
+
+    describe('resetEntitiesFilter with newDefaultFilter', () => {
+      it('should set filter to newDefaultFilter and apply local filtering', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          patchState(store, setAllEntities(mockProducts));
+          store.setLoaded();
+          tick(400);
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'snes' } });
+          tick(400);
+          expect(store.entitiesFilter()).toEqual({ search: 'zero', categoryId: 'snes' });
+          expect(store.entities().length).toEqual(2);
+        });
+      }));
+
+      it('should reset to new default when called without args after newDefaultFilter set', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          patchState(store, setAllEntities(mockProducts));
+          store.setLoaded();
+          tick(400);
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'snes' } });
+          tick(400);
+          store.filterEntities({ filter: { search: 'zzzyyyy', categoryId: 'snes' }, forceLoad: true });
+          tick(400);
+          expect(store.entities().length).toEqual(0);
+          store.resetEntitiesFilter();
+          tick(400);
+          expect(store.entitiesFilter()).toEqual({ search: 'zero', categoryId: 'snes' });
+          expect(store.entities().length).toEqual(2);
+        });
+      }));
+
+      it('isEntitiesFilterChanged should be false after resetEntitiesFilter with newDefaultFilter', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          patchState(store, setAllEntities(mockProducts));
+          store.setLoaded();
+          tick(400);
+          store.filterEntities({ filter: { search: 'zero', categoryId: 'snes' }, forceLoad: true });
+          tick(400);
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'snes' } });
+          tick(400);
+          expect(store.isEntitiesFilterChanged()).toBe(false);
+        });
+      }));
+
+      it('isEntitiesFilterChanged should be true when filtering away from the new default', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          patchState(store, setAllEntities(mockProducts));
+          store.setLoaded();
+          tick(400);
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'snes' } });
+          tick(400);
+          store.filterEntities({ filter: { search: 'mario', categoryId: 'snes' }, forceLoad: true });
+          tick(400);
+          expect(store.isEntitiesFilterChanged()).toBe(true);
+        });
+      }));
+    });
   });
 
   describe('remote filter', () => {
@@ -1140,6 +1201,59 @@ describe('withEntitiesHybridFilter', () => {
           expect(result.error()).toEqual(new Error('fail'));
         }
       });
+    });
+
+    describe('resetEntitiesFilter with newDefaultFilter', () => {
+      it('should set filter to newDefaultFilter and trigger remote load', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          tick();
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'gamecube' } });
+          tick(400);
+          expect(store.entitiesFilter()).toEqual({ search: 'zero', categoryId: 'gamecube' });
+          expect(store.entities().length).toEqual(1);
+        });
+      }));
+
+      it('should reset to new default when called without args after newDefaultFilter set', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          tick();
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'gamecube' } });
+          tick(400);
+          store.filterEntities({ filter: { search: 'zzzyyyy', categoryId: 'gamecube' }, forceLoad: true });
+          tick(400);
+          expect(store.entities().length).toEqual(0);
+          store.resetEntitiesFilter();
+          tick(400);
+          expect(store.entitiesFilter()).toEqual({ search: 'zero', categoryId: 'gamecube' });
+          expect(store.entities().length).toEqual(1);
+        });
+      }));
+
+      it('isEntitiesFilterChanged should be false after resetEntitiesFilter with newDefaultFilter', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          tick();
+          store.filterEntities({ filter: { search: 'zero', categoryId: 'gamecube' }, forceLoad: true });
+          tick(400);
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'gamecube' } });
+          tick(400);
+          expect(store.isEntitiesFilterChanged()).toBe(false);
+        });
+      }));
+
+      it('isEntitiesFilterChanged should be true when filtering away from the new default', fakeAsync(() => {
+        TestBed.runInInjectionContext(() => {
+          const store = new Store();
+          tick();
+          store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', categoryId: 'gamecube' } });
+          tick(400);
+          store.filterEntities({ filter: { search: 'mario', categoryId: 'gamecube' }, forceLoad: true });
+          tick(400);
+          expect(store.isEntitiesFilterChanged()).toBe(true);
+        });
+      }));
     });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import {
-  deepComputed,
   patchState,
   signalStoreFeature,
   SignalStoreFeature,
@@ -105,9 +104,9 @@ import {
  *   withEntitiesHybridFilter({
  *     entity,
  *     collection,
- *     defaultFilter: { name: '' , category: ''},
+ *     defaultFilter: { search: '' , category: ''},
  *     filterFn: (entity, filter) =>
- *        (!filter.name || entity.name.toLowerCase().includes(filter.name.toLowerCase()))
+ *        (!filter.search || entity.name.toLowerCase().includes(filter.search.toLowerCase()))
  *     // in this case the filter will call setProductEntitiesLoading() if the category changes, othewise
  *     // it will filter the entities locally using filterFn
  *     isRemoteFilter: (previous, current) => {
@@ -156,7 +155,7 @@ import {
  *  store.productEntitiesFilter // { search: string , category: string }
  *  // generates the following methods
  *  store.filterProductEntities  // (options: { filter: { search: string, category: string }, debounce?: number, patch?: boolean, forceLoad?: boolean, skipLoadingCall?:boolean }) => void
- *  store.resetProductEntitiesFilter  // (options?: { newDefaultFilter?: { name: string, category: string } }) => void — resets to defaultFilter or to newDefaultFilter if provided, updating the default for future resets
+ *  store.resetProductEntitiesFilter  // (options?: { newDefaultFilter?: { search: string, category: string } }) => void — resets to defaultFilter or to newDefaultFilter if provided, updating the default for future resets
  */
 export function withEntitiesHybridFilter<
   Input extends SignalStoreFeatureResult,
@@ -267,15 +266,16 @@ export function withEntitiesHybridFilter<
             | undefined
           >(
             pipe(
-              map(
-                (options) =>
-                  // if no options are provided, we use the default filter
-                  // and forceLoad
-                  options ?? {
-                    filter: filter(),
-                    debounce: config.defaultDebounce,
-                    forceLoad: true,
-                  },
+              map((options) =>
+                // if no options are provided, we use the default filter
+                // and forceLoad
+                options
+                  ? toFilterOptions(options, defaultFilter)
+                  : {
+                      filter: filter(),
+                      debounce: config.defaultDebounce,
+                      forceLoad: true,
+                    },
               ),
               debounceFilterPipe(filter, config.defaultDebounce),
               tap((value) => {
@@ -321,9 +321,7 @@ export function withEntitiesHybridFilter<
               ) {
                 return filterEntities(options);
               }
-              filterEntities(
-                options ? toFilterOptions(options, defaultFilter) : undefined,
-              );
+              filterEntities(options);
 
               return lastValueFrom(
                 toObservable(callState, { injector: environmentInjector }).pipe(

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
@@ -154,7 +154,7 @@ import {
  *  store.productEntitiesFilter // { search: string , category: string }
  *  // generates the following methods
  *  store.filterProductEntities  // (options: { filter: { search: string, category: string }, debounce?: number, patch?: boolean, forceLoad?: boolean, skipLoadingCall?:boolean }) => void
- *  store.resetProductEntitiesFilter  // () => void
+ *  store.resetProductEntitiesFilter  // (options?: { newDefaultFilter?: { name: string, category: string } }) => void — resets to defaultFilter or to newDefaultFilter if provided, updating the default for future resets
  */
 export function withEntitiesHybridFilter<
   Input extends SignalStoreFeatureResult,
@@ -212,6 +212,7 @@ export function withEntitiesHybridFilter<
       });
     const {
       filterKey,
+      defaultFilterKey,
       filterEntitiesKey,
       resetEntitiesFilterKey,
       isEntitiesFilterChangedKey,
@@ -220,12 +221,13 @@ export function withEntitiesHybridFilter<
     const { entitiesFilterChanged } = getWithEntitiesFilterEvents(config);
 
     return signalStoreFeature(
-      withState({ [filterKey]: defaultFilter }),
+      withState({ [filterKey]: defaultFilter, [defaultFilterKey]: defaultFilter }),
       withComputed((state: Record<string, Signal<unknown>>) => {
         const filter = state[filterKey] as Signal<Filter>;
+        const currentDefault = state[defaultFilterKey] as Signal<Filter>;
         return {
           [isEntitiesFilterChangedKey]: computed(() => {
-            return JSON.stringify(filter()) !== JSON.stringify(defaultFilter);
+            return JSON.stringify(filter()) !== JSON.stringify(currentDefault());
           }),
           [computedFilterKey]: deepComputed(() => filter()),
         };
@@ -330,8 +332,18 @@ export function withEntitiesHybridFilter<
                 ),
               );
             },
-            [resetEntitiesFilterKey]: () => {
-              filterEntities({ filter: defaultFilter });
+            [resetEntitiesFilterKey]: (options?: {
+              newDefaultFilter?: Filter;
+              debounce?: number;
+              forceLoad?: boolean;
+              skipLoadingCall?: boolean;
+            }) => {
+              const newDefault = options?.newDefaultFilter;
+              if (newDefault) {
+                patchState(state as WritableStateSource<any>, { [defaultFilterKey]: newDefault });
+              }
+              const currentDefault = newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
+              filterEntities({ filter: currentDefault, debounce: options?.debounce, forceLoad: options?.forceLoad, skipLoadingCall: options?.skipLoadingCall });
             },
           };
         },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
@@ -63,7 +63,9 @@ import {
 } from './with-entities-filter.util';
 import {
   EntitiesFilterComputed,
+  EntitiesFilterState,
   NamedEntitiesFilterComputed,
+  NamedEntitiesFilterState,
 } from './with-entities-local-filter.model';
 import {
   EntitiesRemoteFilterMethods,
@@ -192,12 +194,12 @@ export function withEntitiesHybridFilter<
         }),
   Collection extends ''
     ? {
-        state: {};
+        state: EntitiesFilterState<Filter>;
         props: EntitiesFilterComputed<Filter>;
         methods: EntitiesRemoteFilterMethods<Filter, Entity>;
       }
     : {
-        state: {};
+        state: NamedEntitiesFilterState<Collection, Filter>;
         props: NamedEntitiesFilterComputed<Collection, Filter>;
         methods: NamedEntitiesRemoteFilterMethods<Collection, Filter, Entity>;
       }
@@ -216,20 +218,23 @@ export function withEntitiesHybridFilter<
       filterEntitiesKey,
       resetEntitiesFilterKey,
       isEntitiesFilterChangedKey,
-      computedFilterKey,
     } = getWithEntitiesFilterKeys(config);
     const { entitiesFilterChanged } = getWithEntitiesFilterEvents(config);
 
     return signalStoreFeature(
-      withState({ [filterKey]: defaultFilter, [defaultFilterKey]: defaultFilter }),
+      withState({
+        [filterKey]: defaultFilter,
+        [defaultFilterKey]: defaultFilter,
+      }),
       withComputed((state: Record<string, Signal<unknown>>) => {
         const filter = state[filterKey] as Signal<Filter>;
         const currentDefault = state[defaultFilterKey] as Signal<Filter>;
         return {
           [isEntitiesFilterChangedKey]: computed(() => {
-            return JSON.stringify(filter()) !== JSON.stringify(currentDefault());
+            return (
+              JSON.stringify(filter()) !== JSON.stringify(currentDefault())
+            );
           }),
-          [computedFilterKey]: deepComputed(() => filter()),
         };
       }),
       withEventHandler(),
@@ -340,10 +345,18 @@ export function withEntitiesHybridFilter<
             }) => {
               const newDefault = options?.newDefaultFilter;
               if (newDefault) {
-                patchState(state as WritableStateSource<any>, { [defaultFilterKey]: newDefault });
+                patchState(state as WritableStateSource<any>, {
+                  [defaultFilterKey]: newDefault,
+                });
               }
-              const currentDefault = newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
-              filterEntities({ filter: currentDefault, debounce: options?.debounce, forceLoad: options?.forceLoad, skipLoadingCall: options?.skipLoadingCall });
+              const currentDefault =
+                newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
+              filterEntities({
+                filter: currentDefault,
+                debounce: options?.debounce,
+                forceLoad: options?.forceLoad,
+                skipLoadingCall: options?.skipLoadingCall,
+              });
             },
           };
         },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -42,7 +42,12 @@ export type EntitiesFilterMethods<Filter, Entity> = {
       | { error: Signal<unknown>; ok: false }
     >;
   };
-  resetEntitiesFilter: () => void;
+  resetEntitiesFilter: (options?: {
+    newDefaultFilter?: Filter;
+    debounce?: number;
+    forceLoad?: boolean;
+    skipLoadingCall?: boolean;
+  }) => void;
 };
 export type NamedEntitiesFilterMethods<
   Collection extends string,
@@ -63,5 +68,10 @@ export type NamedEntitiesFilterMethods<
     >;
   };
 } & {
-  [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: () => void;
+  [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: (options?: {
+    newDefaultFilter?: Filter;
+    debounce?: number;
+    forceLoad?: boolean;
+    skipLoadingCall?: boolean;
+  }) => void;
 };

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.model.ts
@@ -1,18 +1,23 @@
 import { Signal } from '@angular/core';
 import { DeepSignal } from '@ngrx/signals';
-import { RxMethod } from '@ngrx/signals/rxjs-interop';
 import { Observable } from 'rxjs';
 
 import { RxMethodRef } from '../with-calls/with-calls.model';
 
+export type EntitiesFilterState<Filter> = {
+  entitiesFilter: Filter;
+};
 export type EntitiesFilterComputed<Filter> = {
-  entitiesFilter: DeepSignal<Filter>;
   isEntitiesFilterChanged: Signal<boolean>;
+};
+
+export type NamedEntitiesFilterState<Collection extends string, Filter> = {
+  [K in Collection as `${K}EntitiesFilter`]: Filter;
 };
 
 export type NamedEntitiesFilterComputed<Collection extends string, Filter> = {
   [K in Collection as `is${Capitalize<string & K>}EntitiesFilterChanged`]: Signal<boolean>;
-} & { [K in Collection as `${K}EntitiesFilter`]: DeepSignal<Filter> };
+};
 
 export type FilterOptions<Filter> =
   | Filter

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
@@ -1,3 +1,4 @@
+import { computed } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { patchState, signalStore, type, withState } from '@ngrx/signals';
 import {
@@ -40,6 +41,95 @@ describe('withEntitiesLocalFilter', () => {
       store.filterEntities({
         filter: { search: 'zero', foo: 'bar2' },
       });
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entities()).toEqual([
+        {
+          description: 'Super Nintendo Game',
+          id: '1',
+          name: 'F-Zero',
+          price: 12,
+          categoryId: 'snes',
+        },
+        {
+          description: 'GameCube Game',
+          id: '80',
+          name: 'F-Zero GX',
+          price: 55,
+          categoryId: 'gamecube',
+        },
+      ]);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      expect(store.entitiesFilter.search()).toEqual('zero');
+    });
+  }));
+
+  it('should filter entities and store filter using plain object as filter', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.filterEntities({ search: 'zero', foo: 'bar2' });
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entities()).toEqual([
+        {
+          description: 'Super Nintendo Game',
+          id: '1',
+          name: 'F-Zero',
+          price: 12,
+          categoryId: 'snes',
+        },
+        {
+          description: 'GameCube Game',
+          id: '80',
+          name: 'F-Zero GX',
+          price: 55,
+          categoryId: 'gamecube',
+        },
+      ]);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      expect(store.entitiesFilter.search()).toEqual('zero');
+    });
+  }));
+
+  it('should filter entities and store filter in a signal', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.filterEntities(
+        computed(() => ({ filter: { search: 'zero', foo: 'bar2' } })),
+      );
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entities()).toEqual([
+        {
+          description: 'Super Nintendo Game',
+          id: '1',
+          name: 'F-Zero',
+          price: 12,
+          categoryId: 'snes',
+        },
+        {
+          description: 'GameCube Game',
+          id: '80',
+          name: 'F-Zero GX',
+          price: 55,
+          categoryId: 'gamecube',
+        },
+      ]);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      expect(store.entitiesFilter.search()).toEqual('zero');
+    });
+  }));
+
+  it('should filter entities and store filter using plain object as filter of a signal', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      patchState(store, setAllEntities(mockProducts));
+      store.filterEntities(computed(() => ({ search: 'zero', foo: 'bar2' })));
       expect(store.entities().length).toEqual(mockProducts.length);
       tick(400);
       expect(store.entities().length).toEqual(2);
@@ -564,7 +654,9 @@ describe('withEntitiesLocalFilter', () => {
       TestBed.runInInjectionContext(() => {
         const store = new Store();
         patchState(store, setAllEntities(mockProducts));
-        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        store.resetEntitiesFilter({
+          newDefaultFilter: { search: 'zero', foo: 'bar' },
+        });
         tick(400);
         expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
         expect(store.entities().length).toEqual(2);
@@ -575,9 +667,14 @@ describe('withEntitiesLocalFilter', () => {
       TestBed.runInInjectionContext(() => {
         const store = new Store();
         patchState(store, setAllEntities(mockProducts));
-        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        store.resetEntitiesFilter({
+          newDefaultFilter: { search: 'zero', foo: 'bar' },
+        });
         tick(400);
-        store.filterEntities({ filter: { search: 'zzzyyyy', foo: 'bar' }, forceLoad: true });
+        store.filterEntities({
+          filter: { search: 'zzzyyyy', foo: 'bar' },
+          forceLoad: true,
+        });
         tick(400);
         expect(store.entities().length).toEqual(0);
         store.resetEntitiesFilter();
@@ -591,9 +688,14 @@ describe('withEntitiesLocalFilter', () => {
       TestBed.runInInjectionContext(() => {
         const store = new Store();
         patchState(store, setAllEntities(mockProducts));
-        store.filterEntities({ filter: { search: 'zero', foo: 'bar' }, forceLoad: true });
+        store.filterEntities({
+          filter: { search: 'zero', foo: 'bar' },
+          forceLoad: true,
+        });
         tick(400);
-        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        store.resetEntitiesFilter({
+          newDefaultFilter: { search: 'zero', foo: 'bar' },
+        });
         tick(400);
         expect(store.isEntitiesFilterChanged()).toBe(false);
       });
@@ -603,9 +705,14 @@ describe('withEntitiesLocalFilter', () => {
       TestBed.runInInjectionContext(() => {
         const store = new Store();
         patchState(store, setAllEntities(mockProducts));
-        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        store.resetEntitiesFilter({
+          newDefaultFilter: { search: 'zero', foo: 'bar' },
+        });
         tick(400);
-        store.filterEntities({ filter: { search: 'mario', foo: 'bar' }, forceLoad: true });
+        store.filterEntities({
+          filter: { search: 'mario', foo: 'bar' },
+          forceLoad: true,
+        });
         tick(400);
         expect(store.isEntitiesFilterChanged()).toBe(true);
       });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.spec.ts
@@ -558,4 +558,57 @@ describe('withEntitiesLocalFilter', () => {
       }
     });
   });
+
+  describe('resetEntitiesFilter with newDefaultFilter', () => {
+    it('should set filter to newDefaultFilter and apply filtering', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
+        expect(store.entities().length).toEqual(2);
+      });
+    }));
+
+    it('should reset to new default when called without args after newDefaultFilter set', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        store.filterEntities({ filter: { search: 'zzzyyyy', foo: 'bar' }, forceLoad: true });
+        tick(400);
+        expect(store.entities().length).toEqual(0);
+        store.resetEntitiesFilter();
+        tick(400);
+        expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
+        expect(store.entities().length).toEqual(2);
+      });
+    }));
+
+    it('isEntitiesFilterChanged should be false after resetEntitiesFilter with newDefaultFilter', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.filterEntities({ filter: { search: 'zero', foo: 'bar' }, forceLoad: true });
+        tick(400);
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        expect(store.isEntitiesFilterChanged()).toBe(false);
+      });
+    }));
+
+    it('isEntitiesFilterChanged should be true when filtering away from the new default', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        patchState(store, setAllEntities(mockProducts));
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        store.filterEntities({ filter: { search: 'mario', foo: 'bar' }, forceLoad: true });
+        tick(400);
+        expect(store.isEntitiesFilterChanged()).toBe(true);
+      });
+    }));
+  });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -1,6 +1,5 @@
 import { computed, effect, Signal, untracked } from '@angular/core';
 import {
-  deepComputed,
   patchState,
   signalStoreFeature,
   SignalStoreFeature,
@@ -181,15 +180,16 @@ export function withEntitiesLocalFilter<
           | undefined
         >(
           pipe(
-            map(
-              (options) =>
-                // if no options are provided, we use the default filter
-                // and forceLoad
-                options ?? {
-                  filter: filter(),
-                  debounce: 0,
-                  forceLoad: true,
-                },
+            map((options) =>
+              // if no options are provided, we use the default filter
+              // and forceLoad
+              options
+                ? toFilterOptions(options, defaultFilter)
+                : {
+                    filter: filter(),
+                    debounce: 0,
+                    forceLoad: true,
+                  },
             ),
             debounceFilterPipe(filter, config.defaultDebounce),
             tap((value) => {
@@ -228,9 +228,7 @@ export function withEntitiesLocalFilter<
           ) => {
             if (options instanceof Observable || typeof options === 'function')
               return filterEntities(options);
-            filterEntities(
-              options ? toFilterOptions(options, defaultFilter) : undefined,
-            );
+            filterEntities(options);
             return Promise.resolve({ ok: true, value: filteredEntities });
           },
           [resetEntitiesFilterKey]: (options?: {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -43,8 +43,10 @@ import {
 import {
   EntitiesFilterComputed,
   EntitiesFilterMethods,
+  EntitiesFilterState,
   NamedEntitiesFilterComputed,
   NamedEntitiesFilterMethods,
+  NamedEntitiesFilterState,
 } from './with-entities-local-filter.model';
 
 /**
@@ -118,12 +120,12 @@ export function withEntitiesLocalFilter<
         }),
   Collection extends ''
     ? {
-        state: {};
+        state: EntitiesFilterState<Filter>;
         props: EntitiesFilterComputed<Filter>;
         methods: EntitiesFilterMethods<Filter, Entity>;
       }
     : {
-        state: {};
+        state: NamedEntitiesFilterState<Collection, Filter>;
         props: NamedEntitiesFilterComputed<Collection, Filter>;
         methods: NamedEntitiesFilterMethods<Collection, Filter, Entity>;
       }
@@ -141,18 +143,21 @@ export function withEntitiesLocalFilter<
       defaultFilterKey,
       resetEntitiesFilterKey,
       isEntitiesFilterChangedKey,
-      computedFilterKey,
     } = getWithEntitiesFilterKeys(config);
     return signalStoreFeature(
-      withState({ [filterKey]: defaultFilter, [defaultFilterKey]: defaultFilter }),
+      withState({
+        [filterKey]: defaultFilter,
+        [defaultFilterKey]: defaultFilter,
+      }),
       withComputed((state: Record<string, Signal<unknown>>) => {
         const filter = state[filterKey] as Signal<Filter>;
         const currentDefault = state[defaultFilterKey] as Signal<Filter>;
         return {
           [isEntitiesFilterChangedKey]: computed(() => {
-            return JSON.stringify(filter()) !== JSON.stringify(currentDefault());
+            return (
+              JSON.stringify(filter()) !== JSON.stringify(currentDefault())
+            );
           }),
-          [computedFilterKey]: deepComputed(() => filter()),
         };
       }),
       withEventHandler(),
@@ -236,10 +241,17 @@ export function withEntitiesLocalFilter<
           }) => {
             const newDefault = options?.newDefaultFilter;
             if (newDefault) {
-              patchState(state as WritableStateSource<any>, { [defaultFilterKey]: newDefault });
+              patchState(state as WritableStateSource<any>, {
+                [defaultFilterKey]: newDefault,
+              });
             }
-            const currentDefault = newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
-            filterEntities({ filter: currentDefault, debounce: options?.debounce, forceLoad: options?.forceLoad });
+            const currentDefault =
+              newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
+            filterEntities({
+              filter: currentDefault,
+              debounce: options?.debounce,
+              forceLoad: options?.forceLoad,
+            });
           },
         };
       }),

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-local-filter.ts
@@ -84,7 +84,7 @@ import {
  *  store.productEntitiesFilter // { search: string }
  *  // generates the following methods
  *  store.filterProductEntities  // (options: { filter: { search: string }, debounce?: number, patch?: boolean, forceLoad?: boolean }) => void
- *  store.resetProductEntitiesFilter  // () => void
+ *  store.resetProductEntitiesFilter  // (options?: { newDefaultFilter?: { search: string } }) => void — resets to defaultFilter or to newDefaultFilter if provided, updating the default for future resets
  */
 export function withEntitiesLocalFilter<
   Input extends SignalStoreFeatureResult,
@@ -138,17 +138,19 @@ export function withEntitiesLocalFilter<
     const {
       filterEntitiesKey,
       filterKey,
+      defaultFilterKey,
       resetEntitiesFilterKey,
       isEntitiesFilterChangedKey,
       computedFilterKey,
     } = getWithEntitiesFilterKeys(config);
     return signalStoreFeature(
-      withState({ [filterKey]: defaultFilter }),
+      withState({ [filterKey]: defaultFilter, [defaultFilterKey]: defaultFilter }),
       withComputed((state: Record<string, Signal<unknown>>) => {
         const filter = state[filterKey] as Signal<Filter>;
+        const currentDefault = state[defaultFilterKey] as Signal<Filter>;
         return {
           [isEntitiesFilterChangedKey]: computed(() => {
-            return JSON.stringify(filter()) !== JSON.stringify(defaultFilter);
+            return JSON.stringify(filter()) !== JSON.stringify(currentDefault());
           }),
           [computedFilterKey]: deepComputed(() => filter()),
         };
@@ -226,8 +228,18 @@ export function withEntitiesLocalFilter<
             );
             return Promise.resolve({ ok: true, value: filteredEntities });
           },
-          [resetEntitiesFilterKey]: () => {
-            filterEntities({ filter: defaultFilter });
+          [resetEntitiesFilterKey]: (options?: {
+            newDefaultFilter?: Filter;
+            debounce?: number;
+            forceLoad?: boolean;
+            skipLoadingCall?: boolean;
+          }) => {
+            const newDefault = options?.newDefaultFilter;
+            if (newDefault) {
+              patchState(state as WritableStateSource<any>, { [defaultFilterKey]: newDefault });
+            }
+            const currentDefault = newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
+            filterEntities({ filter: currentDefault, debounce: options?.debounce, forceLoad: options?.forceLoad });
           },
         };
       }),

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.model.ts
@@ -19,6 +19,7 @@ export type EntitiesRemoteFilterMethods<Filter, Entity> = {
     >;
   };
   resetEntitiesFilter: (options?: {
+    newDefaultFilter?: Filter;
     debounce?: number;
     forceLoad?: boolean;
     skipLoadingCall?: boolean;
@@ -44,6 +45,7 @@ export type NamedEntitiesRemoteFilterMethods<
   };
 } & {
   [K in Collection as `reset${Capitalize<string & K>}EntitiesFilter`]: (options?: {
+    newDefaultFilter?: Filter;
     debounce?: number;
     forceLoad?: boolean;
     skipLoadingCall?: boolean;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
@@ -557,4 +557,57 @@ describe('withEntitiesRemoteFilter', () => {
       }
     });
   });
+
+  describe('resetEntitiesFilter with newDefaultFilter', () => {
+    it('should set filter to newDefaultFilter and trigger load', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        tick();
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
+        expect(store.entities().length).toEqual(2);
+      });
+    }));
+
+    it('should reset to new default when called without args after newDefaultFilter set', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        tick();
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        store.filterEntities({ filter: { search: 'zzzyyyy', foo: 'bar' }, forceLoad: true });
+        tick(400);
+        expect(store.entities().length).toEqual(0);
+        store.resetEntitiesFilter();
+        tick(400);
+        expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar' });
+        expect(store.entities().length).toEqual(2);
+      });
+    }));
+
+    it('isEntitiesFilterChanged should be false after resetEntitiesFilter with newDefaultFilter', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        tick();
+        store.filterEntities({ filter: { search: 'zero', foo: 'bar' }, forceLoad: true });
+        tick(400);
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        expect(store.isEntitiesFilterChanged()).toBe(false);
+      });
+    }));
+
+    it('isEntitiesFilterChanged should be true when filtering away from the new default', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        tick();
+        store.resetEntitiesFilter({ newDefaultFilter: { search: 'zero', foo: 'bar' } });
+        tick(400);
+        store.filterEntities({ filter: { search: 'mario', foo: 'bar' }, forceLoad: true });
+        tick(400);
+        expect(store.isEntitiesFilterChanged()).toBe(true);
+      });
+    }));
+  });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.spec.ts
@@ -1,3 +1,4 @@
+import { computed } from '@angular/core';
 import {
   discardPeriodicTasks,
   fakeAsync,
@@ -57,6 +58,95 @@ describe('withEntitiesRemoteFilter', () => {
       store.filterEntities({
         filter: { search: 'zero', foo: 'bar2' },
       });
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entities()).toEqual([
+        {
+          description: 'Super Nintendo Game',
+          id: '1',
+          name: 'F-Zero',
+          price: 12,
+          categoryId: 'snes',
+        },
+        {
+          description: 'GameCube Game',
+          id: '80',
+          name: 'F-Zero GX',
+          price: 55,
+          categoryId: 'gamecube',
+        },
+      ]);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      expect(store.entitiesFilter.search()).toEqual('zero');
+    });
+  }));
+
+  it('should filter entities and store filter using plain object as filter', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      tick();
+      store.filterEntities({ search: 'zero', foo: 'bar2' });
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entities()).toEqual([
+        {
+          description: 'Super Nintendo Game',
+          id: '1',
+          name: 'F-Zero',
+          price: 12,
+          categoryId: 'snes',
+        },
+        {
+          description: 'GameCube Game',
+          id: '80',
+          name: 'F-Zero GX',
+          price: 55,
+          categoryId: 'gamecube',
+        },
+      ]);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      expect(store.entitiesFilter.search()).toEqual('zero');
+    });
+  }));
+
+  it('should filter entities and store filter in a signal', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      tick();
+      store.filterEntities(
+        computed(() => ({ filter: { search: 'zero', foo: 'bar2' } })),
+      );
+      expect(store.entities().length).toEqual(mockProducts.length);
+      tick(400);
+      expect(store.entities().length).toEqual(2);
+      expect(store.entities()).toEqual([
+        {
+          description: 'Super Nintendo Game',
+          id: '1',
+          name: 'F-Zero',
+          price: 12,
+          categoryId: 'snes',
+        },
+        {
+          description: 'GameCube Game',
+          id: '80',
+          name: 'F-Zero GX',
+          price: 55,
+          categoryId: 'gamecube',
+        },
+      ]);
+      expect(store.entitiesFilter()).toEqual({ search: 'zero', foo: 'bar2' });
+      expect(store.entitiesFilter.search()).toEqual('zero');
+    });
+  }));
+
+  it('should filter entities and store filter using plain object as filter of a signal', fakeAsync(() => {
+    TestBed.runInInjectionContext(() => {
+      const store = new Store();
+      tick();
+      store.filterEntities(computed(() => ({ search: 'zero', foo: 'bar2' })));
       expect(store.entities().length).toEqual(mockProducts.length);
       tick(400);
       expect(store.entities().length).toEqual(2);

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -133,7 +133,7 @@ import {
  *  store.productEntitiesFilter // { search: string }
  *  // generates the following methods
  *  store.filterProductEntities  // (options: { filter: { search: string }, debounce?: number, patch?: boolean, forceLoad?: boolean, skipLoadingCall?:boolean }) => void
- *  store.resetProductEntitiesFilter  // () => void
+ *  store.resetProductEntitiesFilter  // (options?: { newDefaultFilter?: { name: string } }) => void — resets to defaultFilter or to newDefaultFilter if provided, updating the default for future resets
  */
 export function withEntitiesRemoteFilter<
   Input extends SignalStoreFeatureResult,
@@ -183,6 +183,7 @@ export function withEntitiesRemoteFilter<
     const { entitiesKey } = getWithEntitiesKeys(config);
     const {
       filterKey,
+      defaultFilterKey,
       filterEntitiesKey,
       resetEntitiesFilterKey,
       isEntitiesFilterChangedKey,
@@ -191,12 +192,13 @@ export function withEntitiesRemoteFilter<
     const { entitiesFilterChanged } = getWithEntitiesFilterEvents(config);
 
     return signalStoreFeature(
-      withState({ [filterKey]: defaultFilter }),
+      withState({ [filterKey]: defaultFilter, [defaultFilterKey]: defaultFilter }),
       withComputed((state: Record<string, Signal<unknown>>) => {
         const filter = state[filterKey] as Signal<Filter>;
+        const currentDefault = state[defaultFilterKey] as Signal<Filter>;
         return {
           [isEntitiesFilterChangedKey]: computed(() => {
-            return JSON.stringify(filter()) !== JSON.stringify(defaultFilter);
+            return JSON.stringify(filter()) !== JSON.stringify(currentDefault());
           }),
           [computedFilterKey]: deepComputed(() => filter()),
         };
@@ -280,8 +282,18 @@ export function withEntitiesRemoteFilter<
                 ),
               );
             },
-            [resetEntitiesFilterKey]: () => {
-              filterEntities({ filter: defaultFilter });
+            [resetEntitiesFilterKey]: (options?: {
+              newDefaultFilter?: Filter;
+              debounce?: number;
+              forceLoad?: boolean;
+              skipLoadingCall?: boolean;
+            }) => {
+              const newDefault = options?.newDefaultFilter;
+              if (newDefault) {
+                patchState(state as WritableStateSource<any>, { [defaultFilterKey]: newDefault });
+              }
+              const currentDefault = newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
+              filterEntities({ filter: currentDefault, debounce: options?.debounce, forceLoad: options?.forceLoad, skipLoadingCall: options?.skipLoadingCall });
             },
           };
         },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -54,7 +54,9 @@ import {
 } from './with-entities-filter.util';
 import {
   EntitiesFilterComputed,
+  EntitiesFilterState,
   NamedEntitiesFilterComputed,
+  NamedEntitiesFilterState,
 } from './with-entities-local-filter.model';
 import {
   EntitiesRemoteFilterMethods,
@@ -165,12 +167,12 @@ export function withEntitiesRemoteFilter<
         }),
   Collection extends ''
     ? {
-        state: {};
+        state: EntitiesFilterState<Filter>;
         props: EntitiesFilterComputed<Filter>;
         methods: EntitiesRemoteFilterMethods<Filter, Entity>;
       }
     : {
-        state: {};
+        state: NamedEntitiesFilterState<Collection, Filter>;
         props: NamedEntitiesFilterComputed<Collection, Filter>;
         methods: NamedEntitiesRemoteFilterMethods<Collection, Filter, Entity>;
       }
@@ -187,20 +189,23 @@ export function withEntitiesRemoteFilter<
       filterEntitiesKey,
       resetEntitiesFilterKey,
       isEntitiesFilterChangedKey,
-      computedFilterKey,
     } = getWithEntitiesFilterKeys(config);
     const { entitiesFilterChanged } = getWithEntitiesFilterEvents(config);
 
     return signalStoreFeature(
-      withState({ [filterKey]: defaultFilter, [defaultFilterKey]: defaultFilter }),
+      withState({
+        [filterKey]: defaultFilter,
+        [defaultFilterKey]: defaultFilter,
+      }),
       withComputed((state: Record<string, Signal<unknown>>) => {
         const filter = state[filterKey] as Signal<Filter>;
         const currentDefault = state[defaultFilterKey] as Signal<Filter>;
         return {
           [isEntitiesFilterChangedKey]: computed(() => {
-            return JSON.stringify(filter()) !== JSON.stringify(currentDefault());
+            return (
+              JSON.stringify(filter()) !== JSON.stringify(currentDefault())
+            );
           }),
-          [computedFilterKey]: deepComputed(() => filter()),
         };
       }),
       withEventHandler(),
@@ -290,10 +295,18 @@ export function withEntitiesRemoteFilter<
             }) => {
               const newDefault = options?.newDefaultFilter;
               if (newDefault) {
-                patchState(state as WritableStateSource<any>, { [defaultFilterKey]: newDefault });
+                patchState(state as WritableStateSource<any>, {
+                  [defaultFilterKey]: newDefault,
+                });
               }
-              const currentDefault = newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
-              filterEntities({ filter: currentDefault, debounce: options?.debounce, forceLoad: options?.forceLoad, skipLoadingCall: options?.skipLoadingCall });
+              const currentDefault =
+                newDefault ?? (state[defaultFilterKey] as Signal<Filter>)();
+              filterEntities({
+                filter: currentDefault,
+                debounce: options?.debounce,
+                forceLoad: options?.forceLoad,
+                skipLoadingCall: options?.skipLoadingCall,
+              });
             },
           };
         },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -1,7 +1,6 @@
 import { computed, EnvironmentInjector, inject, Signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import {
-  deepComputed,
   patchState,
   signalStoreFeature,
   SignalStoreFeature,
@@ -91,7 +90,7 @@ import {
  *   withEntitiesRemoteFilter({
  *     entity,
  *     collection,
- *     defaultFilter: { name: '' },
+ *     defaultFilter: { search: '' },
  *   }),
  *   // after you can use withEntitiesLoadingCall to connect the filter to
  *   // the api call, or do it manually as shown after
@@ -100,7 +99,7 @@ import {
  *     fetchEntities: ({ productEntitiesFilter }) => {
  *       return inject(ProductService)
  *         .getProducts({
- *           search: productEntitiesFilter().name,
+ *           search: productEntitiesFilter().search,
  *         })
  *     },
  *   }),
@@ -111,7 +110,7 @@ import {
  * //       if (isProductEntitiesLoading()) {
  * //         inject(ProductService)
  * //              .getProducts({
- * //                 search: productEntitiesFilter().name,
+ * //                 search: productEntitiesFilter().search,
  * //               })
  * //           .pipe(
  * //             takeUntilDestroyed(),
@@ -135,7 +134,7 @@ import {
  *  store.productEntitiesFilter // { search: string }
  *  // generates the following methods
  *  store.filterProductEntities  // (options: { filter: { search: string }, debounce?: number, patch?: boolean, forceLoad?: boolean, skipLoadingCall?:boolean }) => void
- *  store.resetProductEntitiesFilter  // (options?: { newDefaultFilter?: { name: string } }) => void — resets to defaultFilter or to newDefaultFilter if provided, updating the default for future resets
+ *  store.resetProductEntitiesFilter  // (options?: { newDefaultFilter?: { search: string } }) => void — resets to defaultFilter or to newDefaultFilter if provided, updating the default for future resets
  */
 export function withEntitiesRemoteFilter<
   Input extends SignalStoreFeatureResult,
@@ -232,15 +231,16 @@ export function withEntitiesRemoteFilter<
             | undefined
           >(
             pipe(
-              map(
-                (options) =>
-                  // if no options are provided, we use the default filter
-                  // and forceLoad
-                  options ?? {
-                    filter: filter(),
-                    debounce: config.defaultDebounce,
-                    forceLoad: true,
-                  },
+              map((options) =>
+                // if no options are provided, we use the default filter
+                // and forceLoad
+                options
+                  ? toFilterOptions(options, defaultFilter)
+                  : {
+                      filter: filter(),
+                      debounce: config.defaultDebounce,
+                      forceLoad: true,
+                    },
               ),
               debounceFilterPipe(filter, config.defaultDebounce),
               tap((value) => {
@@ -271,9 +271,7 @@ export function withEntitiesRemoteFilter<
               ) {
                 return filterEntities(options);
               }
-              filterEntities(
-                options ? toFilterOptions(options, defaultFilter) : undefined,
-              );
+              filterEntities(options);
 
               return lastValueFrom(
                 toObservable(callState, { injector: environmentInjector }).pipe(


### PR DESCRIPTION
Three related changes to the withEntities*Filter features (local, remote, hybrid):

- resetEntitiesFilter({ newDefaultFilter }) — change the default filter at runtime. isEntitiesFilterChanged now compares against the mutable default. (#320)
- entitiesFilter is now plain writable state instead of an internal _entitiesFilter mirrored by a deepComputed — simpler, directly patchable.
- fix bug filterEntities when using a signal/computed arg (alongside Observable), with a plain filter object. (#321)