### PR TITLE
fix(signals): store lastPushedQueryParams in state instead of closure

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -157,9 +157,8 @@ export function getQueryMapperForEntitiesFilter<Filter>(config?: {
 > {
   const { filterEntitiesKey, filterKey } = getWithEntitiesFilterKeys(config);
 
-  let firstLoad = true;
   return {
-    queryParamsToState: (query, store) => {
+    queryParamsToState: (query, store, firstLoad) => {
       const filter = config?.filterMapper
         ? config?.filterMapper.queryParamsToFilter(query)
         : query.filter
@@ -179,7 +178,6 @@ export function getQueryMapperForEntitiesFilter<Filter>(config?: {
           // otherwise history navigation would not work as expected
           skipLoadingCall: firstLoad && config?.skipLoadingCall,
         });
-        firstLoad = false;
       }
     },
     stateToQueryParams: (store) => {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-pagination/with-entities-local-pagination.util.ts
@@ -54,9 +54,8 @@ export function getQueryMapperForEntitiesPagination(config?: {
   const { loadingKey, loadedKey } = getWithCallStatusKeys({
     collection: config?.collection,
   });
-  let firstLoad = true;
   return {
-    queryParamsToState: (query, store) => {
+    queryParamsToState: (query, store, firstLoad) => {
       const page = query.page;
       const pageSize = query.pageSize;
       const pagination = store[paginationKey] as Signal<
@@ -84,7 +83,6 @@ export function getQueryMapperForEntitiesPagination(config?: {
           // otherwise history navigation would not work as expected
           skipLoadingCall: firstLoad && config?.skipLoadingCall,
         });
-        firstLoad = false;
       }
     },
     stateToQueryParams: (store) => {

--- a/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-sort/with-entities-local-sort.util.ts
@@ -99,9 +99,8 @@ export function getQueryMapperForEntitiesSort(config?: {
   sortDirection: string;
 }> {
   const { sortEntitiesKey, sortKey } = getWithEntitiesSortKeys(config);
-  let firstLoad = true;
   return {
-    queryParamsToState: (query, store) => {
+    queryParamsToState: (query, store, firstLoad) => {
       const sortBy = query.sortBy;
       if (sortBy) {
         const sortDirection = query.sortDirection;
@@ -119,7 +118,6 @@ export function getQueryMapperForEntitiesSort(config?: {
             skipLoadingCall: firstLoad && config?.skipLoadingCall,
           });
         }
-        firstLoad = false;
       }
     },
     stateToQueryParams: (store) => {

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -1,4 +1,8 @@
-import { Type } from '@angular/core';
+import {
+  createEnvironmentInjector,
+  EnvironmentInjector,
+  Type,
+} from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute, Params, provideRouter, Router } from '@angular/router';
 import {
@@ -1222,6 +1226,57 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       tick(400);
       // With skipLoadingCall: false, the fetchEntities should be called
       expect(fetchEntitiesSpy).toHaveBeenCalled();
+    }));
+
+    it('should honour skipLoadingCall on every store instance', fakeAsync(() => {
+      // the mappers are built once per store definition, so a firstLoad flag
+      // kept in their closure would leak from one instance to the next and
+      // silently ignore skipLoadingCall from the second instance onwards
+      const fetchEntitiesSpy = vi.fn(() =>
+        of({ entities: mockProducts.slice(0, 10), total: 10 }),
+      );
+      const Store = signalStore(
+        withEntities({ entity }),
+        withCallStatus(),
+        withEntitiesRemoteFilter({
+          entity,
+          defaultFilter: { search: '', foo: 'bar' },
+        }),
+        withEntitiesLoadingCall({ fetchEntities: fetchEntitiesSpy }),
+        withEntitiesSyncToRouteQueryParams({ entity, skipLoadingCall: true }),
+      );
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useFactory: () => ({
+              queryParams: of({
+                filter: JSON.stringify({ search: 'test', foo: 'bar' }),
+              }),
+            }),
+          },
+        ],
+      });
+      const router = TestBed.inject(Router);
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      const parentInjector = TestBed.inject(EnvironmentInjector);
+
+      // each instance is its own first load, so none of them should fetch
+      for (const instance of [1, 2, 3]) {
+        const injector = createEnvironmentInjector([Store], parentInjector);
+        const store = injector.get(Store) as any;
+        tick();
+        tick(400);
+        expect(store.entitiesFilter()).toEqual({
+          search: 'test',
+          foo: 'bar',
+        });
+        expect(
+          fetchEntitiesSpy,
+          `fetchEntities should not be called for instance ${instance}`,
+        ).not.toHaveBeenCalled();
+      }
     }));
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.ts
@@ -218,7 +218,7 @@ export function getQueryMapperWithPrefix(config: {
   mapper: QueryMapper<any>;
 }): QueryMapper<any> {
   return {
-    queryParamsToState: (query, store) => {
+    queryParamsToState: (query, store, firstLoad) => {
       const newQuery = Object.entries(query).reduce(
         (acc, [key, value]) => {
           if (key.startsWith(config.prefix + '-')) {
@@ -230,7 +230,7 @@ export function getQueryMapperWithPrefix(config: {
         },
         {} as Record<string, any>,
       );
-      config.mapper.queryParamsToState(newQuery, store);
+      config.mapper.queryParamsToState(newQuery, store, firstLoad);
     },
     stateToQueryParams: (store) => {
       const query = config.mapper.stateToQueryParams(store);

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
@@ -1,4 +1,8 @@
-import { computed, createEnvironmentInjector, EnvironmentInjector } from '@angular/core';
+import {
+  computed,
+  createEnvironmentInjector,
+  EnvironmentInjector,
+} from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter, Router } from '@angular/router';
 import { withSyncToRouteQueryParams } from '@ngrx-traits/signals';
@@ -198,6 +202,128 @@ describe('withSyncToRouteQueryParams', () => {
     }).not.toThrow();
     expect(queryParamsToStateSpy).not.toHaveBeenCalled();
   });
+
+  it('should not share the last pushed query params between store instances', fakeAsync(() => {
+    // the store definition is created once, so both instances go through the
+    // same withSyncToRouteQueryParams call, which is what used to leak
+    const Store = signalStore(
+      { protectedState: false },
+      withState({
+        test: 'test',
+        foo: 'foo',
+        bar: false,
+      }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          {
+            queryParamsToState: (query, store) => {
+              patchState(store, {
+                test: query.test,
+                foo: query.foo,
+                bar: query.bar === 'true',
+              });
+            },
+            stateToQueryParams: (store) =>
+              computed(() => ({
+                test: store.test(),
+                foo: store.foo(),
+                bar: store.bar().toString(),
+              })),
+          },
+        ],
+      }),
+    );
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            queryParams: of({
+              test: 'test2',
+              foo: 'foo2',
+              bar: 'true',
+            }),
+          }),
+        },
+      ],
+    });
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const parentInjector = TestBed.inject(EnvironmentInjector);
+
+    // first instance restores from the url and then pushes back to it
+    const injector1 = createEnvironmentInjector([Store], parentInjector);
+    const store1 = injector1.get(Store);
+    expect(store1.test()).toBe('test2');
+    TestBed.tick();
+    tick(400);
+    expect(router.navigate).toHaveBeenCalled();
+
+    // second instance must still restore from the url
+    const injector2 = createEnvironmentInjector([Store], parentInjector);
+    const store2 = injector2.get(Store);
+    expect(store2.test()).toBe('test2');
+    expect(store2.foo()).toBe('foo2');
+    expect(store2.bar()).toBe(true);
+  }));
+
+  it('should ignore query params emitted after pushing params with undefined values', fakeAsync(() => {
+    const queryParams$ = new Subject<Record<string, string | undefined>>();
+    const queryParamsToStateSpy = vi.fn(
+      (query: Record<string, string | undefined>, store: any) => {
+        patchState(store, { test: query['test'], foo: query['foo'] });
+      },
+    );
+    const Store = signalStore(
+      { protectedState: false },
+      withState({
+        test: 'test' as string | undefined,
+        foo: 'foo',
+      }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          {
+            queryParamsToState: queryParamsToStateSpy,
+            stateToQueryParams: (store: any) =>
+              computed(() => ({
+                test: store.test(),
+                foo: store.foo(),
+              })),
+          },
+        ],
+      }),
+    );
+    TestBed.configureTestingModule({
+      providers: [
+        Store,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({ queryParams: queryParams$ }),
+        },
+      ],
+    });
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const store = TestBed.inject(Store);
+
+    // undefined params get dropped from the url, so they must not be stored
+    // as part of the last pushed params
+    patchState(store, { test: undefined });
+    TestBed.tick();
+    tick(400);
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: { test: undefined, foo: 'foo' },
+      queryParamsHandling: 'merge',
+    });
+
+    // the url now only has foo, which is what we just pushed, so the store
+    // should not be patched again
+    queryParams$.next({ foo: 'foo' });
+    expect(queryParamsToStateSpy).not.toHaveBeenCalled();
+  }));
 
   it('store should be synced with url query params with custom debounce', fakeAsync(() => {
     const { store } = init({ debounce: 1000 });

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
@@ -8,8 +8,16 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import { SignalStoreFeature, signalStoreFeature, SignalStoreFeatureResult, type, withHooks, withMethods, withState } from '@ngrx/signals';
-import { concatWith, debounce, defaultIfEmpty, NEVER, take, timer } from 'rxjs';
+import {
+  SignalStoreFeature,
+  signalStoreFeature,
+  SignalStoreFeatureResult,
+  type,
+  withHooks,
+  withMethods,
+  withProps,
+} from '@ngrx/signals';
+import { concatWith, debounce, defaultIfEmpty, NEVER, timer } from 'rxjs';
 
 import { combineFunctionsInObject } from '../util';
 import { StoreSource } from '../with-feature-factory/with-feature-factory.model';
@@ -72,14 +80,26 @@ export function withSyncToRouteQueryParams<
     };
   }
 > {
-  let lastPushedQueryParams: Record<string, any> | undefined;
+  // per instance holder for the last query params this store pushed to the url.
+  // It has to live on the store because withHooks writes it and withMethods
+  // reads it, and it is symbol keyed so it stays off the store public api.
+  const LAST_PUSHED_QUERY_PARAMS = Symbol('lastPushedQueryParams');
   return signalStoreFeature(
     type<Input>(),
-    withState({}),
+    withProps(() => ({
+      [LAST_PUSHED_QUERY_PARAMS]: {
+        value: undefined as Record<string, unknown> | undefined,
+      },
+    })),
     withMethods((store) => {
       const injector = inject(Injector);
       const environmentInjector = inject(EnvironmentInjector);
       const destroyRef = inject(DestroyRef);
+      const lastPushedQueryParams = store[LAST_PUSHED_QUERY_PARAMS];
+      // per store instance, true until the first query params emission has been
+      // restored into the store. Mappers receive it so they can force the load
+      // and honour skipLoadingCall only on that first restore.
+      let firstLoad = true;
       return combineFunctionsInObject(
         {
           loadFromQueryParams: () => {
@@ -87,10 +107,12 @@ export function withSyncToRouteQueryParams<
             activatedRoute.queryParams
               .pipe(
                 defaultIfEmpty({}), // Provide default empty object if observable completes without emitting
-                takeUntilDestroyed(destroyRef)
+                takeUntilDestroyed(destroyRef),
               )
               .subscribe((queryParams) => {
-                if (shallowEqualParams(lastPushedQueryParams, queryParams)) {
+                if (
+                  shallowEqualParams(lastPushedQueryParams.value, queryParams)
+                ) {
                   return;
                 }
                 runInInjectionContext(environmentInjector, () => {
@@ -99,8 +121,10 @@ export function withSyncToRouteQueryParams<
                     mapper.queryParamsToState(
                       queryParams as Params,
                       store as any,
+                      firstLoad,
                     );
                   });
+                  firstLoad = false;
                   config.onQueryParamsStored?.(store);
                 });
               });
@@ -111,7 +135,7 @@ export function withSyncToRouteQueryParams<
     }),
     withHooks((store) => {
       const router = inject(Router);
-
+      const lastPushedQueryParams = store[LAST_PUSHED_QUERY_PARAMS];
       return {
         onInit: () => {
           if (config.restoreOnInit ?? true) {
@@ -132,7 +156,6 @@ export function withSyncToRouteQueryParams<
             }, {});
             return queryParams;
           });
-
           toObservable(computedChanges)
             .pipe(
               concatWith(NEVER),
@@ -140,23 +163,30 @@ export function withSyncToRouteQueryParams<
               takeUntilDestroyed(),
             )
             .subscribe((queryParams) => {
-              lastPushedQueryParams = {
+              const lastParams: Record<string, unknown> = {
                 ...(activatedRoute.snapshot?.queryParams || {}),
                 ...queryParams,
               };
-              const keys = Object.keys(lastPushedQueryParams);
-              for (let key of keys) {
+              for (const key of Object.keys(lastParams)) {
                 // undefined params will be deleted from the url so we should
-                // no store them
-                if (lastPushedQueryParams[key] === undefined) {
-                  delete lastPushedQueryParams[key];
+                // not store them
+                if (lastParams[key] === undefined) {
+                  delete lastParams[key];
                 }
               }
-              router.navigate([], {
-                relativeTo: activatedRoute,
-                queryParams,
-                queryParamsHandling: 'merge',
-              });
+              lastPushedQueryParams.value = lastParams;
+              router
+                .navigate([], {
+                  relativeTo: activatedRoute,
+                  queryParams,
+                  queryParamsHandling: 'merge',
+                })
+                .catch((error) => {
+                  console.error(
+                    'withSyncToRouteQueryParams: failed to sync the store to the route query params',
+                    error,
+                  );
+                });
             });
         },
       };
@@ -165,8 +195,8 @@ export function withSyncToRouteQueryParams<
 }
 
 function shallowEqualParams(
-  a: Record<string, any> | undefined,
-  b: Record<string, any>,
+  a: Record<string, unknown> | undefined,
+  b: Record<string, unknown>,
 ): boolean {
   if (!a) return false;
   const aKeys = Object.keys(a);

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.util.ts
@@ -5,6 +5,11 @@ export type QueryMapper<
   T extends Params = Params,
   Store extends Record<string, any> = Record<string, any>,
 > = {
-  queryParamsToState: (query: T, store: Store) => void;
+  /**
+   * @param firstLoad true only for the first query params emission restored
+   *   into this store instance. Mappers should only read it, the caller resets
+   *   it once all mappers have run.
+   */
+  queryParamsToState: (query: T, store: Store, firstLoad: boolean) => void;
   stateToQueryParams: (store: Store) => Signal<T> | undefined | null;
 };


### PR DESCRIPTION
fixes bug where value shared across all store instances since it was a module-level var

Fixes #323