### PR TITLE
fix(signals): accept a premade equal name on withLink's computation form

### DIFF
--- a/libs/ngrx-traits/signals/src/lib/with-link/with-link.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-link/with-link.spec.ts
@@ -402,6 +402,37 @@ describe('withLink', () => {
       );
     });
 
+    it('takes a premade name on the computation form, where the value type comes from the computation', () => {
+      const Store = signalStore(
+        { protectedState: false },
+        withState({ ids: ['a', 'b'] as string[] }),
+        withLink('selectedIds', {
+          // the value type is only known once this callback is typed, so the
+          // name must not be checked against an unresolved type
+          computation: (store) => store.ids(),
+          set: (value, store) => patchState(store as any, { ids: value }),
+          equal: 'set',
+        }),
+        // @ts-expect-error 'missing' is not a property of the computed value
+        withLink('firstId', {
+          computation: (store) => ({ id: store.ids()[0] }),
+          set: () => void 0,
+          equal: 'missing',
+        }),
+      );
+      TestBed.runInInjectionContext(() => {
+        const store = new Store();
+        const external = signal(['b', 'a']);
+        const setSpy = vi.spyOn(external, 'set');
+        store.linkSelectedIds({ syncWith: external });
+        TestBed.tick();
+
+        // same ids in another order: 'set' resolved, so neither side is written
+        expect(setSpy).not.toHaveBeenCalled();
+        expect(store.ids()).toEqual(['a', 'b']);
+      });
+    });
+
     it("guards the sync to an external signal, and 'array'/'set' are not offered for non arrays", () => {
       const Store = signalStore(
         { protectedState: false },

--- a/libs/ngrx-traits/signals/src/lib/with-link/with-link.util.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-link/with-link.util.ts
@@ -178,13 +178,24 @@ type ElementPropertyName<T> = T extends readonly (infer E)[]
  *
  * The array ones are only offered when the value is an array, the property
  * names when it is an object, the prefixed ones when it is an array of them.
+ *
+ * `unknown extends T` short-circuits all of that while `T` is still
+ * unresolved, which is the case on the `computation` form of `withLink`: the
+ * value type comes from a context-sensitive callback, typed only on a later
+ * inference pass, while `equal` is a plain string checked on the first one.
+ * Narrowing against the empty `T` of that first pass pins it to `unknown` for
+ * good — the value type collapses and every name is rejected. Accepting any
+ * name there costs nothing: `T` is known by the time the argument is checked,
+ * so a wrong name or one that does not fit the value is still an error.
  */
-export type EqualName<T> =
-  | 'stringify'
-  | 'reference'
-  | (T extends readonly any[] ? 'array' | 'set' : never)
-  | PropertyName<T>
-  | ElementPropertyName<T>;
+export type EqualName<T> = unknown extends T
+  ? string
+  :
+      | 'stringify'
+      | 'reference'
+      | (T extends readonly any[] ? 'array' | 'set' : never)
+      | PropertyName<T>
+      | ElementPropertyName<T>;
 
 /** A custom equality function, or the name of a premade one. */
 export type EqualOption<T> = ((a: T, b: T) => boolean) | EqualName<T>;


### PR DESCRIPTION
Fix withLink type: EqualName narrowed with bare conditionals over the value type. On the computation form that type comes from a context-sensitive callback typed on a later inference pass, while equal is a plain string checked on the first one, so the conditionals resolved against an empty type and pinned it to unknown: the name was rejected, set's parameter became unknown and link<Name>() disappeared from the store type. Whether it tripped depended on the surrounding inference work, so the same code compiled in one file and failed in another.

Short-circuit the narrowing while the type is unresolved. Nothing is lost: it is known by the time the argument is checked, so a wrong name or one that does not fit the value is still rejected.