### PR TITLE
feat(docs): light theme with navbar toggle

### DIFF
--- a/apps/docs/index.html
+++ b/apps/docs/index.html
@@ -1,10 +1,26 @@
 <!doctype html>
-<html lang="en" class='dark' data-theme="dark">
+<html lang="en" class="dark" data-theme="dark">
   <head>
     <meta charset="utf-8" />
     <title>NgRx Traits</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // applies the stored/system theme before first paint to avoid a flash of
+      // the wrong theme, ThemeService picks it up from here on the client
+      (function () {
+        try {
+          var theme = localStorage.getItem('ngrx-traits-theme');
+          if (theme !== 'light' && theme !== 'dark') {
+            theme = window.matchMedia('(prefers-color-scheme: light)').matches
+              ? 'light'
+              : 'dark';
+          }
+          document.documentElement.classList.toggle('dark', theme === 'dark');
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (e) {}
+      })();
+    </script>
     <link rel="icon" type="image/x-icon" href="public/favicon.ico" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
     <link
@@ -26,7 +42,7 @@
       href="https://gabrielguerrerosite-914026926.imgix.net"
     />
   </head>
-  <body class="dark bg-white dark:bg-gray-950">
+  <body class="bg-white dark:bg-gray-950">
     <app-root></app-root>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/apps/docs/src/app/components/navbar/footer/footer.component.ts
+++ b/apps/docs/src/app/components/navbar/footer/footer.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'docs-footer',
   standalone: true,
   host: { class: 'block' },
-  template: `<footer class="grid pt-24 text-zinc-300 z-10">
+  template: `<footer class="grid pt-24 text-zinc-700 dark:text-zinc-300 z-10">
     <div class="grid sm:grid-cols-3 gap-8 sm:gap-24">
       <ul class="flex flex-col gap-2">
         <li class="font-bold">Documentation</li>

--- a/apps/docs/src/app/components/navbar/navbar.component.ts
+++ b/apps/docs/src/app/components/navbar/navbar.component.ts
@@ -16,10 +16,12 @@ import {
 } from '@ng-icons/bootstrap-icons';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 
+import { ThemeToggleComponent } from '../theme-toggle/theme-toggle.component';
+
 @Component({
   selector: 'docs-navbar',
   standalone: true,
-  imports: [MatIconButton, MatIcon, NgIcon],
+  imports: [MatIconButton, MatIcon, NgIcon, ThemeToggleComponent],
   viewProviders: [
     provideIcons({ bootstrapGithub, bootstrapDiscord, bootstrapMedium }),
   ],
@@ -90,7 +92,8 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
           <ng-icon class="text-lg" name="bootstrapGithub" />
           <span class="hidden font-medium sm:inline">GitHub</span>
         </a>
-        <div id="docsearch" data-theme="dark"></div>
+        <docs-theme-toggle />
+        <div id="docsearch"></div>
       </div>
     </nav>
   </header>`,

--- a/apps/docs/src/app/components/tab-group/tab-group.component.ts
+++ b/apps/docs/src/app/components/tab-group/tab-group.component.ts
@@ -16,7 +16,7 @@ import type { TabComponent } from '../tab/tab.component';
   template: ` <div class="mb-3 flex gap-x-4 border-b">
       @for (tab of tabs(); track tab.label) {
         <button
-          class="focus-visible:ring-primary -mb-px h-10 border-b-2 font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-opacity-50 focus-visible:ring-offset-2"
+          class="focus-visible:ring-primary/50 -mb-px h-10 border-b-2 font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2"
           [ngClass]="{
             'border-primary text-zinc-600 dark:text-zinc-300':
               activeTab()?.label === tab.label,

--- a/apps/docs/src/app/components/theme-toggle/theme-toggle.component.ts
+++ b/apps/docs/src/app/components/theme-toggle/theme-toggle.component.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+
+import { ThemeService } from '../../utils/theme.service';
+
+@Component({
+  selector: 'docs-theme-toggle',
+  standalone: true,
+  template: `<button
+    type="button"
+    class="inline-flex items-center justify-center rounded-lg px-3 py-2 text-zinc-500 outline-none transition-colors hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-zinc-300"
+    title="Toggle light/dark theme"
+    aria-label="Toggle light/dark theme"
+    (click)="theme.toggle()"
+  >
+    <!-- moon, shown on light theme (click switches to dark) -->
+    <svg
+      class="icon-moon h-[18px] w-[18px]"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278Z"
+      />
+    </svg>
+    <!-- sun, shown on dark theme (click switches to light) -->
+    <svg
+      class="icon-sun h-[18px] w-[18px]"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6Zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8ZM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0Zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13Zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5ZM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8Zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0Zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0Zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707ZM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708Z"
+      />
+    </svg>
+  </button>`,
+  // toggled with css rather than a signal so the server rendered markup stays
+  // valid whatever theme the browser picks before hydration
+  styles: `
+    .icon-sun {
+      display: none;
+    }
+
+    :host-context(html.dark) .icon-sun {
+      display: block;
+    }
+
+    :host-context(html.dark) .icon-moon {
+      display: none;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ThemeToggleComponent {
+  protected readonly theme = inject(ThemeService);
+}

--- a/apps/docs/src/app/pages/(home).page.ts
+++ b/apps/docs/src/app/pages/(home).page.ts
@@ -26,9 +26,11 @@ import { NavbarComponent } from '../components/navbar/navbar.component';
             </div>
 
             <p
-              class="p-4 sm:rounded-2xl  bg-white/5 max-w-xl text-xl font-light leading-9 text-zinc-300 "
+              class="p-4 sm:rounded-2xl bg-zinc-900/5 dark:bg-white/5 max-w-xl text-xl font-light leading-9 text-zinc-700 dark:text-zinc-300 "
             >
-              <span class="text-blue-300 font-bold">Ngrx Traits</span> is a set
+              <span class="text-blue-700 dark:text-blue-300 font-bold"
+                >Ngrx Traits</span
+              > is a set
               of NgRx Signals Custom Store Features that will speed up your
               development by solving common problems such as calling a backend,
               adding pagination, sorting, filtering, selection of entities, and

--- a/apps/docs/src/app/pages/(home).page.ts
+++ b/apps/docs/src/app/pages/(home).page.ts
@@ -26,7 +26,7 @@ import { NavbarComponent } from '../components/navbar/navbar.component';
             </div>
 
             <p
-              class="p-4 sm:rounded-2xl  bg-white bg-opacity-5 max-w-xl text-xl font-light leading-9 text-zinc-300 "
+              class="p-4 sm:rounded-2xl  bg-white/5 max-w-xl text-xl font-light leading-9 text-zinc-300 "
             >
               <span class="text-blue-300 font-bold">Ngrx Traits</span> is a set
               of NgRx Signals Custom Store Features that will speed up your

--- a/apps/docs/src/app/pages/index.page.css
+++ b/apps/docs/src/app/pages/index.page.css
@@ -8,12 +8,7 @@
   height: 100vh;
   /*position: fixed;*/
   /*inset: 0;*/
-  background: linear-gradient(
-    315deg,
-    rgb(41, 40, 40) 33%,
-    rgb(7, 1, 7) 68%,
-    rgb(4, 11, 37) 98%
-  );
+  background: var(--home-background);
   /*background: linear-gradient(*/
   /*  315deg,*/
   /*  rgb(3, 24, 34) 33%,*/
@@ -47,7 +42,7 @@
 
 .wave {
   /*background: rgba(255, 255, 255, 0.25);*/
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--home-wave);
   border-radius: 1000% 1000% 0 0;
   position: absolute;
   width: 800%;
@@ -109,5 +104,5 @@
   aspect-ratio: 1/1;
 }
 ::ng-deep a:hover{
-  color: rgb(154 177 251);
+  color: var(--home-link-hover);
 }

--- a/apps/docs/src/app/utils/theme.service.ts
+++ b/apps/docs/src/app/utils/theme.service.ts
@@ -1,0 +1,53 @@
+import { isPlatformBrowser } from '@angular/common';
+import { effect, inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+
+export type Theme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'ngrx-traits-theme';
+
+/**
+ * Keeps the `dark` class and `data-theme` attribute on <html> in sync with the
+ * selected theme, and persists the choice in localStorage. The initial value is
+ * applied by the inline script in index.html to avoid a flash of the wrong
+ * theme, this service just reads back what that script decided.
+ */
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+  readonly theme = signal<Theme>('dark');
+
+  constructor() {
+    if (!this.isBrowser) return;
+
+    this.theme.set(
+      document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+    );
+
+    effect(() => this.apply(this.theme()));
+  }
+
+  toggle(): void {
+    this.theme.update((theme) => (theme === 'dark' ? 'light' : 'dark'));
+    this.persist(this.theme());
+  }
+
+  private apply(theme: Theme): void {
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    root.setAttribute('data-theme', theme);
+  }
+
+  /**
+   * Only an explicit toggle is stored, persisting the value derived from
+   * prefers-color-scheme would pin the visitor to whatever their os said on
+   * their first visit.
+   */
+  private persist(theme: Theme): void {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // storage can be unavailable (private mode), theme still applies
+    }
+  }
+}

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -1,6 +1,30 @@
 @import 'tailwindcss';
 @config '../tailwind.config.cjs';
 
+/* theme tokens, consumed by component stylesheets that cannot see the
+   `dark` class through view encapsulation */
+:root {
+  --home-background: linear-gradient(
+    315deg,
+    rgb(226, 232, 240) 33%,
+    rgb(248, 250, 252) 68%,
+    rgb(219, 226, 245) 98%
+  );
+  --home-wave: rgba(100, 116, 139, 0.18);
+  --home-link-hover: rgb(37, 99, 235);
+}
+
+html.dark {
+  --home-background: linear-gradient(
+    315deg,
+    rgb(41, 40, 40) 33%,
+    rgb(7, 1, 7) 68%,
+    rgb(4, 11, 37) 98%
+  );
+  --home-wave: rgba(0, 0, 0, 0.25);
+  --home-link-hover: rgb(154, 177, 251);
+}
+
 
 @font-face {
   font-family: 'Geist Mono';
@@ -27,8 +51,14 @@ pre[class*='language-'] {
   @apply py-4 px-5;
 }
 
+/* prose renders code blocks on a dark surface by default, keep them in step
+   with the theme instead */
+.prose pre {
+  @apply bg-zinc-100 text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100;
+}
+
 .token {
-  @apply bg-zinc-950 dark:bg-zinc-800;
+  @apply bg-transparent;
 }
 
 .token.function,
@@ -66,7 +96,7 @@ pre[class*='language-'] {
 }
 
 .app-hover-text{
-  @apply hover:from-[#f14eff] hover:to-[#ffffff] hover:bg-gradient-to-r hover:bg-clip-text hover:text-transparent
+  @apply hover:from-[#f14eff] hover:to-[#5b21b6] dark:hover:to-[#ffffff] hover:bg-gradient-to-r hover:bg-clip-text hover:text-transparent
 }
 .app-title-color {
   @apply from-primary to-accent bg-gradient-to-r bg-clip-text  text-transparent
@@ -86,7 +116,7 @@ pre[class*='language-'] {
 
 .DocSearch-Button {
   --docsearch-searchbox-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.2);
-  @apply absolute left-[calc(50%-88px)] top-[15px] inline-flex h-9 w-44 flex-none items-center gap-x-3 overflow-hidden rounded-lg bg-white px-3 shadow shadow-black/5 ring-1 ring-black/10 focus-within:ring-2 focus-within:ring-blue-500 md:left-[calc(50%-104px)] md:w-52 lg:left-[calc(50%-160px)] lg:w-80;
+  @apply absolute left-[calc(50%-88px)] top-[15px] inline-flex h-9 w-44 flex-none items-center gap-x-3 overflow-hidden rounded-lg bg-white px-3 shadow shadow-black/5 ring-1 ring-black/10 focus-within:ring-2 focus-within:ring-blue-500 md:left-[calc(50%-104px)] md:w-52 lg:left-[calc(50%-160px)] lg:w-80 dark:bg-gray-900 dark:ring-white/10;
 }
 
 .DocSearch-Button-Placeholder {


### PR DESCRIPTION
## Tailwind v4 opacity fix

`bg-white bg-opacity-5` on the home hero rendered solid white after the v4
upgrade (the `*-opacity-*` utilities were removed). Replaced with
`bg-white/5`, and the same dead `ring-opacity-50` in tab-group with
`ring-primary/50`.

## Light theme + toggle

- `ThemeService` keeps the `dark` class and `data-theme` on `<html>` and
  persists the choice in localStorage (`ngrx-traits-theme`).
- An inline script in `index.html` applies the stored theme before first
  paint, falling back to the OS `prefers-color-scheme`; SSR markup stays
  dark so no-JS visitors are unaffected.
- Navbar toggle swaps sun/moon purely in CSS (`:host-context(html.dark)`)
  so the server-rendered markup is valid whatever theme the browser picks
  before hydration.
- Light variants for the home hero, footer, prose code blocks, DocSearch
  and the mobile drawer. Home background/waves moved to CSS custom
  properties since component styles can't see the `dark` class through
  view encapsulation.

Verified both themes on the home page, docs pages and the mobile drawer;
production build passes with no hydration warnings.
