### PR TITLE
fix(signals): stop call promises reporting unhandled rejections, and type no-param calls

### DIFF
--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -458,7 +458,7 @@ withCalls(({ productsSelectedEntity }) => ({
   store.checkoutError // unknown | null
   // generates the following methods
   store.loadProductDetail // ({id: string} | Signal<{id: string}> | Observable<{id: string}>) => void
-  store.checkout // () => void
+  store.checkout // () => Promise<{value, ok: true} | {error, ok: false}>
 ```
 <a name="entityCallConfig"></a>
 

--- a/libs/ngrx-traits/signals/src/lib/test.utils.ts
+++ b/libs/ngrx-traits/signals/src/lib/test.utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Runs `run`, which is expected to start a call and then destroy the injector
+ * while it is still in flight, and returns any rxjs EmptyError reported as an
+ * unhandled rejection while it did so.
+ *
+ * The call promises are built with lastValueFrom over a toObservable of the
+ * call status, so destroying the injector completes that observable without
+ * emitting and rejects the promise. Callers routinely ignore the promise, which
+ * is why the traits keep a no-op handler attached to it.
+ *
+ * zone.js patches Promise, so unhandled rejections surface through its own
+ * handler (console.error) rather than process.on('unhandledRejection'), and
+ * console.error is swapped rather than spied so this stays free of any test
+ * framework globals.
+ */
+export async function emptyErrorsWhileDestroying(run: () => void) {
+  // let rejections left pending by previous tests flush before listening
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const originalConsoleError = console.error;
+  const captured: unknown[] = [];
+  console.error = (...args: unknown[]) => {
+    captured.push(...args);
+  };
+  try {
+    run();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return captured.filter((arg) => (arg as Error)?.name === 'EmptyError');
+  } finally {
+    console.error = originalConsoleError;
+  }
+}

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls-on-destroy.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls-on-destroy.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { signalStore } from '@ngrx/signals';
+import { Subject } from 'rxjs';
+
+import { callConfig, withCalls } from '../index';
+import { emptyErrorsWhileDestroying } from '../test.utils';
+
+// kept in its own spec file: unhandled rejections left behind by other tests
+// land asynchronously and would otherwise pollute the console.error window
+// these tests inspect
+describe('withCalls promises that never settle', () => {
+  it('should not log an unhandled rejection when a callWith call is cut short by destroy', async () => {
+    const apiResponse = new Subject<string>();
+    const Store = signalStore(
+      withCalls(() => ({
+        testCall: callConfig({
+          call: () => apiResponse,
+          mapPipe: 'exhaustMap',
+          callWith: true,
+        }),
+      })),
+    );
+    const emptyErrors = await emptyErrorsWhileDestroying(() => {
+      const store = TestBed.runInInjectionContext(() => new Store());
+      expect(store.isTestCallLoading()).toBeTruthy();
+      // destroys the environment injector while the call is still in flight,
+      // which completes the toObservable of the call status without emitting
+      TestBed.resetTestingModule();
+    });
+    expect(emptyErrors).toEqual([]);
+  });
+
+  it('should still reject for callers that attach their own handler', async () => {
+    const apiResponse = new Subject<string>();
+    const Store = signalStore(
+      withCalls(() => ({
+        testCall: callConfig({
+          call: () => apiResponse,
+          mapPipe: 'exhaustMap',
+          skipWhen: () => true,
+        }),
+      })),
+    );
+    const onRejected = vi.fn();
+    const store = TestBed.runInInjectionContext(() => new Store());
+    // the no-op handler the library attaches only marks the rejection as
+    // handled, it does not swallow it: a handler added here still fires
+    store.testCall().catch(onRejected);
+    TestBed.resetTestingModule();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect((onRejected.mock.calls[0][0] as Error).name).toBe('EmptyError');
+  });
+
+  it('should not log an unhandled rejection when skipWhen skips the call', async () => {
+    const apiResponse = new Subject<string>();
+    const Store = signalStore(
+      withCalls(() => ({
+        testCall: callConfig({
+          call: () => apiResponse,
+          mapPipe: 'exhaustMap',
+          skipWhen: () => true,
+        }),
+      })),
+    );
+    const emptyErrors = await emptyErrorsWhileDestroying(() => {
+      const store = TestBed.runInInjectionContext(() => new Store());
+      // a skipped call leaves the status at 'init', so this promise is never
+      // going to settle, and discarding it must stay harmless
+      store.testCall();
+      expect(store.testCallCallStatus()).toEqual('init');
+      TestBed.resetTestingModule();
+    });
+    expect(emptyErrors).toEqual([]);
+  });
+});

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.spec.ts
@@ -79,7 +79,6 @@ describe('withCalls', () => {
     });
   });
 
-
   it('Fail on a call should set status return error ', async () => {
     TestBed.runInInjectionContext(() => {
       const store = new Store();
@@ -134,6 +133,25 @@ describe('withCalls', () => {
       apiResponse.next('test');
       expect(store.isTestCallLoaded()).toBeTruthy();
       expect(store.testCallResult()).toBe('test');
+    });
+  });
+
+  it('should return promise with value on success for a call with no params', async () => {
+    const Store = signalStore(
+      withCalls(() => ({
+        testCall: () => apiResponse,
+      })),
+    );
+    await TestBed.runInInjectionContext(async () => {
+      const store = new Store();
+      const resultPromise = store.testCall();
+      apiResponse.next('test');
+      TestBed.tick();
+      const result = await resultPromise;
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value()).toBe('test');
+      }
     });
   });
 

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -361,6 +361,12 @@ export function withCalls<
                     ),
                   ),
                 );
+                // the promise never settles if the call is skipped by skipWhen,
+                // or if the store is destroyed mid call (toObservable completes
+                // empty), and callers are free to ignore it, so keep a no-op
+                // handler attached to stop that surfacing as an unhandled
+                // rejection. Callers that await still see the rejection.
+                resultPromise.catch(() => {});
                 return resultPromise;
               };
               return acc;

--- a/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-calls/with-calls.ts
@@ -125,7 +125,7 @@ import { getWithCallKeys } from './with-calls.util';
  *   store.checkoutError // unknown | null
  *   // generates the following methods
  *   store.loadProductDetail // ({id: string} | Signal<{id: string}> | Observable<{id: string}>) => void
- *   store.checkout // () => void
+ *   store.checkout // () => Promise<{value, ok: true} | {error, ok: false}>
  *
  * @warning The default mapPipe is {@link https://www.learnrxjs.io/learn-rxjs/operators/transformation/exhaustmap exhaustMap}. If your call returns an observable that does not complete after the first value is emitted, any changes to the input params will be ignored. Either specify {@link https://www.learnrxjs.io/learn-rxjs/operators/transformation/switchmap switchMap} as mapPipe, or use {@link https://www.learnrxjs.io/learn-rxjs/operators/filtering/take take(1)} or {@link https://www.learnrxjs.io/learn-rxjs/operators/filtering/first first()} as part of your call.
  */
@@ -147,7 +147,10 @@ export function withCalls<
     methods: {
       [K in keyof Calls]: Calls[K] extends (...args: infer P) => any
         ? P extends []
-          ? () => void
+          ? () => Promise<
+              | { value: Signal<ExtractCallResultType<Calls[K]>>; ok: true }
+              | { error: Signal<ExtractErrorType<Calls[K]>>; ok: false }
+            >
           : {
               (
                 param: P[0],
@@ -159,7 +162,10 @@ export function withCalls<
             }
         : Calls[K] extends CallConfig
           ? Parameters<Calls[K]['call']> extends undefined[]
-            ? () => void
+            ? () => Promise<
+                | { value: Signal<ExtractCallResultType<Calls[K]>>; ok: true }
+                | { error: Signal<ExtractErrorType<Calls[K]>>; ok: false }
+              >
             : {
                 (
                   param: Parameters<Calls[K]['call']>[0],

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls-on-destroy.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls-on-destroy.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { signalStore, type } from '@ngrx/signals';
+import { withEntities } from '@ngrx/signals/entities';
+import { Subject } from 'rxjs';
+
+import { mockProducts } from '../test.mocks';
+import { Product } from '../test.model';
+import { emptyErrorsWhileDestroying } from '../test.utils';
+import { withEntitiesCalls } from './with-entities-calls';
+
+// kept in its own spec file: unhandled rejections left behind by other tests
+// land asynchronously and would otherwise pollute the console.error window
+// this test inspects
+describe('withEntitiesCalls promises that never settle', () => {
+  const entity = type<Product>();
+
+  it('should not log an unhandled rejection when a call is cut short by destroy', async () => {
+    const apiResponse = new Subject<Partial<Product>>();
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities({ entity }),
+      withEntitiesCalls({
+        entity,
+        calls: () => ({
+          loadDetail: ({ entity }: { entity: Product }) => apiResponse,
+        }),
+      }),
+    );
+
+    const emptyErrors = await emptyErrorsWhileDestroying(() => {
+      const store = TestBed.runInInjectionContext(() => new Store());
+      // discarded on purpose: the promise is still in flight when the store is
+      // destroyed, so it never settles
+      store.loadDetail({ entity: mockProducts[0] });
+      expect(store.isLoadDetailLoading(mockProducts[0].id)).toBeTruthy();
+      TestBed.resetTestingModule();
+    });
+
+    expect(emptyErrors).toEqual([]);
+  });
+});

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
@@ -466,7 +466,7 @@ export function withEntitiesCalls<
                       ? selectId((param as any).entity)
                       : selectId(param as any);
                 const entityStatus = computed(() => callState()[id]);
-                return lastValueFrom(
+                const resultPromise = lastValueFrom(
                   toObservable(entityStatus, {
                     injector: environmentInjector,
                   }).pipe(
@@ -482,6 +482,10 @@ export function withEntitiesCalls<
                     ),
                   ),
                 );
+                // see withCalls: keep a no-op handler attached so a promise the
+                // caller ignores cannot surface as an unhandled rejection
+                resultPromise.catch(() => {});
+                return resultPromise;
               };
               return acc;
             },

--- a/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-calls/with-entities-calls.ts
@@ -125,7 +125,8 @@ import { getWithEntitiesCallKeys } from './with-entities-calls.util';
  *   store.isLoadOrderDetailLoading(id: string) => boolean
  *   store.isLoadOrderDetailLoaded(id: string) => boolean
  *   store.loadOrderDetailError(id: string) => string | null
- *   store.loadOrderDetail ({id: string} | Signal<{id: string}> | Observable<{id: string}>) => void
+ *   store.loadOrderDetail // ({id: string}) => Promise<{value, ok: true} | {error, ok: false}>
+ *   //   passing a Signal or Observable instead returns an RxMethodRef
  *   // same for changeOrderStatus and deleteOrder
  *
  */
@@ -171,7 +172,9 @@ export function withEntitiesCalls<
           }
         : Calls[K] extends EntityCallConfig
           ? Parameters<Calls[K]['call']> extends undefined[]
-            ? () => void
+            ? // an entity call needs a param to derive the entity id from, so
+              // a call with no params is not a supported shape
+              never
             : {
                 (
                   ...param: Parameters<Calls[K]['call']>

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter-on-destroy.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-filter-on-destroy.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { signalStore, type } from '@ngrx/signals';
+import { withEntities } from '@ngrx/signals/entities';
+import { Subject } from 'rxjs';
+
+import {
+  withCallStatus,
+  withEntitiesHybridFilter,
+  withEntitiesLoadingCall,
+  withEntitiesRemoteFilter,
+} from '../index';
+import { Product } from '../test.model';
+import { emptyErrorsWhileDestroying } from '../test.utils';
+
+// kept in its own spec file: unhandled rejections left behind by other tests
+// land asynchronously and would otherwise pollute the console.error window
+// these tests inspect
+describe('filter traits promises that never settle', () => {
+  const entity = type<Product>();
+
+  it('should not log an unhandled rejection when a remote filter is cut short by destroy', async () => {
+    // never emits, so the load stays in flight and the call status never
+    // reaches loaded, which is what keeps the filterEntities promise pending
+    const apiResponse = new Subject<Product[]>();
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities({ entity }),
+      withCallStatus({ initialValue: 'loading' }),
+      withEntitiesRemoteFilter({ entity, defaultFilter: { search: '' } }),
+      withEntitiesLoadingCall({ fetchEntities: () => apiResponse }),
+    );
+
+    const emptyErrors = await emptyErrorsWhileDestroying(() => {
+      const store = TestBed.runInInjectionContext(() => new Store());
+      // discarded on purpose, as callers routinely do
+      store.filterEntities({ filter: { search: 'zelda' } });
+      TestBed.resetTestingModule();
+    });
+
+    expect(emptyErrors).toEqual([]);
+  });
+
+  it('should not log an unhandled rejection when a hybrid filter is cut short by destroy', async () => {
+    const apiResponse = new Subject<Product[]>();
+    const Store = signalStore(
+      { protectedState: false },
+      withEntities({ entity }),
+      withCallStatus({ initialValue: 'loading' }),
+      withEntitiesHybridFilter({
+        entity,
+        defaultFilter: { search: '', categoryId: 'snes' },
+        isRemoteFilter: (previous, current) =>
+          previous.categoryId !== current.categoryId,
+        filterFn: (entity, filter) =>
+          !filter?.search ||
+          entity.name.toLowerCase().includes(filter.search.toLowerCase()),
+      }),
+      withEntitiesLoadingCall({ fetchEntities: () => apiResponse }),
+    );
+
+    const emptyErrors = await emptyErrorsWhileDestroying(() => {
+      const store = TestBed.runInInjectionContext(() => new Store());
+      // a remote filter change, so it waits on the call status rather than
+      // resolving locally
+      store.filterEntities({
+        filter: { search: '', categoryId: 'megadrive' },
+      });
+      TestBed.resetTestingModule();
+    });
+
+    expect(emptyErrors).toEqual([]);
+  });
+});

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-hybrid-filter.ts
@@ -323,7 +323,7 @@ export function withEntitiesHybridFilter<
               }
               filterEntities(options);
 
-              return lastValueFrom(
+              const resultPromise = lastValueFrom(
                 toObservable(callState, { injector: environmentInjector }).pipe(
                   filterPipe((v) => v === 'loaded' || typeof v === 'object'),
                   take(1),
@@ -334,6 +334,10 @@ export function withEntitiesHybridFilter<
                   ),
                 ),
               );
+              // see withCalls: keep a no-op handler attached so a promise the
+              // caller ignores cannot surface as an unhandled rejection
+              resultPromise.catch(() => {});
+              return resultPromise;
             },
             [resetEntitiesFilterKey]: (options?: {
               newDefaultFilter?: Filter;

--- a/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-entities-filter/with-entities-remote-filter.ts
@@ -273,7 +273,7 @@ export function withEntitiesRemoteFilter<
               }
               filterEntities(options);
 
-              return lastValueFrom(
+              const resultPromise = lastValueFrom(
                 toObservable(callState, { injector: environmentInjector }).pipe(
                   filterPipe((v) => v === 'loaded' || typeof v === 'object'),
                   take(1),
@@ -284,6 +284,10 @@ export function withEntitiesRemoteFilter<
                   ),
                 ),
               );
+              // see withCalls: keep a no-op handler attached so a promise the
+              // caller ignores cannot surface as an unhandled rejection
+              resultPromise.catch(() => {});
+              return resultPromise;
             },
             [resetEntitiesFilterKey]: (options?: {
               newDefaultFilter?: Filter;


### PR DESCRIPTION
Fixes #340.

## Unhandled rejections from call promises

Call methods return a promise built on `toObservable(callStatus)`. That promise
never settles in two cases:

- the injector is destroyed mid call — `toObservable` completes without emitting
- `skipWhen` skips the call — the status stays `'init'`, so no terminal value ever arrives

On teardown `lastValueFrom` then rejects with `EmptyError`, and since the promise
is often discarded that surfaced as an unhandled rejection. It was unconditional
for `callWith`, whose init hook discards the promise it gets back.

The fix attaches a no-op `catch` to the promise the library hands out, in
`withCalls`, `withEntitiesCalls` and the remote/hybrid filter traits. This only
flips the promise's "has a handler" bit, which is the sole input to unhandled
rejection detection — it changes no semantics. Callers that attach their own
handler still receive the rejection, and awaiting without a `try/catch` still
rejects the caller's own promise exactly as before.

Rejected alternatives, both of which change behaviour in ways that bite:

- resolving with `{ ok: false, error }` — `error` is undefined for a skipped or
  cancelled call, so the common `if (!result.ok) showError(...)` branch fires with
  no real error, showing an error toast during teardown
- leaving the promise permanently pending — silently hangs anything that hands the
  promise outward, e.g. a root-scoped serialising queue (poisoned for the rest of
  the session), a `finally` that clears a global busy flag, or a `Promise.all` that
  also awaits live work

This removed all 58 `EmptyError` reports the test suite was emitting, without
touching a single existing spec.

## `() => void` on calls with no params

Calls with no params were typed `() => void`, but the implementation returns the
same promise as calls with params — with no args, `param` is `undefined`, which is
not a function/Observable/signal, so it falls through to the promise path. Awaiting
the result therefore did not typecheck. Fixed in `withCalls` and `withEntitiesCalls`.

## Verification

- 546 tests pass; `tsconfig.lib.json` and `tsconfig.spec.json` both clean
- `apps/example-app` typechecks clean, so no consumer breakage
- new `with-calls-on-destroy.spec.ts` covers the callWith-destroyed path, the
  `skipWhen` path, and that a caller-attached handler still gets the rejection;
  each verified to fail without the fix
