### PR TITLE
fix(signals): withSyncToRouteQueryParams replace history entry on first url push

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
+++ b/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
@@ -87,6 +87,122 @@ export const ProductsLocalStore = signalStore(
 );
 ```
 
+### Two collections, with a short prefix
+
+You can sync more than one collection in the same store, each `withEntitiesSyncToRouteQueryParams` prefixes its own query params so the two never collide.
+
+When you have multiple collections, group each one into its own custom store feature (or give it its own store) instead of listing every feature of both collections directly in one `signalStore`. It keeps each collection readable and reusable on its own. It also avoids the feature limit: `signalStore` accepts up to 15 features, and a fully configured collection already uses about 8 of them, so two collections would not fit.
+
+Use `entityConfig` to declare the entity and collection once, then spread it when a feature takes extra options, or pass it directly when it does not.
+
+```typescript
+// with-product-entities.ts
+export const productEntityConfig = entityConfig({
+  entity: type<Product>(),
+  collection: 'product',
+});
+
+export function withProductEntities() {
+  return signalStoreFeature(
+    withEntities(productEntityConfig),
+    withCallStatus({ ...productEntityConfig, initialValue: 'loading' }),
+    withEntitiesRemoteFilter({
+      ...productEntityConfig,
+      defaultFilter: { search: '' },
+    }),
+    withEntitiesRemotePagination({
+      ...productEntityConfig,
+      pageSize: 10,
+    }),
+    withEntitiesRemoteSort({
+      ...productEntityConfig,
+      defaultSort: { field: 'name', direction: 'asc' },
+    }),
+    withEntitiesSingleSelection(productEntityConfig),
+    // 👇 params become p-filter, p-page, p-pageSize, p-sortBy, p-sortDirection, p-selectedId
+    withEntitiesSyncToRouteQueryParams({
+      ...productEntityConfig,
+      prefix: 'p',
+    }),
+    withEntitiesLoadingCall(
+      ({ productEntitiesPagedRequest, productEntitiesFilter, productEntitiesSort },
+        service = inject(ProductService)) => ({
+        ...productEntityConfig,
+        fetchEntities: async () => { ... },
+      }),
+    ),
+  );
+}
+```
+
+```typescript
+// with-order-entities.ts
+export const orderItemEntityConfig = entityConfig({
+  entity: type<ProductOrder>(),
+  collection: 'orderItem',
+});
+
+export function withOrderEntities() {
+  return signalStoreFeature(
+    withEntities(orderItemEntityConfig),
+    withCallStatus({ ...orderItemEntityConfig, initialValue: 'loading' }),
+    withEntitiesLocalSort({
+      ...orderItemEntityConfig,
+      defaultSort: { field: 'name', direction: 'asc' },
+    }),
+    withEntitiesLocalPagination({
+      ...orderItemEntityConfig,
+      pageSize: 10,
+    }),
+    withEntitiesSingleSelection(orderItemEntityConfig),
+    // 👇 params become o-filter, o-page, o-pageSize, o-sortBy, o-sortDirection, o-selectedId
+    withEntitiesSyncToRouteQueryParams({
+      ...orderItemEntityConfig,
+      prefix: 'o',
+    }),
+  );
+}
+```
+
+Both collections then compose into a single store:
+
+```typescript
+export const ProductsShopStore = signalStore(
+  withProductEntities(),
+  withOrderEntities(),
+);
+```
+
+Without `prefix` the collection name is used, which gets verbose quickly:
+
+```
+?product-filter={"search":""}&product-page=1&product-pageSize=10&product-sortBy=name&product-sortDirection=asc&orderItem-filter={"search":""}&orderItem-page=1&orderItem-pageSize=10&orderItem-sortBy=name&orderItem-sortDirection=asc
+```
+
+With `prefix: 'p'` and `prefix: 'o'` the collections keep their full names in the store while the url stays short:
+
+```
+?p-filter={"search":""}&p-page=1&p-pageSize=10&p-sortBy=name&p-sortDirection=asc&o-filter={"search":""}&o-page=1&o-pageSize=10&o-sortBy=name&o-sortDirection=asc
+```
+
+Setting `prefix: false` removes the prefix entirely, only do that when a single collection syncs to the url, otherwise the collections overwrite each other's params.
+
+The `filter` param is usually the longest one, because the filter object is serialized with `JSON.stringify`. Use `filterMapper` to flatten it into shorter params:
+
+```typescript
+withEntitiesSyncToRouteQueryParams({
+  ...productEntityConfig,
+  prefix: 'p',
+  filterMapper: {
+    // 👇 p-filter={"search":"tv"} becomes p-q=tv
+    filterToQueryParams: (filter) => ({ q: filter.search }),
+    queryParamsToFilter: (query) => ({ search: query.q ?? '' }),
+  },
+}),
+```
+
+Also consider `syncPagination: false`, `syncSort: false` or `syncSingleSelection: false` to drop the params you do not need to restore from the url.
+
 ## API Reference
 
 

--- a/apps/example-app/src/app/app.config.ts
+++ b/apps/example-app/src/app/app.config.ts
@@ -14,7 +14,11 @@ import {
 } from '@angular/material/form-field';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { provideRouter, withInMemoryScrolling, withViewTransitions } from '@angular/router';
+import {
+  provideRouter,
+  withInMemoryScrolling,
+  withViewTransitions,
+} from '@angular/router';
 import { EffectsModule, provideEffects } from '@ngrx/effects';
 import { provideStore } from '@ngrx/store';
 import { StoreModule } from '@ngrx/store';
@@ -29,10 +33,12 @@ export const appConfig: ApplicationConfig = {
     provideRouter(
       routes,
       withInMemoryScrolling({
-        scrollPositionRestoration: 'enabled',
+        // commented out because it some pages the jump to the top of page when url changes is not desired
+        // scrollPositionRestoration: 'enabled',
         anchorScrolling: 'enabled',
       }),
-      withViewTransitions()
+      // this causes extra re-rendering of components when navigating between pages, so it is disabled for now
+      // withViewTransitions(),
     ),
     provideAnimations(),
     importProvidersFrom(StoreModule.forRoot({})),

--- a/apps/example-app/src/app/examples/signals/product-shop-page/components/product-basket-tab/product-basket-tab.component.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/components/product-basket-tab/product-basket-tab.component.ts
@@ -29,8 +29,8 @@ import { SmartProductDetailComponent } from '../smart-product-detail/smart-produ
             (toggleAllSelectForRemove)="
               store.toggleSelectAllOrderItemEntities()
             "
-            [selectedProduct]="store.productEntitySelected()"
-            (selectProduct)="store.selectProductEntity($event)"
+            [selectedProduct]="store.orderItemEntitySelected()"
+            (selectProduct)="store.selectOrderItemEntity($event)"
             (sort)="sortBasket($event)"
           ></product-basket>
         </mat-card-content>
@@ -60,8 +60,10 @@ import { SmartProductDetailComponent } from '../smart-product-detail/smart-produ
           </button>
         </mat-card-actions>
       </mat-card>
-      @if (store.productEntitySelected()) {
-        <smart-product-detail [productId]="store.productEntitySelected()!.id" />
+      @if (store.orderItemEntitySelected()) {
+        <smart-product-detail
+          [productId]="store.orderItemEntitySelected()!.id"
+        />
       }
     </div>
   `,

--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
@@ -4,6 +4,7 @@ import {
   withEntitiesLocalPagination,
   withEntitiesLocalSort,
   withEntitiesMultiSelection,
+  withEntitiesSingleSelection,
   withLogger,
   withSyncToWebStorage,
 } from '@ngrx-traits/signals';
@@ -22,6 +23,7 @@ export function withOrderEntities() {
       ...orderItemEntityConfig,
       defaultSort: { field: 'name', direction: 'asc' },
     }),
+    withEntitiesSingleSelection(orderItemEntityConfig),
     withEntitiesMultiSelection(orderItemEntityConfig),
     withEntitiesLocalPagination({
       ...orderItemEntityConfig,

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -264,6 +264,8 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
           filter: JSON.stringify({ search: 'foo3', foo: 'bar4' }),
         }),
         queryParamsHandling: 'merge',
+        // the initial push replaces the history entry instead of adding one
+        replaceUrl: true,
       });
     }));
 
@@ -305,6 +307,8 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
           filter: JSON.stringify({ search: 'foo3', foo: 'bar4' }),
         }),
         queryParamsHandling: 'merge',
+        // the initial push replaces the history entry instead of adding one
+        replaceUrl: true,
       });
     }));
 
@@ -362,6 +366,8 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
           foo: 'bar4',
         }),
         queryParamsHandling: 'merge',
+        // the initial push replaces the history entry instead of adding one
+        replaceUrl: true,
       });
     }));
   });
@@ -402,6 +408,8 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
           sortDirection: 'asc',
         }),
         queryParamsHandling: 'merge',
+        // the initial push replaces the history entry instead of adding one
+        replaceUrl: true,
       });
     }));
 
@@ -442,6 +450,8 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
           sortDirection: 'asc',
         }),
         queryParamsHandling: 'merge',
+        // the initial push replaces the history entry instead of adding one
+        replaceUrl: true,
       });
     }));
   });

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
@@ -82,6 +82,8 @@ describe('withSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: { test: 'test3', foo: 'foo3', bar: 'false' },
       queryParamsHandling: 'merge',
+      // the initial push replaces the history entry instead of adding one
+      replaceUrl: true,
     });
   }));
 
@@ -317,6 +319,8 @@ describe('withSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: { test: undefined, foo: 'foo' },
       queryParamsHandling: 'merge',
+      // the initial push replaces the history entry instead of adding one
+      replaceUrl: true,
     });
 
     // the url now only has foo, which is what we just pushed, so the store
@@ -342,6 +346,72 @@ describe('withSyncToRouteQueryParams', () => {
       relativeTo: expect.anything(),
       queryParams: { test: 'test3', foo: 'foo3', bar: 'false' },
       queryParamsHandling: 'merge',
+      // the initial push replaces the history entry instead of adding one
+      replaceUrl: true,
     });
+  }));
+
+  it('should not add history entries when initialising multiple sync features', fakeAsync(() => {
+    // each feature pushes its own initial state, so without replacing the
+    // current history entry the user would need one back navigation per
+    // feature just to leave the page
+    const Store = signalStore(
+      { protectedState: false },
+      withState({ aFilter: 'a1', bFilter: 'b1' }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          {
+            queryParamsToState: () => {},
+            stateToQueryParams: (store: any) =>
+              computed(() => ({ 'a-filter': store.aFilter() })),
+          },
+        ],
+      }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          {
+            queryParamsToState: () => {},
+            stateToQueryParams: (store: any) =>
+              computed(() => ({ 'b-filter': store.bFilter() })),
+          },
+        ],
+      }),
+    );
+    TestBed.configureTestingModule({
+      providers: [
+        Store,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            queryParams: of({}),
+            snapshot: { queryParams: {} },
+          }),
+        },
+      ],
+    });
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi
+      .spyOn(router, 'navigate')
+      .mockResolvedValue(true) as any;
+    const store = TestBed.inject(Store) as any;
+
+    TestBed.tick();
+    tick(400);
+    // both features pushed, and neither added a history entry
+    expect(navigateSpy).toHaveBeenCalledTimes(2);
+    expect(
+      navigateSpy.mock.calls.every((call: any) => call[1].replaceUrl === true),
+    ).toBe(true);
+
+    // a later user driven change must still be reachable with the back button
+    navigateSpy.mockClear();
+    patchState(store, { aFilter: 'a2' });
+    TestBed.tick();
+    tick(400);
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(navigateSpy.mock.calls[0][1].replaceUrl).toBeUndefined();
+
+    tick(1000);
   }));
 });

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.ts
@@ -156,6 +156,11 @@ export function withSyncToRouteQueryParams<
             }, {});
             return queryParams;
           });
+          // the first push only reflects the initial state into the url, so it
+          // replaces the current history entry rather than adding one.
+          // Otherwise every sync feature in the store would cost the user an
+          // extra back navigation to get off the page.
+          let firstPush = true;
           toObservable(computedChanges)
             .pipe(
               concatWith(NEVER),
@@ -175,11 +180,16 @@ export function withSyncToRouteQueryParams<
                 }
               }
               lastPushedQueryParams.value = lastParams;
+              // replaceUrl defaults to false, so it is only set when needed to
+              // keep the navigation extras unchanged for later pushes
+              const replaceUrlExtra = firstPush ? { replaceUrl: true } : {};
+              firstPush = false;
               router
                 .navigate([], {
                   relativeTo: activatedRoute,
                   queryParams,
                   queryParamsHandling: 'merge',
+                  ...replaceUrlExtra,
                 })
                 .catch((error) => {
                   console.error(


### PR DESCRIPTION
each withSyncToRouteQueryParams feature pushed its initial state as a new history entry, so leaving a page needed one back press per feature. first push per feature instance now uses replaceUrl, later pushes unchanged so back still works for user driven changes.

Fix #327