### PR TITLE
feat(signals): withLogger accepts name as first arg

### DIFF
--- a/apps/docs/src/app/pages/docs/traits/with-logger.md
+++ b/apps/docs/src/app/pages/docs/traits/with-logger.md
@@ -23,7 +23,7 @@ import { withLogger } from '@ngrx-traits/signals';
 const store = signalStore(
   withState({ foo: 'foo' }),
   withEntities({entity: type<Product>()}),
-  withLogger({name: "MyStore"}),
+  withLogger('MyStore'),
 );
 ```
 
@@ -33,8 +33,7 @@ const store = signalStore(
 const store = signalStore(
   withState({ foo: 'foo' }),
   withEntities({entity: type<Product>()}),
-  withLogger({
-    name: 'orderItemsStore',
+  withLogger('orderItemsStore', {
     // you can use a function to filter the state that is logged
     // filter: ({ entityMap, ids }) => ({
     //   entityMap,
@@ -46,9 +45,25 @@ const store = signalStore(
 );
 ```
 
+### Log the diff of the state on every change:
+
+```typescript
+const store = signalStore(
+  withState({ foo: 'foo', bar: 'bar' }),
+  withLogger('MyStore', { showDiff: true }),
+);
+
+// patchState(store, { foo: 'foo2' }) logs:
+// MyStore store changed:  { bar: 'bar', foo: 'foo2' }
+// MyStore store changes diff :
+// - foo: foo
+// + foo: foo2
+```
+
 ## API Reference
 
-| Property     | Description                                                                                                                   | Value                                 |
-|--------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| name         | Name to log in the console                                                                                                    | `type<T>()`                           |
-| filter       | Optional either a function to filter the state that is logged or an array of props names of the state that should be included | `(store)=> filteredStore` \| string[] |
+| Property | Description                                                                                                                   | Value                                 |
+|----------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| name     | Name to log in the console, passed as the first argument                                                                      | `string`                              |
+| filter   | Optional either a function to filter the state that is logged or an array of props names of the state that should be included | `(store)=> filteredStore` \| string[] |
+| showDiff | Optional, if true logs the diff between the previous and the current state on every change                                    | `boolean`                             |

--- a/apps/example-app/src/app/examples/components/genre-multi-select/genre-multi-select.store.ts
+++ b/apps/example-app/src/app/examples/components/genre-multi-select/genre-multi-select.store.ts
@@ -48,8 +48,7 @@ export const GenreStore = signalStore(
   }),
   withLinkEntitiesMultiSelection(genreEntityConfig),
   withLinkEntitiesSingleSelection(genreEntityConfig),
-  withLogger({
-    name: 'GenreStore',
+  withLogger('GenreStore', {
     filter: ['genreIdsSelected', 'genreIdSelected'],
   }),
 );

--- a/apps/example-app/src/app/examples/signals/product-link-page/product-edit.store.ts
+++ b/apps/example-app/src/app/examples/signals/product-link-page/product-edit.store.ts
@@ -81,5 +81,5 @@ export const ProductEditStore = signalStore(
     // a draft that has never been saved still has no id
     isNew: () => !productDetail().id,
   })),
-  withLogger({ name: 'ProductEditStore', filter: ['id'] }),
+  withLogger('ProductEditStore', { filter: ['id'] }),
 );

--- a/apps/example-app/src/app/examples/signals/product-link-page/product-link.store.ts
+++ b/apps/example-app/src/app/examples/signals/product-link-page/product-link.store.ts
@@ -67,8 +67,7 @@ export const ProductLinkStore = signalStore(
     upsertProduct: (product: Product) =>
       patchState(store, upsertEntity(product, productsEntityConfig)),
   })),
-  withLogger({
-    name: 'ProductLinkStore',
+  withLogger('ProductLinkStore', {
     showDiff: true,
     filter: ['productEntitiesFilter', 'productEntitySelected'],
   }),

--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-order-entities.ts
@@ -28,8 +28,7 @@ export function withOrderEntities() {
     withEntitiesLocalPagination(orderItemEntityConfig, {
       pageSize: 10,
     }),
-    withLogger({
-      name: 'orderItemStore',
+    withLogger('orderItemStore', {
       showDiff: true,
       // filter: ({ orderItemEntityMap, orderItemIds }) => ({
       //   orderItemEntityMap,

--- a/apps/example-app/src/app/examples/signals/product-shop-page/with-product-entities.ts
+++ b/apps/example-app/src/app/examples/signals/product-shop-page/with-product-entities.ts
@@ -69,7 +69,7 @@ export function withProductEntities() {
         mapError: (error) => (error as Error).message,
       }),
     ),
-    withLogger({ name: 'ProductEntitiesStore' }),
+    withLogger('ProductEntitiesStore'),
   );
 }
 

--- a/apps/example-app/src/app/examples/signals/register-user-page/register-user.store.ts
+++ b/apps/example-app/src/app/examples/signals/register-user-page/register-user.store.ts
@@ -16,5 +16,5 @@ export const RegisterUserStore = signalStore(
       },
     }),
   })),
-  withLogger({ name: 'RegisterUserStore' }),
+  withLogger('RegisterUserStore'),
 );

--- a/libs/ngrx-traits/signals/api-docs.md
+++ b/libs/ngrx-traits/signals/api-docs.md
@@ -145,7 +145,7 @@ can access the store. This can be useful for creating store features that need t
 features that don't have a config factory that can access the store.</p></dd>
 <dt><a href="#withInputBindings">withInputBindings(inputs)</a></dt>
 <dd><p>Binds component inputs to the store, so that the store is updated with the latest values of the inputs.</p></dd>
-<dt><a href="#withLogger">withLogger(name, filter, showDiff)</a></dt>
+<dt><a href="#withLogger">withLogger(name, config)</a></dt>
 <dd><p>Log the state of the store on every change, optionally filter the signals to log
 the filter prop can receive an array with the names of the props to filter, or you can provide a function
 which receives the store as an argument and should return the object to log, if any of the props in the object is a signal
@@ -1515,7 +1515,7 @@ const Store = signalStore(
 ```
 <a name="withLogger"></a>
 
-## withLogger(name, filter, showDiff)
+## withLogger(name, config)
 <p>Log the state of the store on every change, optionally filter the signals to log
 the filter prop can receive an array with the names of the props to filter, or you can provide a function
 which receives the store as an argument and should return the object to log, if any of the props in the object is a signal
@@ -1526,8 +1526,7 @@ it will log the value of the signal. If showDiff is true it will log the diff of
 | Param | Description |
 | --- | --- |
 | name | <p>The name of the store to log</p> |
-| filter | <p>optional filter function to filter the store signals or an array of keys to filter</p> |
-| showDiff | <p>optional flag to log the diff of the state on every change</p> |
+| config | <p>optional filter and showDiff options</p> |
 
 **Example**  
 ```js
@@ -1536,16 +1535,45 @@ const Store = signalStore(
     withComputed(({ prop1, prop2 }) => ({
       prop3: computed(() => prop1() + prop2()),
     })),
-    withLogger({
-      name: 'Store',
-      // by default it will log all state and computed signals
-      // or you can filter with an array of keys
-      // filter: ['prop1', 'prop2'],
+    // by default it will log all state and computed signals
+    withLogger('Store'),
+  );
+
+ // logs on every change:
+ // Store store initialized:  { prop1: 1, prop2: 2, prop3: 3 }
+ // Store store changed:  { prop1: 5, prop2: 2, prop3: 7 }
+```
+**Example**  
+```js
+const Store = signalStore(
+    withState(() => ({ prop1: 1, prop2: 2 })),
+    withComputed(({ prop1, prop2 }) => ({
+      prop3: computed(() => prop1() + prop2()),
+    })),
+    withLogger('Store', {
+      // you can filter with an array of keys
+      filter: ['prop1', 'prop2'],
       // or you can filter with a function
       // filter: ({ prop1, prop2 }) => ({ prop1, prop2 }),
-      // showDiff: true,
+      // the function can also return nested signals or their values
+      // filter: ({ myObject }) => ({ x: myObject.x }),
+      // filter: ({ myObject }) => myObject.x(),
     }),
   );
+```
+**Example**  
+```js
+// showDiff logs what changed between the previous and the current state
+ const Store = signalStore(
+    withState(() => ({ prop1: 1, prop2: 2 })),
+    withLogger('Store', { showDiff: true }),
+  );
+
+ // after patchState(store, { prop1: 5 }) logs:
+ // Store store changed:  { prop1: 5, prop2: 2 }
+ // Store store changes diff :
+ // - prop1: 1
+ // + prop1: 5
 ```
 <a name="extractRouteParams"></a>
 

--- a/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.spec.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.spec.ts
@@ -17,7 +17,7 @@ describe('withLogger', () => {
       withComputed(({ prop1, prop2 }) => ({
         prop3: computed(() => prop1() + prop2()),
       })),
-      withLogger({ name: 'Store' }),
+      withLogger('Store'),
     );
 
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {
@@ -46,8 +46,7 @@ describe('withLogger', () => {
       withComputed(({ prop1, prop2 }) => ({
         prop3: computed(() => prop1() + prop2()),
       })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ['prop1', 'prop2'],
       }),
     );
@@ -76,8 +75,7 @@ describe('withLogger', () => {
       withComputed(({ prop1, prop2 }) => ({
         prop3: computed(() => prop1() + prop2()),
       })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ({ prop1, prop2 }) => ({ prop1: prop1(), prop2: prop2() }),
       }),
     );
@@ -106,8 +104,7 @@ describe('withLogger', () => {
       withComputed(({ prop1, prop2 }) => ({
         prop3: computed(() => prop1() + prop2()),
       })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ({ prop1, prop2 }) => ({ prop1: prop1, prop2: prop2 }),
       }),
     );
@@ -133,8 +130,7 @@ describe('withLogger', () => {
     const Store = signalStore(
       { providedIn: 'root', protectedState: false },
       withState(() => ({ myObject: { x: 1, y: 2 }, prop2: 2 })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ({ myObject }) => ({ x: myObject.x, y: myObject.y }),
       }),
     );
@@ -160,8 +156,7 @@ describe('withLogger', () => {
     const Store = signalStore(
       { providedIn: 'root', protectedState: false },
       withState(() => ({ myObject: { x: 1, y: 2 }, prop2: 2 })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ({ myObject }) => ({ x: myObject.x() }),
       }),
     );
@@ -183,8 +178,7 @@ describe('withLogger', () => {
     const Store = signalStore(
       { providedIn: 'root', protectedState: false },
       withState(() => ({ myObject: { x: 1, y: 2 }, prop2: 2 })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ({ myObject }) => myObject.x(),
       }),
     );
@@ -204,8 +198,7 @@ describe('withLogger', () => {
     const Store = signalStore(
       { providedIn: 'root', protectedState: false },
       withState(() => ({ prop1: 0 })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ({ prop1 }) => prop1(),
       }),
     );
@@ -228,8 +221,7 @@ describe('withLogger', () => {
       withComputed(({ prop1, prop2 }) => ({
         prop3: computed(() => prop1() + prop2()),
       })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ['prop3'],
         showDiff: true,
       }),
@@ -265,7 +257,7 @@ describe('withLogger', () => {
       withComputed(({ zebra, apple }) => ({
         computed1: computed(() => zebra() + apple()),
       })),
-      withLogger({ name: 'Store' }),
+      withLogger('Store'),
     );
 
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {
@@ -296,8 +288,7 @@ describe('withLogger', () => {
       withComputed(({ zebra, apple }) => ({
         computed1: computed(() => zebra() + apple()),
       })),
-      withLogger({
-        name: 'Store',
+      withLogger('Store', {
         filter: ['zebra', 'apple'],
       }),
     );
@@ -317,6 +308,28 @@ describe('withLogger', () => {
     expect(loggedObject).toEqual({
       zebra: 1,
       apple: 2,
+    });
+  });
+
+  it('should still support the deprecated object syntax', () => {
+    const Store = signalStore(
+      { providedIn: 'root', protectedState: false },
+      withState(() => ({ prop1: 1, prop2: 2 })),
+      withLogger({ name: 'Store', filter: ['prop1'] }),
+    );
+
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {
+      /* Empty */
+    });
+    const store = TestBed.inject(Store);
+    TestBed.tick();
+    expect(consoleLog).toHaveBeenCalledWith('Store store initialized: ', {
+      prop1: 1,
+    });
+    patchState(store, { prop1: 2 });
+    TestBed.tick();
+    expect(consoleLog).toHaveBeenCalledWith('Store store changed: ', {
+      prop1: 2,
     });
   });
 });

--- a/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.ts
+++ b/libs/ngrx-traits/signals/src/lib/with-logger/with-logger.ts
@@ -11,6 +11,10 @@ import {
 
 import { deepDiff } from './with-logger.util';
 
+type LoggerFilter<Input extends SignalStoreFeatureResult> =
+  | ((store: StateSignals<Input['state']> & Input['props']) => any)
+  | readonly (keyof (StateSignals<Input['state']> & Input['props']))[];
+
 /**
  * Log the state of the store on every change, optionally filter the signals to log
  * the filter prop can receive an array with the names of the props to filter, or you can provide a function
@@ -19,8 +23,7 @@ import { deepDiff } from './with-logger.util';
  * If showDiff is true it will log the diff of the state on every change.
  *
  * @param name - The name of the store to log
- * @param filter - optional filter function to filter the store signals or an array of keys to filter
- * @param showDiff - optional flag to log the diff of the state on every change
+ * @param config - optional filter and showDiff options
  *
  * @example
  *
@@ -29,31 +32,80 @@ import { deepDiff } from './with-logger.util';
  *     withComputed(({ prop1, prop2 }) => ({
  *       prop3: computed(() => prop1() + prop2()),
  *     })),
- *     withLogger({
- *       name: 'Store',
- *       // by default it will log all state and computed signals
- *       // or you can filter with an array of keys
- *       // filter: ['prop1', 'prop2'],
+ *     // by default it will log all state and computed signals
+ *     withLogger('Store'),
+ *   );
+ *
+ *  // logs on every change:
+ *  // Store store initialized:  { prop1: 1, prop2: 2, prop3: 3 }
+ *  // Store store changed:  { prop1: 5, prop2: 2, prop3: 7 }
+ *
+ * @example
+ *
+ *  const Store = signalStore(
+ *     withState(() => ({ prop1: 1, prop2: 2 })),
+ *     withComputed(({ prop1, prop2 }) => ({
+ *       prop3: computed(() => prop1() + prop2()),
+ *     })),
+ *     withLogger('Store', {
+ *       // you can filter with an array of keys
+ *       filter: ['prop1', 'prop2'],
  *       // or you can filter with a function
  *       // filter: ({ prop1, prop2 }) => ({ prop1, prop2 }),
  *       // the function can also return nested signals or their values
  *       // filter: ({ myObject }) => ({ x: myObject.x }),
  *       // filter: ({ myObject }) => myObject.x(),
- *       // showDiff: true,
  *     }),
  *   );
+ *
+ * @example
+ *  // showDiff logs what changed between the previous and the current state
+ *  const Store = signalStore(
+ *     withState(() => ({ prop1: 1, prop2: 2 })),
+ *     withLogger('Store', { showDiff: true }),
+ *   );
+ *
+ *  // after patchState(store, { prop1: 5 }) logs:
+ *  // Store store changed:  { prop1: 5, prop2: 2 }
+ *  // Store store changes diff :
+ *  // - prop1: 1
+ *  // + prop1: 5
  */
-export function withLogger<Input extends SignalStoreFeatureResult>({
-  name,
-  filter,
-  showDiff,
-}: {
+export function withLogger<Input extends SignalStoreFeatureResult>(
+  name: string,
+  config?: {
+    filter?: LoggerFilter<Input>;
+    showDiff?: boolean;
+  },
+): SignalStoreFeature<Input, EmptyFeatureResult>;
+/**
+ * @deprecated Pass the name as the first argument instead, the rest of the options
+ * stay in the config object, e.g. `withLogger('Store', { filter: ['prop1'], showDiff: true })`.
+ *
+ * @param config - object with the name of the store to log, and the optional filter and showDiff options
+ */
+export function withLogger<Input extends SignalStoreFeatureResult>(config: {
   name: string;
-  filter?:
-    | ((store: StateSignals<Input['state']> & Input['props']) => any)
-    | readonly (keyof (StateSignals<Input['state']> & Input['props']))[];
+  filter?: LoggerFilter<Input>;
   showDiff?: boolean;
-}): SignalStoreFeature<Input, EmptyFeatureResult> {
+}): SignalStoreFeature<Input, EmptyFeatureResult>;
+export function withLogger<Input extends SignalStoreFeatureResult>(
+  nameOrConfig:
+    | string
+    | {
+        name: string;
+        filter?: LoggerFilter<Input>;
+        showDiff?: boolean;
+      },
+  config?: {
+    filter?: LoggerFilter<Input>;
+    showDiff?: boolean;
+  },
+): SignalStoreFeature<Input, EmptyFeatureResult> {
+  const { name, filter, showDiff } =
+    typeof nameOrConfig === 'string'
+      ? { name: nameOrConfig, ...config }
+      : nameOrConfig;
   return signalStoreFeature(
     type<Input>(),
     withHooks({


### PR DESCRIPTION
`withLogger('Store', { filter, showDiff })` — name as first argument,
rest of the settings optional in the second.

- Object form `withLogger({ name, ... })` deprecated (JSDoc `@deprecated`), still works.
- Docs page + api-docs updated to the new form, added a `showDiff` example.
- Example app stores migrated.
- Tests migrated, one kept covering the deprecated form.