### PR TITLE
feat(signals): filterState accepts array of state props

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-server-state-transfer.md
+++ b/apps/docs/src/app/pages/docs/traits/with-server-state-transfer.md
@@ -70,7 +70,8 @@ const store = signalStore(
 
 ### Transfer specific state properties using filterState
 
-Use `filterState` when you only want to transfer a subset of your state:
+Use `filterState` when you only want to transfer a subset of your state, it can
+receive an array with the names of the state props to transfer:
 
 ```typescript
 const store = signalStore(
@@ -80,6 +81,20 @@ const store = signalStore(
   withServerStateTransfer({
     key: 'products-state',
     // Only transfer entity data, not loading states
+    filterState: ['orderItemsEntityMap', 'orderItemsIds'],
+  }),
+);
+```
+
+Or a function, useful when you need to transform the state before transferring it:
+
+```typescript
+const store = signalStore(
+  withEntities({ entity, collection }),
+  withCallStatus({ prop: collection, initialValue: 'loading' }),
+
+  withServerStateTransfer({
+    key: 'products-state',
     filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
       orderItemsEntityMap,
       orderItemsIds,
@@ -224,7 +239,7 @@ This custom store feature receives an object to allow specific configurations:
 | Property      | Description                                                                                          | Value                          |
 |---------------|------------------------------------------------------------------------------------------------------|--------------------------------|
 | key           | Unique key to store state in TransferState                                                           | string                         |
-| filterState   | Filter state before transferring (mutually exclusive with valueMapper)                               | (state) => Partial\<State\>    |
+| filterState   | Array of state prop names, or function, to filter the state before transferring (mutually exclusive with valueMapper) | ['state1'] \| (state) => Partial\<State\> |
 | valueMapper   | Custom transformation between store and transfer value (mutually exclusive with filterState)         | TransferValueMapper<T, Store>   |
 | onRestore     | Callback executed after state restoration on client                                                  | (store) => void                |
 
@@ -244,7 +259,7 @@ valueMapper: (store: Store) => {
 | stateToTransferValue  | Transform store state to transfer value (server)     | () => T \| undefined \| null   |
 | transferValueToState  | Transform transfer value to state (client)           | (value: T) => void             |
 
-**Note:** `valueMapper` and `filterState` are mutually exclusive - use one or the other, not both.
+**Note:** `valueMapper` and `filterState` are mutually exclusive - use one or the other, not both, TypeScript will report an error if you provide both.
 
 ## State
 

--- a/apps/docs/src/app/pages/docs/traits/with-sync-to-web-storage.md
+++ b/apps/docs/src/app/pages/docs/traits/with-sync-to-web-storage.md
@@ -87,7 +87,25 @@ const store = signalStore(
     key: 'my-key',
     type: 'session',
     expires: 5000,
-    // filter the state before saving to the storage
+    // filter the state before saving to the storage,
+    // with an array of state prop names
+    filterState: ['orderItemsEntityMap', 'orderItemsIds'],
+  }),
+);
+```
+
+Or with a function, useful when you need to transform the state before saving it:
+
+```typescript
+const store = signalStore(
+  // following are not required, just an example it can have anything
+  withEntities({ entity, collection }),
+  withCallStatus({ prop: collection, initialValue: 'loading' }),
+
+  withSyncToWebStorage({
+    key: 'my-key',
+    type: 'session',
+    expires: 5000,
     filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
       orderItemsEntityMap,
       orderItemsIds,
@@ -154,7 +172,7 @@ const store = signalStore(
 );
 ```
 
-**Note:** `valueMapper` and `filterState` are mutually exclusive - you can only use one or the other, not both.
+**Note:** `valueMapper` and `filterState` are mutually exclusive - you can only use one or the other, not both, TypeScript will report an error if you provide both.
 
 ### Splitting the state in multiple store keys
 You can add withSyncToWebStorage multiple times with different keys, this can be useful if you are creating your own store features and each has a withSyncToWebStorage, or you need to split the state in two keys.
@@ -216,7 +234,7 @@ This trait receives an object to allow specific configurations:
 | type                    | Type of storage to use                                                                               | 'session' \| 'local'                                   |
 | restoreOnInit           | Auto restore the state from the storage when the store is initialized                                | boolean. Default: true                                 |
 | saveStateChangesAfterMs | Milliseconds after which the state is saved to storage when it changes                               | number. Default: 500                                   |
-| filterState             | Optional function to filter the state signals that will be synced to storage (mutually exclusive with valueMapper) | ({state1}) => ({state1})                               |
+| filterState             | Optional array of state prop names, or function, to filter the state that will be synced to storage (mutually exclusive with valueMapper) | ['state1'] \| ({state1}) => ({state1})                  |
 | valueMapper             | Optional custom transformation between store state and storage value (mutually exclusive with filterState) | StorageValueMapper<T, Store>                           |
 | expires                 | If the data is older than the time in milliseconds it won't be restored                              | number                                                 |
 | onRestore               | Optional callback after the state is restored from storage                                           | (store) => void                                        |

--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
@@ -39,10 +39,7 @@ export function withOrderEntities() {
     withSyncToWebStorage({
       key: 'orderItems',
       type: 'session',
-      filterState: ({ orderItemEntityMap, orderItemIds }) => ({
-        orderItemEntityMap,
-        orderItemIds,
-      }),
+      filterState: ['orderItemEntityMap', 'orderItemIds'],
     }),
   );
 }

--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -1564,7 +1564,7 @@ Parameters from deeper child routes take precedence over parent route parameters
 | Param | Description |
 | --- | --- |
 | key | <p>the key to use in the TransferState</p> |
-| filterState | <p>filter the state before saving to TransferState (mutually exclusive with valueMapper)</p> |
+| filterState | <p>filter the state before saving to TransferState, either an array of state keys or a function (mutually exclusive with valueMapper)</p> |
 | valueMapper | <p>custom transformation between store state and transfer value (mutually exclusive with filterState)</p> |
 | onRestore | <p>callback after the state is restored from TransferState</p> |
 
@@ -1578,10 +1578,13 @@ const store = signalStore(
  withServerStateTransfer({
      key: 'my-state',
      // optionally, filter the state before transferring
-     filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
-      orderItemsEntityMap,
-      orderItemsIds,
-    }),
+     // with an array of state keys
+     filterState: ['orderItemsEntityMap', 'orderItemsIds'],
+     // or with a function
+     // filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
+     //  orderItemsEntityMap,
+     //  orderItemsIds,
+     // }),
  }),
  );
 ```
@@ -1743,7 +1746,7 @@ const Store = signalStore(
 | type | <p>'session' or 'local' storage</p> |
 | saveStateChangesAfterMs | <p>save the state to the storage after this many milliseconds, 0 to disable</p> |
 | restoreOnInit | <p>restore the state from the storage on init</p> |
-| filterState | <p>filter the state before saving to the storage (mutually exclusive with valueMapper)</p> |
+| filterState | <p>filter the state before saving to the storage, either an array of state keys or a function (mutually exclusive with valueMapper)</p> |
 | valueMapper | <p>custom transformation between store state and storage value (mutually exclusive with filterState)</p> |
 | onRestore | <p>callback after the state is restored from the storage</p> |
 | expires | <p>storage will not be loaded if is older than this many milliseconds</p> |
@@ -1761,10 +1764,13 @@ const store = signalStore(
      restoreOnInit: true,
      saveStateChangesAfterMs: 300,
      // optionally, filter the state before saving to the storage
-     filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
-      orderItemsEntityMap,
-      orderItemsIds,
-    }),
+     // with an array of state keys
+     filterState: ['orderItemsEntityMap', 'orderItemsIds'],
+     // or with a function
+     // filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
+     //  orderItemsEntityMap,
+     //  orderItemsIds,
+     // }),
  }),
  );
 ```

--- a/libs/ngrx-traits/signals/src/lib/util.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/util.spec.ts
@@ -1,0 +1,30 @@
+import { toFilterStateFn } from './util';
+
+describe('toFilterStateFn', () => {
+  const state = { a: 1, b: 2, c: 3 };
+
+  it('should return undefined when no filterState is provided', () => {
+    expect(toFilterStateFn(undefined)).toBeUndefined();
+  });
+
+  it('should return the function as is when filterState is a function', () => {
+    const fn = (s: typeof state) => ({ a: s.a });
+    expect(toFilterStateFn<typeof state>(fn)).toBe(fn);
+  });
+
+  it('should pick only the listed props when filterState is an array', () => {
+    const filter = toFilterStateFn<typeof state>(['a', 'c'])!;
+    expect(filter(state)).toEqual({ a: 1, c: 3 });
+    // keeps the order of the array so the stored value is stable
+    expect(Object.keys(filter(state))).toEqual(['a', 'c']);
+  });
+
+  it('should ignore an empty array and warn in dev mode', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* Empty */
+    });
+    expect(toFilterStateFn<typeof state>([])).toBeUndefined();
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+});

--- a/libs/ngrx-traits/signals/src/lib/util.ts
+++ b/libs/ngrx-traits/signals/src/lib/util.ts
@@ -1,3 +1,5 @@
+import { isDevMode } from '@angular/core';
+
 export function capitalize(name: string) {
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
@@ -75,4 +77,28 @@ export function combineFunctionsInObject<
   );
   result = Object.getOwnPropertySymbols(param).reduce(replaceProps, result);
   return result as T;
+}
+
+// Normalizes a filterState option, which can be an array of state prop names or
+// a function, into a function that filters the state. Not part of the public api,
+// the jsdoc comment style is avoided here so it does not end up in api-docs.md
+export function toFilterStateFn<T extends object>(
+  filterState?: ((state: T) => Partial<T>) | readonly (keyof T)[],
+): ((state: T) => Partial<T>) | undefined {
+  if (!filterState) return undefined;
+  if (Array.isArray(filterState)) {
+    // Array.isArray does not narrow a readonly array out of the union
+    const keys = filterState as readonly (keyof T)[];
+    if (!keys.length) {
+      isDevMode() &&
+        console.warn('filterState received an empty array, it will be ignored');
+      return undefined;
+    }
+    return (state) =>
+      keys.reduce((acc, key) => {
+        acc[key] = state[key];
+        return acc;
+      }, {} as Partial<T>);
+  }
+  return filterState as (state: T) => Partial<T>;
 }

--- a/libs/ngrx-traits/signals/src/lib/with-server-state-transfer/with-server-state-transfer.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-server-state-transfer/with-server-state-transfer.spec.ts
@@ -97,6 +97,40 @@ describe('withServerStateTransfer', () => {
       });
     });
 
+    it('should save state filtered with an array of state keys to TransferState on server', () => {
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          { protectedState: false },
+          withEntities({ entity }),
+          withCallStatus(),
+          withServerStateTransfer({
+            key: 'test-state',
+            filterState: ['ids', 'entityMap'],
+          }),
+        );
+        const store = new Store();
+        TestBed.tick();
+
+        patchState(store, setAllEntities(mockProducts));
+        store.setLoaded();
+        TestBed.tick();
+
+        const stateKey = makeStateKey('test-state');
+        expect(mockTransferState.set).toHaveBeenCalledWith(
+          stateKey,
+          expect.objectContaining({
+            ids: expect.any(Array),
+            entityMap: expect.any(Object),
+          }),
+        );
+        // Should only include the filtered props
+        const lastCall = mockTransferState.set.mock.calls[
+          mockTransferState.set.mock.calls.length - 1
+        ][1] as any;
+        expect(Object.keys(lastCall)).toEqual(['ids', 'entityMap']);
+      });
+    });
+
     it('should save state using valueMapper on server', () => {
       TestBed.runInInjectionContext(() => {
         const Store = signalStore(
@@ -220,6 +254,31 @@ describe('withServerStateTransfer', () => {
         TestBed.tick();
 
         expect(store.entities()).toEqual(mockProducts);
+      });
+    });
+
+    it('should restore state filtered with an array of state keys on client', () => {
+      const transferredState = {
+        ids: mockProducts.map((p) => p.id),
+        entityMap: mockProducts.reduce((acc, p) => ({ ...acc, [p.id]: p }), {}),
+      };
+      mockTransferState.get.mockReturnValue(transferredState);
+
+      TestBed.runInInjectionContext(() => {
+        const Store = signalStore(
+          { protectedState: false },
+          withEntities({ entity }),
+          withCallStatus(),
+          withServerStateTransfer({
+            key: 'test-state',
+            filterState: ['ids', 'entityMap'],
+          }),
+        );
+        const store = new Store();
+        TestBed.tick();
+
+        expect(store.entities()).toEqual(mockProducts);
+        expect(store.isLoaded()).toBe(false); // callStatus was filtered out
       });
     });
 
@@ -360,5 +419,38 @@ describe('withServerStateTransfer', () => {
         expect(mockTransferState.set).not.toHaveBeenCalled();
       });
     });
+  });
+  it('should only allow state props and not computed props or valueMapper in filterState', () => {
+    signalStore(
+      withEntities({ entity }),
+      withCallStatus(),
+      withServerStateTransfer({
+        key: 'test-state',
+        // @ts-expect-error entities is a computed prop, not a state prop
+        filterState: ['ids', 'entities'],
+      }),
+    );
+    signalStore(
+      withEntities({ entity }),
+      withServerStateTransfer({
+        key: 'test-state',
+        // @ts-expect-error not a state prop
+        filterState: ['nope'],
+      }),
+    );
+    signalStore(
+      withEntities({ entity }),
+      // @ts-expect-error filterState and valueMapper are mutually exclusive
+      withServerStateTransfer({
+        key: 'test-state',
+        filterState: ['ids'],
+        valueMapper: () => ({
+          stateToTransferValue: () => ({}),
+          transferValueToState: () => {
+            /* Empty */
+          },
+        }),
+      }),
+    );
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-server-state-transfer/with-server-state-transfer.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-server-state-transfer/with-server-state-transfer.ts
@@ -17,13 +17,14 @@ import {
   WritableStateSource,
 } from '@ngrx/signals';
 
+import { toFilterStateFn } from '../util';
 import { StoreSource } from '../with-feature-factory/with-feature-factory.model';
 import { TransferValueMapper } from './with-server-state-transfer.util';
 
 /**
  * Sync the state of the store using Angular's TransferState API for SSR
  * @param key - the key to use in the TransferState
- * @param filterState - filter the state before saving to TransferState (mutually exclusive with valueMapper)
+ * @param filterState - filter the state before saving to TransferState, either an array of state keys or a function (mutually exclusive with valueMapper)
  * @param valueMapper - custom transformation between store state and transfer value (mutually exclusive with filterState)
  * @param onRestore - callback after the state is restored from TransferState
  *
@@ -36,10 +37,13 @@ import { TransferValueMapper } from './with-server-state-transfer.util';
  *  withServerStateTransfer({
  *      key: 'my-state',
  *      // optionally, filter the state before transferring
- *      filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
- *       orderItemsEntityMap,
- *       orderItemsIds,
- *     }),
+ *      // with an array of state keys
+ *      filterState: ['orderItemsEntityMap', 'orderItemsIds'],
+ *      // or with a function
+ *      // filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
+ *      //  orderItemsEntityMap,
+ *      //  orderItemsIds,
+ *      // }),
  *  }),
  *  );
  *
@@ -77,7 +81,9 @@ import { TransferValueMapper } from './with-server-state-transfer.util';
  *  );
  *
  */
-export function withServerStateTransfer<Input extends SignalStoreFeatureResult>({
+export function withServerStateTransfer<
+  Input extends SignalStoreFeatureResult,
+>({
   key,
   onRestore,
   ...rest
@@ -86,17 +92,25 @@ export function withServerStateTransfer<Input extends SignalStoreFeatureResult>(
   onRestore?: (store: StoreSource<Input>) => void;
 } & (
   | {
-      filterState: (state: Input['state']) => Partial<Input['state']>;
+      filterState:
+        | ((state: Input['state']) => Partial<Input['state']>)
+        | readonly (keyof Input['state'])[];
+      valueMapper?: never;
     }
-  | { valueMapper: TransferValueMapper<any, StoreSource<Input>> }
-  | {}
+  | {
+      valueMapper: TransferValueMapper<any, StoreSource<Input>>;
+      filterState?: never;
+    }
+  | { filterState?: never; valueMapper?: never }
 )): SignalStoreFeature<Input, { state: {}; props: {}; methods: {} }> {
+  const filterState = toFilterStateFn<Input['state']>(
+    (rest as any).filterState,
+  );
   return signalStoreFeature(
     type<Input>(),
     withHooks((store: WritableStateSource<Input['state']>) => {
       const transferState = inject(TransferState);
       const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
-      const filterState = (rest as any).filterState;
       const valueMapper = (rest as any).valueMapper?.(store);
       const stateKey = makeStateKey<any>(key);
 

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.spec.ts
@@ -106,6 +106,121 @@ describe('withSyncToWebStorage', () => {
     });
   });
 
+  it('should save and load to local session using an array of state keys in filterState', () => {
+    const onRestore = vi.fn();
+    TestBed.runInInjectionContext(() => {
+      const Store = signalStore(
+        { protectedState: false },
+        withEntities({ entity }),
+        withCallStatus(),
+        withSyncToWebStorage({
+          key: 'test',
+          type: 'session',
+          restoreOnInit: false,
+          saveStateChangesAfterMs: 0,
+          filterState: ['ids', 'entityMap'],
+          onRestore,
+        }),
+      );
+      const store = new Store();
+      store.clearFromStore();
+      TestBed.tick();
+      store.setLoaded();
+      patchState(store, setAllEntities(mockProducts));
+      store.saveToStorage();
+      expect(Object.keys(getFromStorage('test', 'session'))).toEqual([
+        'ids',
+        'entityMap',
+      ]);
+
+      store.setLoading();
+      patchState(store, setAllEntities(mockProducts.slice(0, 30)));
+
+      store.loadFromStorage();
+      expect(store.entities()).toEqual(mockProducts);
+      expect(store.isLoading()).toBe(true); // it keeps the current value because it was filtered
+      expect(onRestore).toHaveBeenCalled();
+    });
+  });
+
+  it('should filter with an array of state keys of a collection', () => {
+    TestBed.runInInjectionContext(() => {
+      const Store = signalStore(
+        { protectedState: false },
+        withEntities({ entity, collection: 'products' }),
+        withCallStatus({ prop: 'products' }),
+        withSyncToWebStorage({
+          key: 'test',
+          type: 'session',
+          restoreOnInit: false,
+          saveStateChangesAfterMs: 0,
+          filterState: ['productsIds', 'productsEntityMap'],
+        }),
+      );
+      const store = new Store();
+      store.clearFromStore();
+      TestBed.tick();
+      store.setProductsLoaded();
+      patchState(
+        store,
+        setAllEntities(mockProducts, { collection: 'products' }),
+      );
+      store.saveToStorage();
+
+      expect(Object.keys(getFromStorage('test', 'session'))).toEqual([
+        'productsIds',
+        'productsEntityMap',
+      ]);
+
+      store.setProductsLoading();
+      patchState(
+        store,
+        setAllEntities(mockProducts.slice(0, 30), { collection: 'products' }),
+      );
+
+      store.loadFromStorage();
+      expect(store.productsEntities()).toEqual(mockProducts);
+      expect(store.isProductsLoading()).toBe(true); // it keeps the current value because it was filtered
+    });
+  });
+
+  it('should only allow state props and not computed props or valueMapper in filterState', () => {
+    signalStore(
+      withEntities({ entity }),
+      withCallStatus(),
+      withSyncToWebStorage({
+        key: 'test',
+        type: 'session',
+        // @ts-expect-error entities is a computed prop, not a state prop
+        filterState: ['ids', 'entities'],
+      }),
+    );
+    signalStore(
+      withEntities({ entity }),
+      withSyncToWebStorage({
+        key: 'test',
+        type: 'session',
+        // @ts-expect-error not a state prop
+        filterState: ['nope'],
+      }),
+    );
+    signalStore(
+      withEntities({ entity }),
+      // @ts-expect-error filterState and valueMapper are mutually exclusive
+      withSyncToWebStorage({
+        key: 'test',
+        type: 'session',
+        filterState: ['ids'],
+        valueMapper: () => ({
+          stateToStorageValue: () => ({}),
+          storageValueToState: () => {
+            /* Empty */
+          },
+        }),
+      }),
+    );
+  });
+
   it('should save after milliseconds set in saveStateChangesAfterMs if is greater than 0 ', fakeAsync(() => {
     TestBed.runInInjectionContext(() => {
       const Store = signalStore(
@@ -654,7 +769,10 @@ describe('withSyncToWebStorage', () => {
     }));
   });
 });
-function getFromStorage(key: string) {
-  const data = window.localStorage.getItem(key);
+function getFromStorage(key: string, type: 'local' | 'session' = 'local') {
+  const data =
+    type === 'local'
+      ? window.localStorage.getItem(key)
+      : window.sessionStorage.getItem(key);
   return data ? JSON.parse(data) : undefined;
 }

--- a/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-sync-to-web-storage/with-sync-to-web-storage.ts
@@ -3,18 +3,16 @@ import { effect, inject, isDevMode, PLATFORM_ID } from '@angular/core';
 import {
   getState,
   patchState,
-  Prettify,
   SignalStoreFeature,
   signalStoreFeature,
   SignalStoreFeatureResult,
-  StateSignals,
   type,
   withHooks,
   withMethods,
   WritableStateSource,
 } from '@ngrx/signals';
 
-import { combineFunctionsInObject } from '../util';
+import { combineFunctionsInObject, toFilterStateFn } from '../util';
 import { StoreSource } from '../with-feature-factory/with-feature-factory.model';
 import { StorageValueMapper } from './with-sync-to-web-storage.util';
 
@@ -24,7 +22,7 @@ import { StorageValueMapper } from './with-sync-to-web-storage.util';
  * @param type - 'session' or 'local' storage
  * @param saveStateChangesAfterMs - save the state to the storage after this many milliseconds, 0 to disable
  * @param restoreOnInit - restore the state from the storage on init
- * @param filterState - filter the state before saving to the storage (mutually exclusive with valueMapper)
+ * @param filterState - filter the state before saving to the storage, either an array of state keys or a function (mutually exclusive with valueMapper)
  * @param valueMapper - custom transformation between store state and storage value (mutually exclusive with filterState)
  * @param onRestore - callback after the state is restored from the storage
  * @param expires - storage will not be loaded if is older than this many milliseconds
@@ -41,10 +39,13 @@ import { StorageValueMapper } from './with-sync-to-web-storage.util';
  *      restoreOnInit: true,
  *      saveStateChangesAfterMs: 300,
  *      // optionally, filter the state before saving to the storage
- *      filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
- *       orderItemsEntityMap,
- *       orderItemsIds,
- *     }),
+ *      // with an array of state keys
+ *      filterState: ['orderItemsEntityMap', 'orderItemsIds'],
+ *      // or with a function
+ *      // filterState: ({ orderItemsEntityMap, orderItemsIds }) => ({
+ *      //  orderItemsEntityMap,
+ *      //  orderItemsIds,
+ *      // }),
  *  }),
  *  );
  *
@@ -107,10 +108,16 @@ export function withSyncToWebStorage<Input extends SignalStoreFeatureResult>({
   onRestore?: (store: StoreSource<Input>) => void;
 } & (
   | {
-      filterState: (state: Input['state']) => Partial<Input['state']>;
+      filterState:
+        | ((state: Input['state']) => Partial<Input['state']>)
+        | readonly (keyof Input['state'])[];
+      valueMapper?: never;
     }
-  | { valueMapper: StorageValueMapper<any, StoreSource<Input>> }
-  | {}
+  | {
+      valueMapper: StorageValueMapper<any, StoreSource<Input>>;
+      filterState?: never;
+    }
+  | { filterState?: never; valueMapper?: never }
 )): SignalStoreFeature<
   Input,
   {
@@ -123,11 +130,13 @@ export function withSyncToWebStorage<Input extends SignalStoreFeatureResult>({
     };
   }
 > {
+  const filterState = toFilterStateFn<Input['state']>(
+    (rest as any).filterState,
+  );
   return signalStoreFeature(
     type<Input>(),
     withMethods((store: WritableStateSource<Input['state']>) => {
       const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
-      const filterState = (rest as any).filterState;
       const valueMapper = (rest as any).valueMapper?.(store);
       return combineFunctionsInObject(
         {


### PR DESCRIPTION
`withSyncToWebStorage` and `withServerStateTransfer` `filterState` now accepts a
typed array of state prop names as well as a function, mirroring `withLogger`'s
`filter` but restricted to state props (no computed props).

```ts
withSyncToWebStorage({
  key: 'orderItems',
  type: 'session',
  filterState: ['orderItemEntityMap', 'orderItemIds'],
})
```

Also in this change:

- Shared internal `toFilterStateFn` helper used by both features. An empty array
  is ignored with a dev-mode warning, so it can't silently transfer `{}` and fire
  `onRestore` on an untouched store.
- `filterState` and `valueMapper` are now mutually exclusive at the type level.
  They were documented as such but the config union allowed both, which produced
  a store that saved the `filterState` subset and restored through the mapper.
- Docs, api-docs, example app and tests updated, including `@ts-expect-error`
  tests pinning that only state props are accepted.

Note: `api-docs.md` was edited by hand because `nx run ngrx-traits-signals:api-docs`
currently fails on `beta` — jsdoc2md can't parse the `entityConfig({ entity, collection })`
text in the `@param` lines added in `d8573cd`. Worth a separate fix.
