### PR TITLE
feat(signals): nested props and array types for getQueryMapperForState

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
+++ b/apps/docs/src/app/pages/docs/traits/with-entities-sync-to-route-query-params.md
@@ -210,9 +210,29 @@ withEntitiesSyncToRouteQueryParams({
 }),
 ```
 
-The filter type has to be given, it cannot be inferred from the store, and that is what makes the field names autocomplete and their types check. The available types are the same ones [getQueryMapperForState](/docs/traits/with-sync-to-route-query-params) uses: `'string'`, `'number'`, `'boolean'`, `'date'`, `'date-time'`, `'time'` and `'json'`.
+The filter type has to be given, it cannot be inferred from the store, and that is what makes the field names autocomplete and their types check. The available types are the same ones [getQueryMapperForState](/docs/traits/with-sync-to-route-query-params) uses: `'string'`, `'number'`, `'boolean'`, `'date'`, `'date-time'`, `'time'`, `'string-array'`, `'number-array'` and `'json'`. The same caveat applies to `'string-array'`, a field whose values can carry a comma has to be declared as `'json'`, since the comma is what separates the entries.
 
-Fields that are `undefined` or `null` are removed from the url, and a field that does not match its declared type is dropped. Keep in mind the filter is replaced rather than patched when restoring, so a hand edited url that only carries some of the fields gives a filter with only those. A url carrying none of them leaves the filter untouched.
+A field holding an object can be described field by field too, with a nested props object, which gives it one param per leaf named with the path to it:
+
+```typescript
+type ProductFilter = { search: string; range: { from: Date; to: Date } };
+
+withEntitiesSyncToRouteQueryParams({
+  ...productEntityConfig,
+  prefix: 'p',
+  // 👇 p-search=tv&p-range.from=2026-08-11&p-range.to=2026-08-31
+  filterMapper: getFilterQueryMapper<ProductFilter>({
+    search: 'string',
+    range: { from: 'date', to: 'date' },
+  }),
+}),
+```
+
+Fields that are `undefined` or `null` are removed from the url. On the way back the generated mapper patches the filter instead of replacing it, so the fields it does not declare keep the value they have, at the top level and inside a declared object alike.
+
+Every declared field is restored, and one whose param is missing from the url, or does not match its declared type, falls back to the value it has in `defaultFilter` rather than being left empty, which is what makes a bare url restore the declared fields to their defaults instead of leaving the filter alone. When `defaultFilter` says nothing about the field, the value the filter already holds is kept instead of emptying it.
+
+The flip side is that a field cannot travel as cleared unless its default already is, restoring a url without its param brings the default back rather than an empty value.
 
 For anything else, like renaming a field to something shorter, pass the mapper object by hand:
 
@@ -227,6 +247,8 @@ withEntitiesSyncToRouteQueryParams({
   },
 }),
 ```
+
+`queryParamsToFilter` also receives the store `defaultFilter` and the filter the store holds right now, `(query, defaultFilter, currentFilter)`, to fall back on for what the url does not carry, and it can return `undefined` to leave the filter alone. Set `patch: true` on the mapper when it only maps some of the fields, so the rest are merged instead of replaced.
 
 Also consider `syncPagination: false`, `syncSort: false` or `syncSingleSelection: false` to drop the params you do not need to restore from the url.
 

--- a/apps/docs/src/app/pages/docs/traits/with-sync-to-route-query-params.md
+++ b/apps/docs/src/app/pages/docs/traits/with-sync-to-route-query-params.md
@@ -54,23 +54,67 @@ Which gives a url like:
 ?search=shoes&page=2&showSold=true&day=2026-08-11&startsAt=2026-08-11T09:30:00.000Z&filter=%7B%22color%22%3A%22red%22%2C%22size%22%3A10%7D
 ```
 
-The prop names come from the state of the store the feature is added to, so they autocomplete, and each prop only accepts the types that fit its value. Declaring `page: 'string'` for a numeric prop, or a prop that is not in the state, is a compile error.
+The prop names come from the state of the store the feature is added to, so they autocomplete, and each prop only accepts the types that fit its value. Declaring `page: 'string'` for a numeric prop, or a prop that is not in the state, is a compile error, and so is the same mistake inside a nested props object.
 
 ### Available types
 
-| Type          | Use for            | In the url                              |
-| ------------- | ------------------ | --------------------------------------- |
-| `'string'`    | string props       | `?search=shoes`                         |
-| `'number'`    | number props       | `?page=2`                               |
-| `'boolean'`   | boolean props      | `?showSold=true`                        |
-| `'date'`      | Date props         | `?day=2026-08-11`                       |
-| `'date-time'` | Date props         | `?startsAt=2026-08-11T09:30:00.000Z`    |
-| `'time'`      | Date props         | `?at=09:30`                             |
-| `'json'`      | objects and arrays | `?filter=%7B%22color%22%3A%22red%22%7D` |
+| Type            | Use for                       | In the url                              |
+| --------------- | ----------------------------- | --------------------------------------- |
+| `'string'`      | string props                  | `?search=shoes`                         |
+| `'number'`      | number props                  | `?page=2`                               |
+| `'boolean'`     | boolean props                 | `?showSold=true`                        |
+| `'date'`        | Date props                    | `?day=2026-08-11`                       |
+| `'date-time'`   | Date props                    | `?startsAt=2026-08-11T09:30:00.000Z`    |
+| `'time'`        | Date props                    | `?at=09:30`                             |
+| `'string-array'`| string[] props                | `?tags=shoes,boots`                     |
+| `'number-array'`| number[] props                | `?ids=1,2,3`                            |
+| `'json'`        | objects and arrays            | `?filter=%7B%22color%22%3A%22red%22%7D` |
+| `{ field: ... }`| objects, described field by field | `?filter.color=red`                 |
 
 Only `'json'` props go through `JSON.stringify`, the rest are written in their plain form so the url stays readable. `'json'` is not offered for primitives, it would write the same url while accepting more on the way back, so `?showSold=123` could put a number in a boolean prop.
 
 A `Date` prop picks how much of the date to keep. `'date'` and `'time'` are written in local time, so a day picked as the 11th does not travel as the 10th for anyone west of Greenwich, while `'date-time'` writes a full iso timestamp in UTC. A `'time'` param has no day to sit on, so it is restored onto the epoch date, `1970-01-01`.
+
+An array of strings or of numbers can travel as a comma separated list with `'string-array'` or `'number-array'`, which reads better than the json version of the same prop, `?tags=shoes,boots` instead of `?tags=%5B%22shoes%22%2C%22boots%22%5D`. Both keep the param when the array is empty, written as `?tags=`, so an empty array is restored as one instead of reading back as a prop the url does not carry. A `'number-array'` param with an element that is not a number is skipped whole, half an array is worse than the one the prop already holds.
+
+A `'string-array'` prop must not hold values with a comma in them. The comma is the separator, so `['a,b']` is written as `?tags=a,b` and read back as `['a', 'b']`, silently. Escaping it is not worth it, the router encodes the value again so it would surface in the url as `%252C`, which defeats the point of a readable list. Declare the prop as `'json'` when its values can carry commas. In dev mode a warning is logged naming the prop when one is written, in production the check is skipped.
+
+Arrays of anything else only take `'json'`, a props object has no way to describe their elements.
+
+### Describing an object field by field
+
+A prop holding an object can travel as `'json'`, or be described with a nested props object of the same shape, which gives it one param per field named with the path to it:
+
+```typescript
+const Store = signalStore(
+  withState({
+    filter: { color: 'red', size: 10, from: new Date() },
+  }),
+  withSyncToRouteQueryParams({
+    mappers: [
+      getQueryMapperForState({
+        filter: { color: 'string', from: 'date' },
+      }),
+    ],
+  }),
+);
+```
+
+```
+?filter.color=red&filter.from=2026-08-11
+```
+
+Instead of the `'json'` version of the same prop:
+
+```
+?filter=%7B%22color%22%3A%22red%22%2C%22from%22%3A%222026-08-11T00%3A00%3A00.000Z%22%7D
+```
+
+Besides the shorter url, the fields keep their types on the way back. `from` above is restored as a `Date`, while `JSON.parse` would have given back the string it was serialized to.
+
+Nesting goes as deep as the object does, `{ range: { from: 'date' } }` becomes `?range.from=2026-08-11`, and the field names and types are checked at every level.
+
+The fields you leave undeclared, `size` above, are neither written to the url nor touched when it is read back, they keep the value the store has. That is what makes a partial declaration safe, the object is merged rather than replaced.
 
 ### How values that do not fit are handled
 
@@ -79,6 +123,8 @@ A `Date` prop picks how much of the date to keep. `'date'` and `'time'` are writ
 | The prop is `undefined` or `null`                                     | The param is removed from the url              |
 | The param is missing from the url                                     | The prop is left untouched in the store        |
 | The param does not match its type, `?page=abc` from a hand edited url | The param is skipped, the prop keeps its value |
+| A nested field is left undeclared                                     | It is not written to the url, and keeps its value when the url is read back |
+| A nested param is present but the prop holds nothing yet              | The object is built from the params that are there |
 
 ### Restoring on demand instead of on init
 

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter.util.ts
@@ -89,9 +89,15 @@ export type FilterQueryMapper<Filter, T extends Params = Params> = {
   /**
    * @param defaultFilter the filter the store was created with, to fall back on
    *   for fields the query params do not carry
+   * @param currentFilter the filter the store holds right now, to keep the
+   *   parts of it the query params say nothing about
    * @returns the filter to apply, or undefined to leave the current one alone
    */
-  queryParamsToFilter: (query: T, defaultFilter: Filter) => Filter | undefined;
+  queryParamsToFilter: (
+    query: T,
+    defaultFilter: Filter,
+    currentFilter: Filter,
+  ) => Filter | undefined;
   filterToQueryParams: (filter: Filter) => T | undefined | null;
   /**
    * Merge the restored filter into the current one instead of replacing it,
@@ -172,8 +178,13 @@ export function getQueryMapperForEntitiesFilter<Filter>(config?: {
   return {
     queryParamsToState: (query, store, firstLoad) => {
       const defaultFilter = (store[defaultFilterKey] as Signal<Filter>)?.();
+      const currentFilter = (store[filterKey] as Signal<Filter>)?.();
       const filter = config?.filterMapper
-        ? config?.filterMapper.queryParamsToFilter(query, defaultFilter)
+        ? config?.filterMapper.queryParamsToFilter(
+            query,
+            defaultFilter,
+            currentFilter,
+          )
         : query.filter
           ? JSON.parse(query.filter)
           : undefined;

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-entities-sync-to-route-query-params.spec.ts
@@ -127,6 +127,26 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
     );
   };
 
+  const defaultFrom = new Date(2026, 0, 2);
+  type NestedFilter = { search: string; range: { from: Date; to: string } };
+
+  const nestedFilterStoreFeature = () => {
+    return signalStoreFeature(
+      withEntities({ entity }),
+      withCallStatus({ initialValue: 'loaded' }),
+      withEntitiesLocalFilter({
+        entity,
+        defaultFilter: {
+          search: '',
+          range: { from: defaultFrom, to: 'end' },
+        } as NestedFilter,
+        filterFn: (e, filter) =>
+          !filter?.search ||
+          e?.name.toLowerCase().includes(filter.search.toLowerCase()),
+      }),
+    );
+  };
+
   const localCollectionStoreFeature = ({
     load,
   }: { load?: Subject<boolean> } = {}) => {
@@ -420,6 +440,180 @@ describe('withEntitiesSyncToRouteQueryParams', () => {
       expect(() => store.entities()).not.toThrow();
       expect(store.entitiesFilter()).toEqual({ search: 'a', category: 'all' });
     });
+
+    it('should spread a nested filter field over one param per leaf', () => {
+      const Store = signalStore(
+        nestedFilterStoreFeature(),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          filterMapper: getFilterQueryMapper<NestedFilter>({
+            search: 'string',
+            range: { from: 'date' },
+          }),
+        }),
+      );
+      const { store } = init({
+        Store,
+        queryParams: { search: 'foo', 'range.from': '2026-05-06' },
+      });
+      expect(store.entitiesFilter()).toEqual({
+        search: 'foo',
+        // a nested date comes back a Date, and to, which is not declared,
+        // keeps the value it has in defaultFilter
+        range: { from: new Date(2026, 4, 6), to: 'end' },
+      });
+    });
+
+    it('should restore a declared nested field to its default when its param is not in the url', () => {
+      const Store = signalStore(
+        nestedFilterStoreFeature(),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          filterMapper: getFilterQueryMapper<NestedFilter>({
+            search: 'string',
+            range: { from: 'date' },
+          }),
+        }),
+      );
+      const { store } = init({ Store, queryParams: { search: 'foo' } });
+      expect(store.entitiesFilter()).toEqual({
+        search: 'foo',
+        range: { from: defaultFrom, to: 'end' },
+      });
+    });
+
+    function initWithQueryParams<S extends Type<any>>({
+      Store,
+      queryParams,
+    }: {
+      Store: S;
+      queryParams: Subject<Record<string, any>>;
+    }) {
+      TestBed.configureTestingModule({
+        providers: [
+          Store,
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useFactory: () => ({ queryParams }),
+          },
+        ],
+      });
+      const router = TestBed.inject(Router);
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      return { store: TestBed.inject(Store) as InstanceType<S> };
+    }
+
+    it('should keep an undeclared nested field the user changed, not only on the first load', fakeAsync(() => {
+      const Store = signalStore(
+        nestedFilterStoreFeature(),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          // to is deliberately left out, only from is synced
+          filterMapper: getFilterQueryMapper<NestedFilter>({
+            search: 'string',
+            range: { from: 'date' },
+          }),
+        }),
+      );
+      const queryParams = new Subject<Record<string, any>>();
+      const { store } = initWithQueryParams({ Store, queryParams });
+      queryParams.next({});
+      tick(400);
+
+      store.filterEntities({
+        filter: { search: '', range: { from: defaultFrom, to: 'MINE' } },
+        forceLoad: true,
+      });
+      tick(400);
+      expect(store.entitiesFilter().range.to).toBe('MINE');
+
+      // a later emission, a back navigation or another feature pushing a param
+      queryParams.next({ search: 'foo' });
+      tick(400);
+
+      expect(store.entitiesFilter()).toEqual({
+        search: 'foo',
+        // the field the mapper does not declare keeps what the user set, it
+        // used to be reset to the value it has in defaultFilter
+        range: { from: defaultFrom, to: 'MINE' },
+      });
+    }));
+
+    it('should keep an undeclared nested field when the default filter has no value for it', fakeAsync(() => {
+      type OptionalRangeFilter = {
+        search: string;
+        range?: { from: Date; to: string };
+      };
+      const Store = signalStore(
+        withEntities({ entity }),
+        withCallStatus({ initialValue: 'loaded' }),
+        withEntitiesLocalFilter({
+          entity,
+          defaultFilter: { search: '' } as OptionalRangeFilter,
+          filterFn: (e, filter) =>
+            !filter?.search ||
+            e?.name.toLowerCase().includes(filter.search.toLowerCase()),
+        }),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          filterMapper: getFilterQueryMapper<OptionalRangeFilter>({
+            search: 'string',
+            range: { from: 'date' },
+          }),
+        }),
+      );
+      const queryParams = new Subject<Record<string, any>>();
+      const { store } = initWithQueryParams({ Store, queryParams });
+      queryParams.next({});
+      tick(400);
+
+      store.filterEntities({
+        filter: { search: '', range: { from: defaultFrom, to: 'MINE' } },
+        forceLoad: true,
+      });
+      tick(400);
+
+      queryParams.next({ search: 'foo' });
+      tick(400);
+
+      // the whole range used to be replaced by { from: undefined }
+      expect(store.entitiesFilter()).toEqual({
+        search: 'foo',
+        range: { from: defaultFrom, to: 'MINE' },
+      });
+    }));
+
+    it('changes on a nested filter field should update url query params', fakeAsync(() => {
+      const Store = signalStore(
+        nestedFilterStoreFeature(),
+        withEntitiesSyncToRouteQueryParams({
+          entity,
+          filterMapper: getFilterQueryMapper<NestedFilter>({
+            search: 'string',
+            range: { from: 'date' },
+          }),
+        }),
+      );
+      const { store, router } = init({ Store, queryParams: {} });
+      store.filterEntities({
+        filter: {
+          search: 'foo3',
+          range: { from: new Date(2026, 4, 6), to: 'end' },
+        },
+        forceLoad: true,
+      });
+      tick(400);
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: expect.objectContaining({
+          search: 'foo3',
+          'range.from': '2026-05-06',
+        }),
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    }));
 
     it('changes on entities filter should update url query params, with a generated filterMapper', fakeAsync(() => {
       const Store = signalStore(

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.spec.ts
@@ -620,3 +620,327 @@ describe('getQueryMapperForState', () => {
     tick(1000);
   }));
 });
+
+describe('getQueryMapperForState with nested props', () => {
+  const day = new Date(2026, 2, 4);
+
+  function init(queryParams: Record<string, string> = {}) {
+    const Store = signalStore(
+      { protectedState: false },
+      withState({
+        filter: {
+          color: 'red',
+          size: 10,
+          from: day,
+          nested: { deep: 'initial' },
+        },
+        optional: undefined as { a: string } | undefined,
+      }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          getQueryMapperForState({
+            filter: {
+              color: 'string',
+              from: 'date',
+              nested: { deep: 'string' },
+            },
+            optional: { a: 'string' },
+          }),
+        ],
+      }),
+    );
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        Store,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            queryParams: of(queryParams),
+            snapshot: { queryParams },
+          }),
+        },
+      ],
+    });
+    return { store: TestBed.inject(Store) };
+  }
+
+  it('should restore nested props from their dotted params', () => {
+    const { store } = init({
+      'filter.color': 'blue',
+      'filter.from': '2026-05-06',
+      'filter.nested.deep': 'restored',
+    });
+    expect(store.filter()).toEqual({
+      color: 'blue',
+      // a nested date comes back a Date, JSON.parse would give a string
+      from: new Date(2026, 4, 6),
+      // size is not declared, so it keeps the value the store had
+      size: 10,
+      nested: { deep: 'restored' },
+    });
+  });
+
+  it('should keep the undeclared and missing nested fields untouched', () => {
+    const { store } = init({ 'filter.color': 'blue' });
+    expect(store.filter()).toEqual({
+      color: 'blue',
+      size: 10,
+      from: day,
+      nested: { deep: 'initial' },
+    });
+  });
+
+  it('should skip a nested param that does not match its declared type', () => {
+    const { store } = init({ 'filter.from': 'not a date' });
+    expect(store.filter().from).toEqual(day);
+  });
+
+  it('should build the object when the prop holds nothing yet', () => {
+    const { store } = init({ 'optional.a': 'built' });
+    expect(store.optional()).toEqual({ a: 'built' });
+  });
+
+  it('should write one param per leaf, named with the path to it', fakeAsync(() => {
+    const { store } = init();
+    const router = TestBed.inject(Router);
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    patchState(store, {
+      filter: {
+        color: 'green',
+        size: 42,
+        from: new Date(2026, 4, 6),
+        nested: { deep: 'written' },
+      },
+    });
+    TestBed.tick();
+    tick(400);
+
+    expect(navigate.mock.calls[0][1]?.queryParams).toEqual({
+      'filter.color': 'green',
+      'filter.from': '2026-05-06',
+      'filter.nested.deep': 'written',
+      // size is not declared, so it never reaches the url
+      'optional.a': undefined,
+    });
+    tick(1000);
+  }));
+
+  it('should remove the params of a prop that holds nothing', fakeAsync(() => {
+    const { store } = init();
+    const router = TestBed.inject(Router);
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    patchState(store, { filter: undefined as any });
+    TestBed.tick();
+    tick(400);
+
+    const params = navigate.mock.calls[0][1]?.queryParams as any;
+    expect(params['filter.color']).toBe(undefined);
+    expect(params['filter.nested.deep']).toBe(undefined);
+    tick(1000);
+  }));
+});
+
+describe('getQueryMapperForState prop checking', () => {
+  // these only have to compile, the @ts-expect-error comments are the
+  // assertions, tsc fails the build when one of them stops erroring
+  it('should reject props and types that do not fit the state', () => {
+    signalStore(
+      withState({ search: '', page: 0, filter: { color: 'red', size: 1 } }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          getQueryMapperForState({
+            search: 'string',
+            // @ts-expect-error not a prop of the state
+            pge: 'number',
+          }),
+          getQueryMapperForState({
+            // @ts-expect-error page holds a number, not a string
+            page: 'string',
+          }),
+          getQueryMapperForState({
+            // @ts-expect-error color is not a field of filter
+            filter: { colour: 'string' },
+          }),
+          getQueryMapperForState({
+            // @ts-expect-error size holds a number, not a boolean
+            filter: { size: 'boolean' },
+          }),
+          // the ones that do fit still compile
+          getQueryMapperForState({ filter: 'json' }),
+          getQueryMapperForState({ filter: { color: 'string' } }),
+        ],
+      }),
+    );
+    expect(true).toBe(true);
+  });
+});
+
+describe('getQueryMapperForState with array props', () => {
+  function init(queryParams: Record<string, string> = {}) {
+    const Store = signalStore(
+      { protectedState: false },
+      withState({
+        tags: ['a', 'b'] as string[],
+        ids: [1, 2] as number[],
+        mixed: [{ a: 1 }] as { a: number }[],
+        filter: { sizes: [10] as number[] },
+      }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          getQueryMapperForState({
+            tags: 'string-array',
+            ids: 'number-array',
+            mixed: 'json',
+            filter: { sizes: 'number-array' },
+          }),
+        ],
+      }),
+    );
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        Store,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            queryParams: of(queryParams),
+            snapshot: { queryParams },
+          }),
+        },
+      ],
+    });
+    return { store: TestBed.inject(Store) };
+  }
+
+  it('should restore arrays from a comma separated param', () => {
+    const { store } = init({
+      tags: 'shoes,boots,hats',
+      ids: '3,4,5',
+      'filter.sizes': '10,20',
+    });
+    expect(store.tags()).toEqual(['shoes', 'boots', 'hats']);
+    expect(store.ids()).toEqual([3, 4, 5]);
+    expect(store.filter()).toEqual({ sizes: [10, 20] });
+  });
+
+  it('should restore a single value as an array of one', () => {
+    const { store } = init({ tags: 'shoes', ids: '3' });
+    expect(store.tags()).toEqual(['shoes']);
+    expect(store.ids()).toEqual([3]);
+  });
+
+  it('should restore an empty param as an empty array', () => {
+    const { store } = init({ tags: '', ids: '' });
+    expect(store.tags()).toEqual([]);
+    expect(store.ids()).toEqual([]);
+  });
+
+  it('should skip a number array with an element that is not a number', () => {
+    expect(init({ ids: '1,x,3' }).store.ids()).toEqual([1, 2]);
+    // an empty element would read as 0
+    expect(init({ ids: '1,,3' }).store.ids()).toEqual([1, 2]);
+    expect(init({ ids: '1,2,' }).store.ids()).toEqual([1, 2]);
+  });
+
+  it('should write arrays as a comma separated list', fakeAsync(() => {
+    const { store } = init();
+    const router = TestBed.inject(Router);
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    patchState(store, {
+      tags: ['shoes', 'boots'],
+      ids: [3, 4],
+      mixed: [{ a: 2 }],
+      filter: { sizes: [] },
+    });
+    TestBed.tick();
+    tick(400);
+
+    expect(navigate.mock.calls[0][1]?.queryParams).toEqual({
+      tags: 'shoes,boots',
+      ids: '3,4',
+      // an array of anything else still goes through JSON.stringify
+      mixed: JSON.stringify([{ a: 2 }]),
+      // an empty array keeps the param, so it does not read back as missing
+      'filter.sizes': '',
+    });
+    tick(1000);
+  }));
+
+  it('should skip a repeated param instead of failing the whole restore', () => {
+    // the router hands a repeated param over as an array, which used to throw
+    // inside the mapper and take every mapper after it down with it
+    const { store } = init({
+      tags: ['shoes', 'boots'] as unknown as string,
+      ids: '3,4',
+    });
+    // the prop keeps the value it started with, nothing is guessed from it
+    expect(store.tags()).toEqual(['a', 'b']);
+    // and the params after the repeated one are still restored
+    expect(store.ids()).toEqual([3, 4]);
+  });
+
+  it('should warn when a string array value carries the separator', fakeAsync(() => {
+    const { store } = init();
+    const router = TestBed.inject(Router);
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    patchState(store, { tags: ['shoes,boots'] });
+    TestBed.tick();
+    tick(400);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("'tags'"));
+    // the value is still written, it just does not survive the round trip
+    expect((navigate.mock.calls[0][1]?.queryParams as any).tags).toBe(
+      'shoes,boots',
+    );
+    warn.mockRestore();
+    tick(1000);
+  }));
+
+  it('should not warn for a number array or for values without a comma', fakeAsync(() => {
+    const { store } = init();
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    patchState(store, { tags: ['shoes', 'boots'], ids: [1, 2] });
+    TestBed.tick();
+    tick(400);
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+    tick(1000);
+  }));
+
+  it('should reject an array type that does not fit the array', () => {
+    signalStore(
+      withState({ tags: ['a'] as string[], ids: [1] as number[] }),
+      withSyncToRouteQueryParams({
+        mappers: [
+          getQueryMapperForState({
+            // @ts-expect-error tags holds strings, not numbers
+            tags: 'number-array',
+          }),
+          getQueryMapperForState({
+            // @ts-expect-error ids holds numbers, not strings
+            ids: 'string-array',
+          }),
+          getQueryMapperForState({
+            // @ts-expect-error an array cannot be described field by field
+            tags: { 0: 'string' },
+          }),
+          // json is still allowed for both
+          getQueryMapperForState({ tags: 'json', ids: 'json' }),
+        ],
+      }),
+    );
+    expect(true).toBe(true);
+  });
+});

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-route-query-params/with-sync-to-route-query-params.util.ts
@@ -1,4 +1,4 @@
-import { computed, Signal } from '@angular/core';
+import { computed, isDevMode, Signal } from '@angular/core';
 import { Params } from '@angular/router';
 import { patchState, SignalStoreFeatureResult } from '@ngrx/signals';
 
@@ -31,6 +31,8 @@ export type QueryParamType =
   | 'date'
   | 'date-time'
   | 'time'
+  | 'string-array'
+  | 'number-array'
   | 'json';
 
 /**
@@ -39,15 +41,17 @@ export type QueryParamType =
  * undefined are stripped so optional props can be synced too.
  *
  * Each kind of value gets exactly one type, except dates which choose how much
- * of the date to keep in the url, and 'json' is left for objects and arrays. It
- * is not offered as an alternative for the primitives because it writes the
- * same url while validating less on the way back, so '?flag=123' would put a
- * number in a boolean prop, and not for dates because JSON.parse gives back a
- * string, not a Date.
+ * of the date to keep in the url, and objects which either travel as 'json' or
+ * are described field by field with a nested props object of the same shape.
+ * 'json' is not offered as an alternative for the primitives because it writes
+ * the same url while validating less on the way back, so '?flag=123' would put
+ * a number in a boolean prop, and not for dates because JSON.parse gives back a
+ * string, not a Date. An array of strings or of numbers can travel as a comma
+ * separated list instead of json, anything else in an array only takes 'json'.
  */
 type QueryParamTypeFor<T> = 0 extends 1 & T
   ? // an any typed prop matches every branch below, so let it pick any type
-    QueryParamType
+    QueryParamType | Record<string, any>
   : [NonNullable<T>] extends [Date]
     ? 'date' | 'date-time' | 'time'
     : [NonNullable<T>] extends [boolean]
@@ -56,15 +60,98 @@ type QueryParamTypeFor<T> = 0 extends 1 & T
         ? 'string'
         : [NonNullable<T>] extends [number]
           ? 'number'
-          : 'json';
+          : [NonNullable<T>] extends [readonly string[]]
+            ? 'json' | 'string-array'
+            : [NonNullable<T>] extends [readonly number[]]
+              ? 'json' | 'number-array'
+              : [NonNullable<T>] extends [readonly any[]]
+                ? 'json'
+                : [NonNullable<T>] extends [object]
+                  ? 'json' | QueryParamTypesFor<NonNullable<T>>
+                  : 'json';
 
 /**
  * The props object shape for a given store state, every state prop is optional
- * and can only be declared as one of the types that fits its value.
+ * and can only be declared as one of the types that fits its value, or as a
+ * nested props object when it holds one.
  */
 type QueryParamTypesFor<State> = {
   [K in keyof State]?: QueryParamTypeFor<State[K]>;
 };
+
+/**
+ * The query param names a props object produces, a prop declared with a nested
+ * props object becomes one param per leaf, named with the path to it joined by
+ * dots.
+ */
+type QueryParamNames<Props> = {
+  [K in keyof Props & string]: Props[K] extends QueryParamType
+    ? K
+    : `${K}.${QueryParamNames<Props[K]>}`;
+}[keyof Props & string];
+
+/**
+ * Fails on the props that are not in the state, at every level. The names are
+ * autocompleted from QueryParamTypesFor but not checked against it, because the
+ * state is still being inferred while the props object is read, which is what
+ * turns the excess property check off. Mapping every key to the type it is
+ * allowed to have, or to a message when the state does not have it, checks them
+ * once the state is known.
+ */
+type OnlyStateProps<Props, State> = {
+  [K in keyof Props]: K extends keyof State
+    ? Props[K] extends QueryParamType
+      ? QueryParamTypeFor<State[K]>
+      : OnlyStateProps<Props[K], NonNullable<State[K]>>
+    : `'${K & string}' is not a prop of the state`;
+};
+
+type PropsTree = { [key: string]: QueryParamType | PropsTree };
+
+/**
+ * Turns a props object into one entry per leaf, keeping the path to each one,
+ * so a nested prop becomes the query param 'filter.color' and can be read back
+ * into the right place.
+ */
+function flattenProps(
+  props: PropsTree,
+  path: string[] = [],
+): [string[], QueryParamType][] {
+  return Object.entries(props).reduce(
+    (acc, [key, value]) =>
+      typeof value === 'string'
+        ? [...acc, [[...path, key], value] as [string[], QueryParamType]]
+        : [...acc, ...flattenProps(value, [...path, key])],
+    [] as [string[], QueryParamType][],
+  );
+}
+
+/**
+ * Reads the value at a path, undefined as soon as the path runs into nothing.
+ */
+function getIn(value: unknown, path: string[]): unknown {
+  return path.reduce<any>(
+    (acc, key) => (acc === undefined || acc === null ? undefined : acc[key]),
+    value,
+  );
+}
+
+/**
+ * Returns a copy of value with the path set. The objects along the way are
+ * copied instead of mutated, and the fields the path does not touch are kept,
+ * so the ones a props object does not declare survive the round trip.
+ */
+function setIn(value: unknown, path: string[], leaf: unknown): unknown {
+  const [key, ...rest] = path;
+  const base =
+    value && typeof value === 'object'
+      ? (value as Record<string, unknown>)
+      : {};
+  return {
+    ...base,
+    [key]: rest.length ? setIn(base[key], rest, leaf) : leaf,
+  };
+}
 
 /**
  * Creates a QueryMapper that syncs state props to query params with the same
@@ -73,12 +160,23 @@ type QueryParamTypesFor<State> = {
  * The prop names come from the state of the store the
  * withSyncToRouteQueryParams feature is added to, so they autocomplete, and
  * each prop only accepts the types that fit its value, so declaring
- * `page: 'string'` for a numeric prop is a compile error.
+ * `page: 'string'` for a numeric prop, or a prop the state does not have, is a
+ * compile error, at every level of a nested props object.
  *
  * Only 'json' props go through JSON.stringify, the rest are written in their
  * plain form so urls stay readable. Date props pick how much of the date to
  * keep, 'date' writes 2026-08-11, 'date-time' writes an iso timestamp and
- * 'time' writes 09:30, all in local time except 'date-time'.
+ * 'time' writes 09:30, all in local time except 'date-time'. An array of
+ * strings or of numbers can be written as a comma separated list with
+ * 'string-array' or 'number-array', so ?tags=shoes,boots. The comma is the
+ * separator, so a string carrying one comes back split in two, use 'json' for
+ * those, in dev mode a warning is logged when it happens.
+ *
+ * A prop holding an object can be declared as 'json' to travel as a single
+ * param, or described field by field with a nested props object, which gives
+ * it one param per field named with the path to it, so `filter.color=red`. The
+ * fields left undeclared keep the value they have in the store, they are
+ * neither written to the url nor cleared when it is read back.
  *
  * A prop that is undefined or null is removed from the url, a param missing
  * from the url is left untouched in the store, and a param that does not match
@@ -95,6 +193,7 @@ type QueryParamTypesFor<State> = {
  *         showSold: false,
  *         day: new Date(),
  *         startsAt: new Date(),
+ *         tags: ['shoes'],
  *         filter: { color: 'red', size: 10 },
  *       }),
  *       withSyncToRouteQueryParams({
@@ -105,35 +204,68 @@ type QueryParamTypesFor<State> = {
  *             showSold: 'boolean',
  *             day: 'date',
  *             startsAt: 'date-time',
+ *             tags: 'string-array',
  *             filter: 'json',
  *           }),
  *         ],
  *       }),
  *     );
  *     // ?search=shoes&page=2&showSold=true&day=2026-08-11
- *     //  &startsAt=2026-08-11T09:30:00.000Z
+ *     //  &startsAt=2026-08-11T09:30:00.000Z&tags=shoes,boots
  *     //  &filter=%7B%22color%22%3A%22red%22%2C%22size%22%3A10%7D
+ *
+ * @example
+ *     // the same filter prop described field by field instead, which keeps the
+ *     // url readable and brings back a real Date rather than the string
+ *     // JSON.parse would give
+ *     const Store = signalStore(
+ *       withState({
+ *         filter: { color: 'red', size: 10, from: new Date() },
+ *       }),
+ *       withSyncToRouteQueryParams({
+ *         mappers: [
+ *           getQueryMapperForState({
+ *             filter: { color: 'string', from: 'date' },
+ *           }),
+ *         ],
+ *       }),
+ *     );
+ *     // ?filter.color=red&filter.from=2026-08-11
+ *     // size is not declared, so it stays at whatever the store holds
  */
 export function getQueryMapperForState<
   Input extends SignalStoreFeatureResult,
-  const Props extends QueryParamTypesFor<Input['state']>,
+  const Props extends QueryParamTypesFor<Input['state']> &
+    OnlyStateProps<Props, Input['state']>,
 >(
   props: Props,
 ): QueryMapper<
-  Partial<Record<keyof Props & string, string>>,
+  Partial<Record<QueryParamNames<Props>, string>>,
   Record<string, any>,
   Input
 > {
-  const entries = Object.entries(props) as [string, QueryParamType][];
+  const entries = flattenProps(props as PropsTree);
   return {
     queryParamsToState: (query, store) => {
       const params = query as Record<string, string | undefined>;
+      const signals = store as unknown as Record<string, Signal<unknown>>;
       const state = entries.reduce(
-        (acc, [prop, propType]) => {
-          const value = params[prop];
+        (acc, [path, propType]) => {
+          const value = params[path.join('.')];
           if (value === undefined) return acc;
           const parsed = deserializeQueryParam(value, propType);
-          if (parsed) acc[prop] = parsed.value;
+          if (!parsed) return acc;
+          const [prop, ...rest] = path;
+          acc[prop] = rest.length
+            ? // merged over the value the prop already holds, patchState only
+              // replaces whole props, so the fields this mapper does not
+              // declare would be dropped otherwise
+              setIn(
+                prop in acc ? acc[prop] : signals[prop]?.(),
+                rest,
+                parsed.value,
+              )
+            : parsed.value;
           return acc;
         },
         {} as Record<string, unknown>,
@@ -147,12 +279,17 @@ export function getQueryMapperForState<
       return computed(
         () =>
           entries.reduce(
-            (acc, [prop, propType]) => {
-              acc[prop] = serializeQueryParam(signals[prop](), propType);
+            (acc, [path, propType]) => {
+              const [prop, ...rest] = path;
+              acc[path.join('.')] = serializeQueryParam(
+                getIn(signals[prop](), rest),
+                propType,
+                path.join('.'),
+              );
               return acc;
             },
             {} as Record<string, string | undefined>,
-          ) as Partial<Record<keyof Props & string, string>>,
+          ) as Partial<Record<QueryParamNames<Props>, string>>,
       );
     },
   };
@@ -168,11 +305,17 @@ export function getQueryMapperForState<
  * The filter type cannot be inferred from the store, so it has to be given,
  * which is what makes the field names autocomplete and their types check.
  *
+ * A field holding an object can be described field by field too, with a nested
+ * props object, which gives it one param per field named with the path to it,
+ * so `range.from=2026-08-11`.
+ *
  * A field that is undefined or null is removed from the url. On the way back
- * the mapper patches the filter instead of replacing it, so fields it does not
- * declare keep their value, while every declared field is restored, falling
+ * the mapper patches the filter instead of replacing it, so the fields it does
+ * not declare keep their value, the ones at the top level and the ones inside
+ * a declared object alike, while every declared field is restored, falling
  * back to the value the field has in the store defaultFilter when its param is
- * missing or does not match its type. A bare url therefore restores the
+ * missing or does not match its type, or to the one the filter already holds
+ * when defaultFilter says nothing about it. A bare url therefore restores the
  * declared fields to their defaults, which is also what makes the back button
  * work after clearing a filter.
  *
@@ -195,28 +338,64 @@ export function getQueryMapperForState<
  *       }),
  *     });
  *     // ?product-search=shoes&product-maxPrice=100&product-from=2026-08-11
+ *
+ * @example
+ *     type ProductFilter = {
+ *       search: string;
+ *       range: { from: Date; to: Date };
+ *     };
+ *
+ *     withEntitiesSyncToRouteQueryParams({
+ *       entity,
+ *       collection,
+ *       filterMapper: getFilterQueryMapper<ProductFilter>({
+ *         search: 'string',
+ *         range: { from: 'date', to: 'date' },
+ *       }),
+ *     });
+ *     // ?product-search=shoes&product-range.from=2026-08-11
+ *     //  &product-range.to=2026-08-31
  */
 export function getFilterQueryMapper<
   Filter extends Record<string, any>,
   const Props extends QueryParamTypesFor<Filter> = QueryParamTypesFor<Filter>,
 >(props: Props): FilterQueryMapper<Filter> {
-  const entries = Object.entries(props) as [string, QueryParamType][];
+  const entries = flattenProps(props as PropsTree);
   return {
     // the filter is merged, so the fields this mapper does not declare survive
     patch: true,
-    queryParamsToFilter: (query, defaultFilter) => {
+    queryParamsToFilter: (query, defaultFilter, currentFilter) => {
       const params = query as Record<string, string | undefined>;
       return entries.reduce(
-        (acc, [prop, propType]) => {
-          const value = params[prop];
+        (acc, [path, propType]) => {
+          const value = params[path.join('.')];
           const parsed =
             value === undefined
               ? undefined
               : deserializeQueryParam(value, propType);
           // every declared field is written, one whose param is missing or
           // unparsable falls back to its default rather than to undefined,
-          // which would hand a filterFn a field it does not expect to be empty
-          acc[prop] = parsed ? parsed.value : defaultFilter?.[prop];
+          // which would hand a filterFn a field it does not expect to be empty.
+          // the default comes first so a bare url restores the declared fields
+          // to it, the current value is only there for the fields defaultFilter
+          // says nothing about
+          const leaf = parsed
+            ? parsed.value
+            : getIn(defaultFilter, path) ?? getIn(currentFilter, path);
+          const [prop, ...rest] = path;
+          acc[prop] = rest.length
+            ? // the filter is only merged field by field at the top level, so
+              // a nested field this mapper does not declare is kept by seeding
+              // the object with the one the store holds, the same way the state
+              // mapper seeds from the prop it is about to patch
+              setIn(
+                prop in acc
+                  ? acc[prop]
+                  : getIn(currentFilter, [prop]) ?? defaultFilter?.[prop],
+                rest,
+                leaf,
+              )
+            : leaf;
           return acc;
         },
         {} as Record<string, unknown>,
@@ -224,8 +403,12 @@ export function getFilterQueryMapper<
     },
     filterToQueryParams: (filter) =>
       entries.reduce(
-        (acc, [prop, propType]) => {
-          acc[prop] = serializeQueryParam(filter?.[prop], propType);
+        (acc, [path, propType]) => {
+          acc[path.join('.')] = serializeQueryParam(
+            getIn(filter, path),
+            propType,
+            path.join('.'),
+          );
           return acc;
         },
         {} as Record<string, string | undefined>,
@@ -236,6 +419,7 @@ export function getFilterQueryMapper<
 function serializeQueryParam(
   value: unknown,
   type: QueryParamType,
+  name?: string,
 ): string | undefined {
   // undefined removes the param from the url, null is treated the same so a
   // cleared prop does not end up as the string 'null' in the url
@@ -243,6 +427,26 @@ function serializeQueryParam(
   switch (type) {
     case 'json':
       return JSON.stringify(value);
+    case 'string-array':
+    case 'number-array':
+      if (!Array.isArray(value)) return String(value);
+      if (
+        isDevMode() &&
+        type === 'string-array' &&
+        value.some((item) => `${item}`.includes(','))
+      ) {
+        // the comma is the separator, so the value would silently come back
+        // split in two, which is worth saying out loud rather than debugging.
+        // dev mode only, this runs on every write of the param
+        console.warn(
+          `[withSyncToRouteQueryParams] the value of ${
+            name ? `'${name}'` : 'a string-array prop'
+          } contains a comma, it will be read back as two entries, declare the prop as 'json' instead`,
+        );
+      }
+      // an empty array still writes the param, as an empty value, dropping it
+      // would read back as 'the url does not carry this prop' instead
+      return value.join(',');
     case 'date':
       // the local date, not the utc one, so a date picked as the 11th does not
       // travel as the 10th for anyone west of greenwich
@@ -277,6 +481,12 @@ function deserializeQueryParam(
   value: string,
   type: QueryParamType,
 ): { value: unknown } | undefined {
+  // a repeated param, ?tags=a&tags=b, is handed over as an array, and there is
+  // no telling which entry was meant, so it is skipped like any other value
+  // that does not match its declared type. without this the string methods
+  // below throw, and the throw takes the whole restore with it, the mappers
+  // after this one never run
+  if (typeof value !== 'string') return undefined;
   switch (type) {
     case 'string':
       return { value };
@@ -314,6 +524,21 @@ function deserializeQueryParam(
       if (hours > 23 || minutes > 59 || seconds > 59) return undefined;
       // a time on its own has no day to sit on, so it lands on the epoch date
       return { value: new Date(1970, 0, 1, hours, minutes, seconds) };
+    }
+    case 'string-array':
+      return { value: value === '' ? [] : value.split(',') };
+    case 'number-array': {
+      if (value === '') return { value: [] };
+      const items = value.split(',');
+      // an empty element would read as 0, the same way '?page=' is rejected
+      // for a number prop rather than restored as one
+      if (items.some((item) => item.trim() === '')) return undefined;
+      const parsed = items.map(Number);
+      // one bad element skips the whole param, half an array is worse than the
+      // one the prop already holds
+      return parsed.some((item) => Number.isNaN(item))
+        ? undefined
+        : { value: parsed };
     }
     case 'json':
       try {


### PR DESCRIPTION
Follows up on getQueryMapperForState / getFilterQueryMapper with three
things: nested props, real prop name checking, and comma separated arrays.

## Nested props

A prop holding an object could only travel as `'json'`. It can now be
described field by field with a nested props object of the same shape,
which gives it one param per leaf, named with the path to it:

```ts
getQueryMapperForState({
  filter: { color: 'string', from: 'date' },
})
// ?filter.color=red&filter.from=2026-08-11
// instead of ?filter=%7B%22color%22%3A%22red%22%2C%22from%22%3A%222026...
```

Besides the shorter url the fields keep their types, `from` comes back a
`Date` where `JSON.parse` gave back the string. Nesting goes as deep as the
object does, and `'json'` still works on the same props.

Fields you leave undeclared are neither written to the url nor cleared when
it is read back, the object is merged rather than replaced. That needed a
copy-on-write `setIn`, seeded with the value already in the store for
`getQueryMapperForState` and with `defaultFilter[prop]` for
`getFilterQueryMapper`, whose filter merge is shallow and would otherwise
replace the whole nested object.

## Props that are not in the state now fail to compile

`getQueryMapperForState({ pge: 'number' })` used to compile and then throw
`signals[prop] is not a function` at runtime. The excess property check does
not run while `Input` is still being inferred from the mappers array, and
TypeScript skips it entirely against a target with no known properties, so
nothing caught the name. Value types were caught, that is assignability, not
freshness.

The constraint is now F-bounded and maps every key to the type it is allowed
to have, or to a message when the state does not have it:

```
error TS2322: Type '"number"' is not assignable to type
  '"'pge' is not a prop of the state'"
```

It has to recurse, checking only the top level turned off the nested check
that freshness had been doing. `getFilterQueryMapper` was never affected,
its `Filter` is explicit so the constraint is concrete from the start.

Autocomplete is unchanged, verified against the language service: keys
complete at every level, values complete at the top level.

## string-array and number-array

An array of strings or numbers can be written as a comma separated list
instead of a json blob, `?tags=shoes,boots` and `?ids=1,2,3`. `'json'` is
still available for both, and arrays of anything else still only take it.

Three judgement calls:

- an empty array keeps the param, written as `?tags=`, and reads back as
  `[]`. Dropping it would read as "the url does not carry this prop" and
  leave the old array in place, so an emptied array could never travel
- one bad element skips the whole param, `?ids=1,x,3` leaves the prop alone
  rather than restoring `[1,3]`
- empty elements are rejected for `'number-array'`, `?ids=1,,3` would come
  back as `0` since `Number('')` is `0`, matching `'number'` already
  rejecting `?page=`

A `'string-array'` value carrying a comma cannot round trip, it comes back
split in two. Escaping is not worth it, the router encodes the value again
so it would surface as `%252C`. Instead the prop is named in a
`console.warn` guarded by `isDevMode()`, the way `with-calls` and
`with-sync-to-web-storage` warn, and the docs say to use `'json'` for those.

## Tests

31 new tests across the two specs, covering nested restore and write,
merging, the array types and their rejection cases, and the dev warning.
Seven of them are `@ts-expect-error` assertions on the prop checking, so
`tsc -p tsconfig.spec.json` fails if any of those stops erroring.

660 pass, lib and spec typecheck clean, prettier clean.

## Docs

`with-sync-to-route-query-params.md` gets the new types in the table, a
section on describing an object field by field, and the array notes with the
comma caveat. `with-entities-sync-to-route-query-params.md` gets the shared
type list and a nested `filterMapper` example.
